### PR TITLE
Modernize CI and Cloudflare deploy toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,11 @@ jobs:
             contents: read
             deployments: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
-                  node-version: 20
+                  node-version: 24
 
             - name: Install dependencies
               run: npm install
@@ -41,10 +41,11 @@ jobs:
                   CF_PAGES_COMMIT_SHA: ${{ github.sha }}
 
             - name: Deploy to Cloudflare Pages
-              uses: cloudflare/wrangler-action@v3
+              uses: cloudflare/wrangler-action@v4
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  wranglerVersion: "4"
                   command: pages deploy dist --project-name globaldeets --branch main --commit-hash ${{ github.sha }} --commit-dirty=false
 
             - name: Verify production deployment

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "vite": "^8.0.11"
   },
   "optionalDependencies": {
-    "sharp": "^0.34.5"
+    "sharp": "^0.35.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }


### PR DESCRIPTION
## Toolchain stabilization

The now-green production workflow still reports deprecated Node 20 action runtimes and installs an old Wrangler 3.90.0 path with multiple audit findings.

### Changes
- `actions/checkout@v4` → `@v7`
- `actions/setup-node@v4` → `@v7`
- CI/deploy application runtime Node 20 → Node 24
- `cloudflare/wrangler-action@v3` → `@v4`
- pin Wrangler to the latest v4 major (`wranglerVersion: "4"`) rather than floating into a future v5
- `sharp` `^0.34.5` → `^0.35.3`
- align the package Node floor with sharp's supported Node 20.9+ baseline

This is infrastructure-only; no site UX/content changes. PR validation must pass before merge, and the post-merge Cloudflare deployment remains the authoritative Pages/Wrangler v4 compatibility proof.