### PR TITLE
Stabilize production routing, news health, and deploy verification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,5 +47,20 @@ jobs:
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   command: pages deploy dist --project-name globaldeets --branch main --commit-hash ${{ github.sha }} --commit-dirty=false
 
-            - name: Post-deploy health probe
-              run: npm run health:prod -- --skip-active-copy
+            - name: Verify production deployment
+              env:
+                  EXPECTED_COMMIT: ${{ github.sha }}
+              run: |
+                  for attempt in 1 2 3 4 5 6; do
+                    if npm run health:prod -- --skip-active-copy --expected-commit="${EXPECTED_COMMIT}" --deploy-meta-max-age-hours=1; then
+                      exit 0
+                    fi
+
+                    if [ "${attempt}" -eq 6 ]; then
+                      echo "Production did not converge to a healthy state after all verification attempts."
+                      exit 1
+                    fi
+
+                    echo "Production verification attempt ${attempt} failed; retrying after propagation delay."
+                    sleep 10
+                  done

--- a/_routes.json
+++ b/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/*"],
-  "exclude": ["/ads.txt", "/robots.txt", "/sitemap.xml", "/favicon.ico"]
+  "include": ["/api/*", "/create-checkout", "/get-session"],
+  "exclude": []
 }

--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -116,8 +116,8 @@ const LANG_NAMES = {
 const CACHE_KEY = 'news_feed_v1';
 export const SOURCE_HEALTH_KEY = 'news_source_health_v1';
 const CACHE_TTL_SECONDS = 900; // 15 minutes
-const SOURCE_HEALTH_TTL_SECONDS = 86_400; // retain latest observation for 24 hours
-const SOURCE_TIMEOUT_MS = 5000;
+export const SOURCE_HEALTH_TTL_SECONDS = 86_400; // retain latest observation for 24 hours
+export const SOURCE_TIMEOUT_MS = 5000;
 const VALID_REGIONS = new Set([
   'global',
   'middle-east',
@@ -349,7 +349,7 @@ function makeSourceHealth(source, observation) {
   };
 }
 
-function slugifySourceName(name) {
+export function slugifySourceName(name) {
   return name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')

--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -11,7 +11,7 @@
 //   binding = "NEWS_CACHE"
 //   id = "<your-kv-namespace-id>"
 
-const SOURCES = [
+export const SOURCES = [
   // ── Global ───────────────────────────────────────────────────────────────
   {
     name: 'BBC World',
@@ -114,7 +114,10 @@ const LANG_NAMES = {
 };
 
 const CACHE_KEY = 'news_feed_v1';
+export const SOURCE_HEALTH_KEY = 'news_source_health_v1';
 const CACHE_TTL_SECONDS = 900; // 15 minutes
+const SOURCE_HEALTH_TTL_SECONDS = 86_400; // retain latest observation for 24 hours
+const SOURCE_TIMEOUT_MS = 5000;
 const VALID_REGIONS = new Set([
   'global',
   'middle-east',
@@ -177,15 +180,23 @@ export async function onRequestGet({ env, request }) {
     });
   }
 
-  // Cache miss — fetch all sources in parallel, then translate non-English
-  const items = await fetchAllSources();
+  // Cache miss — fetch all sources in parallel, capture health, then translate non-English.
+  const { items, sourceHealth } = await fetchAllSources();
   await translateNonEnglish(items, env);
 
-  // Write to KV (best-effort — don't fail the request if KV is unavailable)
+  // Write feed + the exact source observations that produced it to KV. Both writes are
+  // best-effort so an unavailable KV namespace never takes down the public news endpoint.
   if (env.NEWS_CACHE) {
-    await env.NEWS_CACHE.put(CACHE_KEY, JSON.stringify(items), {
-      expirationTtl: CACHE_TTL_SECONDS,
-    }).catch(() => {});
+    await Promise.all([
+      env.NEWS_CACHE.put(CACHE_KEY, JSON.stringify(items), {
+        expirationTtl: CACHE_TTL_SECONDS,
+      }),
+      env.NEWS_CACHE.put(
+        SOURCE_HEALTH_KEY,
+        JSON.stringify({ generatedAt: new Date().toISOString(), sourceHealth }),
+        { expirationTtl: SOURCE_HEALTH_TTL_SECONDS }
+      ),
+    ]).catch(() => {});
   }
 
   const filtered = filterByRegion(items, region);
@@ -239,18 +250,15 @@ async function translateNonEnglish(items, env) {
 }
 
 async function fetchAllSources() {
-  const results = await Promise.allSettled(SOURCES.map(source => fetchAndParseRSS(source)));
+  // fetchAndParseRSS never throws; every source produces both stories and an observation.
+  const results = await Promise.all(SOURCES.map(source => fetchAndParseRSS(source)));
 
-  const items = [];
-  for (const result of results) {
-    if (result.status === 'fulfilled') {
-      items.push(...result.value);
-    }
-  }
+  const items = results.flatMap(result => result.items);
+  const sourceHealth = results.map(result => result.health);
 
   // Sort newest-first, deduplicate by id, cap at 300 for KV storage
   const seen = new Set();
-  return items
+  const normalizedItems = items
     .sort((a, b) => new Date(b.published) - new Date(a.published))
     .filter(item => {
       if (seen.has(item.id)) return false;
@@ -258,25 +266,94 @@ async function fetchAllSources() {
       return true;
     })
     .slice(0, 300);
+
+  return { items: normalizedItems, sourceHealth };
 }
 
-async function fetchAndParseRSS({ name, url, region, lang }) {
+async function fetchAndParseRSS(source) {
+  const { name, url, region, lang } = source;
+  const startedAt = new Date().toISOString();
+  const startedMs = Date.now();
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
+  const timer = setTimeout(() => controller.abort(), SOURCE_TIMEOUT_MS);
 
   try {
     const res = await fetch(url, {
       signal: controller.signal,
       headers: { 'User-Agent': 'GlobalDeets/1.0 RSS Reader (+https://globaldeets.com)' },
     });
-    if (!res.ok) return [];
+
+    if (!res.ok) {
+      return {
+        items: [],
+        health: makeSourceHealth(source, {
+          startedAt,
+          status: res.status,
+          error: `HTTP ${res.status}`,
+          storyCount: 0,
+          latencyMs: Date.now() - startedMs,
+        }),
+      };
+    }
+
     const text = await res.text();
+    const items = parseRSS(text, name, region, lang);
+    const error = items.length === 0 ? 'No stories parsed from source response.' : null;
+
+    return {
+      items,
+      health: makeSourceHealth(source, {
+        startedAt,
+        succeededAt: error ? null : new Date().toISOString(),
+        status: res.status,
+        error,
+        storyCount: items.length,
+        latencyMs: Date.now() - startedMs,
+      }),
+    };
+  } catch (error) {
+    const reason =
+      error?.name === 'AbortError'
+        ? `Timed out after ${SOURCE_TIMEOUT_MS}ms`
+        : error?.message || 'Source fetch failed';
+
+    return {
+      items: [],
+      health: makeSourceHealth(source, {
+        startedAt,
+        status: null,
+        error: reason,
+        storyCount: 0,
+        latencyMs: Date.now() - startedMs,
+      }),
+    };
+  } finally {
     clearTimeout(timer);
-    return parseRSS(text, name, region, lang);
-  } catch {
-    clearTimeout(timer);
-    return [];
   }
+}
+
+function makeSourceHealth(source, observation) {
+  return {
+    sourceId: slugifySourceName(source.name),
+    name: source.name,
+    url: source.url,
+    region: source.region,
+    lang: source.lang,
+    lastFetchStartedAt: observation.startedAt,
+    lastFetchSucceededAt: observation.succeededAt || null,
+    lastStatus: observation.status,
+    lastError: observation.error || null,
+    storyCount: observation.storyCount,
+    averageLatencyMs: observation.latencyMs,
+    consecutiveFailures: observation.error ? 1 : 0,
+  };
+}
+
+function slugifySourceName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 function parseRSS(xml, sourceName, region, lang = 'en') {

--- a/functions/api/news/health.js
+++ b/functions/api/news/health.js
@@ -1,7 +1,9 @@
 // Cloudflare Pages Function - GET /api/news/health
 
-const SOURCES_PATH = '/data/sources.json';
-const SOURCE_HEALTH_KEY = 'news_source_health_v1';
+import { SOURCES, SOURCE_HEALTH_KEY } from '../news.js';
+
+const SOURCE_HEALTH_TTL_SECONDS = 86_400;
+const SOURCE_TIMEOUT_MS = 5000;
 
 const ALLOWED_ORIGINS = new Set([
   'https://globaldeets.com',
@@ -34,60 +36,109 @@ export async function onRequestOptions({ request }) {
 
 export async function onRequestGet({ env, request }) {
   const headers = getCorsHeaders(request);
-  const snapshot = await env.NEWS_CACHE?.get(SOURCE_HEALTH_KEY, { type: 'json' });
+  const snapshot = await readSnapshot(env);
 
-  if (snapshot?.sourceHealth) {
-    return new Response(
-      JSON.stringify({
-        generatedAt: snapshot.generatedAt || null,
-        cacheAgeSeconds: getCacheAgeSeconds(snapshot.generatedAt),
-        sourceHealth: snapshot.sourceHealth,
-      }),
-      { headers }
-    );
+  if (snapshot?.sourceHealth?.length) {
+    return jsonResponse(snapshot.generatedAt, snapshot.sourceHealth, headers);
   }
 
-  const sources = await loadSources(request, env);
+  // Self-initialize health from the exact same canonical SOURCES list used by /api/news.
+  // This avoids a false 500 on a fresh deployment or empty KV namespace.
+  const sourceHealth = await Promise.all(SOURCES.map(probeSource));
+  const generatedAt = new Date().toISOString();
+
+  if (env.NEWS_CACHE) {
+    await env.NEWS_CACHE.put(
+      SOURCE_HEALTH_KEY,
+      JSON.stringify({ generatedAt, sourceHealth }),
+      { expirationTtl: SOURCE_HEALTH_TTL_SECONDS }
+    ).catch(() => {});
+  }
+
+  return jsonResponse(generatedAt, sourceHealth, headers);
+}
+
+async function readSnapshot(env) {
+  if (!env.NEWS_CACHE) return null;
+  try {
+    return await env.NEWS_CACHE.get(SOURCE_HEALTH_KEY, { type: 'json' });
+  } catch {
+    return null;
+  }
+}
+
+function jsonResponse(generatedAt, sourceHealth, headers) {
   return new Response(
     JSON.stringify({
-      generatedAt: null,
-      cacheAgeSeconds: null,
-      sourceHealth: sources.map(source => ({
-        sourceId: source.id,
-        name: source.name,
-        region: source.region,
-        countryCode: source.countryCode,
-        sourceType: source.sourceType,
-        lastFetchStartedAt: null,
-        lastFetchSucceededAt: null,
-        lastStatus: null,
-        lastError: 'No source health snapshot has been generated yet.',
-        storyCount: 0,
-        averageLatencyMs: null,
-        consecutiveFailures: 0,
-      })),
+      generatedAt: generatedAt || null,
+      cacheAgeSeconds: getCacheAgeSeconds(generatedAt),
+      healthySources: sourceHealth.filter(source => !source.lastError).length,
+      totalSources: sourceHealth.length,
+      sourceHealth,
     }),
     { headers }
   );
 }
 
-async function loadSources(request, env) {
-  const sourceUrl = new URL(SOURCES_PATH, request.url);
-  let response;
+async function probeSource(source) {
+  const startedAt = new Date().toISOString();
+  const startedMs = Date.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SOURCE_TIMEOUT_MS);
 
-  if (env?.ASSETS?.fetch) {
-    response = await env.ASSETS.fetch(sourceUrl);
-  } else {
-    response = await fetch(sourceUrl.href);
+  try {
+    const response = await fetch(source.url, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'GlobalDeets/1.0 Health Probe (+https://globaldeets.com)' },
+    });
+
+    return makeHealth(source, {
+      startedAt,
+      succeededAt: response.ok ? new Date().toISOString() : null,
+      status: response.status,
+      error: response.ok ? null : `HTTP ${response.status}`,
+      latencyMs: Date.now() - startedMs,
+    });
+  } catch (error) {
+    const reason =
+      error?.name === 'AbortError'
+        ? `Timed out after ${SOURCE_TIMEOUT_MS}ms`
+        : error?.message || 'Source fetch failed';
+
+    return makeHealth(source, {
+      startedAt,
+      succeededAt: null,
+      status: null,
+      error: reason,
+      latencyMs: Date.now() - startedMs,
+    });
+  } finally {
+    clearTimeout(timer);
   }
+}
 
-  if (!response.ok) {
-    throw new Error(`Unable to load source registry: HTTP ${response.status}`);
-  }
+function makeHealth(source, observation) {
+  return {
+    sourceId: slugifySourceName(source.name),
+    name: source.name,
+    url: source.url,
+    region: source.region,
+    lang: source.lang,
+    lastFetchStartedAt: observation.startedAt,
+    lastFetchSucceededAt: observation.succeededAt,
+    lastStatus: observation.status,
+    lastError: observation.error,
+    storyCount: null,
+    averageLatencyMs: observation.latencyMs,
+    consecutiveFailures: observation.error ? 1 : 0,
+  };
+}
 
-  const registry = await response.json();
-  const sources = Array.isArray(registry.sources) ? registry.sources : [];
-  return sources.filter(source => source.active !== false);
+function slugifySourceName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 function getCacheAgeSeconds(generatedAt) {

--- a/functions/api/news/health.js
+++ b/functions/api/news/health.js
@@ -1,9 +1,12 @@
 // Cloudflare Pages Function - GET /api/news/health
 
-import { SOURCES, SOURCE_HEALTH_KEY } from '../news.js';
-
-const SOURCE_HEALTH_TTL_SECONDS = 86_400;
-const SOURCE_TIMEOUT_MS = 5000;
+import {
+  SOURCES,
+  SOURCE_HEALTH_KEY,
+  SOURCE_HEALTH_TTL_SECONDS,
+  SOURCE_TIMEOUT_MS,
+  slugifySourceName,
+} from '../news.js';
 
 const ALLOWED_ORIGINS = new Set([
   'https://globaldeets.com',
@@ -132,13 +135,6 @@ function makeHealth(source, observation) {
     averageLatencyMs: observation.latencyMs,
     consecutiveFailures: observation.error ? 1 : 0,
   };
-}
-
-function slugifySourceName(name) {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
 }
 
 function getCacheAgeSeconds(generatedAt) {

--- a/tools/stage-deploy.js
+++ b/tools/stage-deploy.js
@@ -12,8 +12,21 @@ const ROOT_STATIC_FILES = new Set([
   'deploy-meta.json',
   'robots.txt',
   'sitemap.xml',
+  'ads.txt',
   '_headers',
+  '_redirects',
+  '_routes.json',
 ]);
+
+const REQUIRED_DEPLOY_FILES = [
+  'index.html',
+  '404.html',
+  'deploy-meta.json',
+  'ads.txt',
+  '_headers',
+  '_redirects',
+  '_routes.json',
+];
 
 const PUBLIC_DIRECTORIES = ['assets', 'data', 'functions', 'shared'];
 
@@ -95,6 +108,13 @@ function relativeParts(fullPath) {
 }
 
 function assertCleanArtifact() {
+  const missing = REQUIRED_DEPLOY_FILES.filter(name => !existsSync(join(OUT_DIR, name)));
+  if (missing.length > 0) {
+    console.error('Refusing to deploy artifact missing required Pages controls:');
+    for (const file of missing) console.error(`- ${file}`);
+    process.exit(1);
+  }
+
   const forbidden = walkFiles(OUT_DIR).filter(fullPath => {
     const parts = relativeParts(fullPath);
     const fileName = parts[parts.length - 1];


### PR DESCRIPTION
## Production stability repair

This PR addresses the concrete failure modes found in the September 1 production audit.

### What was broken
- The June 10 Cloudflare deployment succeeded, but GitHub deployment verification failed afterward.
- `tools/stage-deploy.js` omitted `_redirects`, `_routes.json`, and `ads.txt` from the deployed artifact.
- `_routes.json` routed all paths through Pages Functions middleware, preventing static routing controls from being authoritative.
- `/api/news/health` depended on `news_source_health_v1`, but no code wrote that KV key.
- Its fallback tried to load nonexistent `/data/sources.json`.
- The live news fetcher silently swallowed per-source failures, so source health could not reflect the actual feed.
- The deploy workflow performed only one immediate custom-domain health probe after upload.

### Repairs
- Preserve and require `_headers`, `_redirects`, `_routes.json`, `ads.txt`, `404.html`, and deploy metadata in `dist`.
- Scope Pages Functions routing to `/api/*`, `/create-checkout`, and `/get-session`; static pages return to Pages routing + `_headers`.
- Emit per-source fetch health alongside the live feed and persist it to KV.
- Make `/api/news/health` self-initialize from the same canonical `SOURCES` list when KV is empty.
- Retry post-deploy verification while requiring the exact expected commit and fresh deployment metadata.

### Intent
This is deliberately a stabilization-only tranche: no visual redesign or feature expansion.