### PR TITLE
Repair stale live-news feed endpoints

### DIFF
--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -64,14 +64,19 @@ export const SOURCES = [
     region: 'asia',
     lang: 'en',
   },
-  { name: 'CNA', url: 'https://www.channelnewsasia.com/rss/8395986', region: 'asia', lang: 'en' },
-  { name: 'Dawn', url: 'https://www.dawn.com/feeds/home', region: 'asia', lang: 'en' },
+  {
+    name: 'CNA',
+    url: 'https://www.channelnewsasia.com/api/v1/rss-outbound-feed?_format=xml&category=6311',
+    region: 'asia',
+    lang: 'en',
+  },
+  { name: 'Dawn', url: 'https://www.dawn.com/feeds/home/', region: 'asia', lang: 'en' },
 
   // ── Americas ─────────────────────────────────────────────────────────────
   { name: 'NPR', url: 'https://feeds.npr.org/1004/rss.xml', region: 'americas', lang: 'en' },
   {
     name: 'Mercopress',
-    url: 'https://en.mercopress.com/rss/latest-news',
+    url: 'https://en.mercopress.com/rss/',
     region: 'americas',
     lang: 'en',
   },


### PR DESCRIPTION
## Source reliability repair

Production source-health telemetry identified six degraded feeds. This tranche changes only endpoints with current evidence rather than guessing replacements.

### Repairs
- CNA: replace retired `/rss/8395986` URL with CNA's current outbound World RSS endpoint.
- Mercopress: replace retired `/rss/latest-news` URL with the current official `/rss/` feed.
- Dawn: normalize to the current official `/feeds/home/` endpoint used by active RSS consumers.

### Deliberately not changed yet
AP/RSSHub, Kyiv Independent, and The East African remain visible in source-health telemetry until a stable replacement is independently verified. No source is silently removed and no third-party substitute is invented.

No UI changes.