### PR TITLE
Restore native Cloudflare Pages HTML routing

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,17 +1,7 @@
-/ /index.html 200
-/about /about.html 200
-/analytics /analytics.html 200
-/bb-content /bb-content.html 200
-/categories /categories.html 200
-/contact /contact.html 200
-/donate /donate.html 200
-/globe /globe.html 200
-/knowledge /knowledge.html 200
-/news /news.html 200
-/offline /offline.html 200
-/spheres /spheres.html 200
-/timeline /timeline.html 200
-/worldmap /worldmap.html 200
-/privacy /privacy.html 200
-/terms /terms.html 200
-/* /404.html 404
+# GlobalDeets relies on Cloudflare Pages native static HTML routing.
+# Pages serves /news from news.html, redirects /news.html to /news,
+# and serves the top-level 404.html for unknown routes with HTTP 404.
+#
+# Do not add a catch-all `/* /404.html 404` rule here: Pages _redirects
+# does not support non-redirect 404 rewrites, and redirect rules are applied
+# even when a matching static asset exists.

--- a/health-prod.js
+++ b/health-prod.js
@@ -41,16 +41,16 @@ const DEPLOY_META_MAX_AGE_HOURS = Number(
 // ── Routes to probe ──────────────────────────────────────────────────────────
 const ROUTES = [
   { path: '/', label: 'Home', expect: 200, type: 'text/html' },
-  { path: '/news.html', label: 'News', expect: 200, type: 'text/html' },
-  { path: '/globe.html', label: 'Globe', expect: 200, type: 'text/html' },
-  { path: '/about.html', label: 'About', expect: 200, type: 'text/html' },
-  { path: '/spheres.html', label: 'Spheres', expect: 200, type: 'text/html' },
-  { path: '/knowledge.html', label: 'Knowledge', expect: 200, type: 'text/html' },
-  { path: '/worldmap.html', label: 'World Map', expect: 200, type: 'text/html' },
-  { path: '/timeline.html', label: 'Timeline', expect: 200, type: 'text/html' },
-  { path: '/categories.html', label: 'Categories', expect: 200, type: 'text/html' },
-  { path: '/contact.html', label: 'Contact', expect: 200, type: 'text/html' },
-  { path: '/donate.html', label: 'Donate', expect: 200, type: 'text/html' },
+  { path: '/news', label: 'News', expect: 200, type: 'text/html' },
+  { path: '/globe', label: 'Globe', expect: 200, type: 'text/html' },
+  { path: '/about', label: 'About', expect: 200, type: 'text/html' },
+  { path: '/spheres', label: 'Spheres', expect: 200, type: 'text/html' },
+  { path: '/knowledge', label: 'Knowledge', expect: 200, type: 'text/html' },
+  { path: '/worldmap', label: 'World Map', expect: 200, type: 'text/html' },
+  { path: '/timeline', label: 'Timeline', expect: 200, type: 'text/html' },
+  { path: '/categories', label: 'Categories', expect: 200, type: 'text/html' },
+  { path: '/contact', label: 'Contact', expect: 200, type: 'text/html' },
+  { path: '/donate', label: 'Donate', expect: 200, type: 'text/html' },
   { path: '/manifest.json', label: 'PWA Manifest', expect: 200, type: 'application/json' },
   {
     path: '/deploy-meta.json',
@@ -68,7 +68,13 @@ const ROUTES = [
   },
   { path: '/sitemap.xml', label: 'Sitemap', expect: 200, type: 'application/xml' },
   { path: '/robots.txt', label: 'Robots.txt', expect: 200, type: 'text/plain' },
-  { path: '/offline.html', label: 'Offline fallback', expect: 200, type: 'text/html' },
+  { path: '/offline', label: 'Offline fallback', expect: 200, type: 'text/html' },
+  {
+    path: '/__globaldeets_health_missing__',
+    label: 'Native Pages 404',
+    expect: 404,
+    type: 'text/html',
+  },
   // API
   {
     path: '/api/news?region=global&limit=5',


### PR DESCRIPTION
## Production routing repair

The first stabilization deployment proved that the build, Functions, APIs, security headers, metadata, and source-health telemetry are healthy, but direct static HTML routes fail in production.

### Root cause
Cloudflare Pages applies `_redirects` rules even when a matching static asset exists, and Pages does not support `404` rewrites such as `/* /404.html 404`. That catch-all intercepted every static HTML route.

### Repair
- Remove redundant extensionless rewrites and the unsupported catch-all from `_redirects`.
- Rely on Cloudflare Pages' native HTML routing (`/news` -> `news.html`) and built-in top-level `404.html` handling.
- Update production health probes to canonical extensionless URLs.
- Add an explicit unknown-route probe that must return HTTP 404 with HTML.

No visual or product changes.