### PR TITLE
Restore canonical GlobalDeets sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,75 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-
-    <!-- Homepage / Portfolio Hub -->
-    <url>
-        <loc>https://globaldeets.com/</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>daily</changefreq>
-        <priority>1.0</priority>
-    </url>
-
-    <!-- Analytics Dashboard -->
-    <url>
-        <loc>https://globaldeets.com/analytics.html</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-    </url>
-
-    <!-- Timeline View -->
-    <url>
-        <loc>https://globaldeets.com/timeline.html</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.7</priority>
-    </url>
-
-    <!-- Categories View -->
-    <url>
-        <loc>https://globaldeets.com/categories.html</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.7</priority>
-    </url>
-
-    <!-- Contact Page -->
-    <url>
-        <loc>https://globaldeets.com/contact.html</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.6</priority>
-    </url>
-
-    <!-- Ecosystem Cross-Links -->
-    <url>
-        <loc>https://goodflippindesign.com/</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.9</priority>
-    </url>
-
-    <url>
-        <loc>https://aiaimate.com/</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>daily</changefreq>
-        <priority>0.9</priority>
-    </url>
-
-    <url>
-        <loc>https://culturesherpa.org/</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.9</priority>
-    </url>
-
-    <url>
-        <loc>https://goodflippinvibes.com/</loc>
-        <lastmod>2026-02-03</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-    </url>
-
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://globaldeets.com/</loc></url>
+  <url><loc>https://globaldeets.com/news</loc></url>
+  <url><loc>https://globaldeets.com/globe</loc></url>
+  <url><loc>https://globaldeets.com/worldmap</loc></url>
+  <url><loc>https://globaldeets.com/knowledge</loc></url>
+  <url><loc>https://globaldeets.com/spheres</loc></url>
+  <url><loc>https://globaldeets.com/timeline</loc></url>
+  <url><loc>https://globaldeets.com/categories</loc></url>
+  <url><loc>https://globaldeets.com/analytics</loc></url>
+  <url><loc>https://globaldeets.com/about</loc></url>
+  <url><loc>https://globaldeets.com/contact</loc></url>
+  <url><loc>https://globaldeets.com/donate</loc></url>
 </urlset>


### PR DESCRIPTION
## Sitemap integrity repair

The existing sitemap was still a February-era portfolio artifact: it called the homepage a portfolio hub, omitted the current News/Globe/World Map/Knowledge/Spheres surfaces, used `.html` URLs instead of the canonical Pages routes, and listed unrelated external ecosystem domains inside GlobalDeets' sitemap.

### Repair
- publish only `globaldeets.com` URLs
- use canonical extensionless Pages URLs
- include the current primary intelligence/navigation surfaces
- remove guessed/stale `lastmod` dates rather than publishing false freshness signals

No UI or routing behavior changes.