### PR TITLE
Make news operational failures observable and non-fatal

### DIFF
--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -160,6 +160,18 @@ const BASE_HEADERS = {
   'Cache-Control': 'public, max-age=900',
 };
 
+function logOperationalError(phase, error, details = {}) {
+  console.error(
+    JSON.stringify({
+      event: 'globaldeets.news.error',
+      phase,
+      sourceFingerprint: SOURCE_FINGERPRINT,
+      ...details,
+      error: error?.message || String(error || 'unknown error'),
+    })
+  );
+}
+
 function getCorsHeaders(request) {
   const origin = request?.headers?.get('Origin');
   const allowOrigin = ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com';
@@ -189,7 +201,7 @@ export async function onRequestGet({ env, request }) {
 
   // Source definitions are part of the cache key, so changing any source deterministically
   // invalidates the old feed instead of waiting for TTL expiry.
-  const cached = await env.NEWS_CACHE?.get(CACHE_KEY, { type: 'json' });
+  const cached = await readFeedCache(env);
   if (cached) {
     const filtered = filterByRegion(cached, region);
     const page = filtered.slice(offset, offset + limit);
@@ -206,8 +218,34 @@ export async function onRequestGet({ env, request }) {
 
   const { items, sourceHealth } = await fetchAllSources();
   await translateNonEnglish(items, env);
+  await writeCaches(env, items, sourceHealth);
 
-  if (env.NEWS_CACHE) {
+  const filtered = filterByRegion(items, region);
+  const page = filtered.slice(offset, offset + limit);
+  return new Response(
+    JSON.stringify({
+      items: page,
+      cached: false,
+      total: filtered.length,
+      sourceFingerprint: SOURCE_FINGERPRINT,
+    }),
+    { headers }
+  );
+}
+
+async function readFeedCache(env) {
+  if (!env.NEWS_CACHE) return null;
+  try {
+    return await env.NEWS_CACHE.get(CACHE_KEY, { type: 'json' });
+  } catch (error) {
+    logOperationalError('kv_read_feed', error, { cacheKey: CACHE_KEY });
+    return null;
+  }
+}
+
+async function writeCaches(env, items, sourceHealth) {
+  if (!env.NEWS_CACHE) return;
+  try {
     await Promise.all([
       env.NEWS_CACHE.put(CACHE_KEY, JSON.stringify(items), {
         expirationTtl: CACHE_TTL_SECONDS,
@@ -221,20 +259,13 @@ export async function onRequestGet({ env, request }) {
         }),
         { expirationTtl: SOURCE_HEALTH_TTL_SECONDS }
       ),
-    ]).catch(() => {});
+    ]);
+  } catch (error) {
+    logOperationalError('kv_write_news', error, {
+      feedCacheKey: CACHE_KEY,
+      healthCacheKey: SOURCE_HEALTH_KEY,
+    });
   }
-
-  const filtered = filterByRegion(items, region);
-  const page = filtered.slice(offset, offset + limit);
-  return new Response(
-    JSON.stringify({
-      items: page,
-      cached: false,
-      total: filtered.length,
-      sourceFingerprint: SOURCE_FINGERPRINT,
-    }),
-    { headers }
-  );
 }
 
 async function translateNonEnglish(items, env) {
@@ -266,9 +297,13 @@ async function translateNonEnglish(items, env) {
         item.summary = summaryRes?.translated_text || item.summary;
         item.translated = true;
         item.originalLang = item.lang;
-      } catch {
+      } catch (error) {
         item.translated = false;
         item.originalLang = item.lang;
+        logOperationalError('translation', error, {
+          source: item.source,
+          sourceLang,
+        });
       }
     })
   );

--- a/functions/api/news/health.js
+++ b/functions/api/news/health.js
@@ -23,6 +23,18 @@ const BASE_HEADERS = {
   'Cache-Control': 'public, max-age=60',
 };
 
+function logOperationalError(phase, error, details = {}) {
+  console.error(
+    JSON.stringify({
+      event: 'globaldeets.news.health.error',
+      phase,
+      sourceFingerprint: SOURCE_FINGERPRINT,
+      ...details,
+      error: error?.message || String(error || 'unknown error'),
+    })
+  );
+}
+
 function getCorsHeaders(request) {
   const origin = request?.headers?.get('Origin');
   const allowOrigin = ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com';
@@ -55,13 +67,7 @@ export async function onRequestGet({ env, request }) {
   const sourceHealth = await Promise.all(SOURCES.map(probeSource));
   const generatedAt = new Date().toISOString();
 
-  if (env.NEWS_CACHE) {
-    await env.NEWS_CACHE.put(
-      SOURCE_HEALTH_KEY,
-      JSON.stringify({ generatedAt, sourceFingerprint: SOURCE_FINGERPRINT, sourceHealth }),
-      { expirationTtl: SOURCE_HEALTH_TTL_SECONDS }
-    ).catch(() => {});
-  }
+  await writeSnapshot(env, generatedAt, sourceHealth);
 
   return jsonResponse(generatedAt, sourceHealth, headers);
 }
@@ -70,8 +76,22 @@ async function readSnapshot(env) {
   if (!env.NEWS_CACHE) return null;
   try {
     return await env.NEWS_CACHE.get(SOURCE_HEALTH_KEY, { type: 'json' });
-  } catch {
+  } catch (error) {
+    logOperationalError('kv_read_health', error, { cacheKey: SOURCE_HEALTH_KEY });
     return null;
+  }
+}
+
+async function writeSnapshot(env, generatedAt, sourceHealth) {
+  if (!env.NEWS_CACHE) return;
+  try {
+    await env.NEWS_CACHE.put(
+      SOURCE_HEALTH_KEY,
+      JSON.stringify({ generatedAt, sourceFingerprint: SOURCE_FINGERPRINT, sourceHealth }),
+      { expirationTtl: SOURCE_HEALTH_TTL_SECONDS }
+    );
+  } catch (error) {
+    logOperationalError('kv_write_health', error, { cacheKey: SOURCE_HEALTH_KEY });
   }
 }
 

--- a/tests/news-functions.test.mjs
+++ b/tests/news-functions.test.mjs
@@ -51,6 +51,23 @@ function request(path = '/api/news') {
   });
 }
 
+function rssResponse(url = 'https://example.com/feed') {
+  return new Response(
+    `<rss><channel><item><title>Story ${String(url)}</title><link>https://example.com/story</link><description>Summary</description><pubDate>Wed, 02 Sep 2026 00:00:00 GMT</pubDate></item></channel></rss>`,
+    { status: 200, headers: { 'content-type': 'application/rss+xml' } }
+  );
+}
+
+function captureErrors(t) {
+  const original = console.error;
+  const entries = [];
+  console.error = value => entries.push(String(value));
+  t.after(() => {
+    console.error = original;
+  });
+  return entries;
+}
+
 const story = {
   id: 'cached-1',
   headline: 'Cached headline',
@@ -92,12 +109,7 @@ test('/api/news cache miss writes feed and health under the current source finge
   t.after(() => {
     globalThis.fetch = previousFetch;
   });
-
-  globalThis.fetch = async url =>
-    new Response(
-      `<rss><channel><item><title>Story ${String(url)}</title><link>https://example.com/story</link><description>Summary</description><pubDate>Wed, 02 Sep 2026 00:00:00 GMT</pubDate></item></channel></rss>`,
-      { status: 200, headers: { 'content-type': 'application/rss+xml' } }
-    );
+  globalThis.fetch = async url => rssResponse(url);
 
   const kv = makeKv();
   const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=5') });
@@ -114,6 +126,49 @@ test('/api/news cache miss writes feed and health under the current source finge
   const healthWrite = kv.puts.find(put => put.key === SOURCE_HEALTH_KEY);
   assert.equal(healthWrite.value.sourceFingerprint, SOURCE_FINGERPRINT);
   assert.equal(healthWrite.value.sourceHealth.length, SOURCES.length);
+});
+
+test('/api/news degrades to live fetch when KV read fails and emits structured telemetry', async t => {
+  const previousFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+  globalThis.fetch = async url => rssResponse(url);
+  const errors = captureErrors(t);
+  const kv = makeKv();
+  kv.get = async () => {
+    throw new Error('simulated KV read failure');
+  };
+
+  const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=5') });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.cached, false);
+  assert.ok(json.items.length > 0);
+  assert.ok(errors.some(entry => entry.includes('"phase":"kv_read_feed"')));
+  assert.ok(errors.some(entry => entry.includes(SOURCE_FINGERPRINT)));
+});
+
+test('/api/news remains available when KV writes fail and emits structured telemetry', async t => {
+  const previousFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+  globalThis.fetch = async url => rssResponse(url);
+  const errors = captureErrors(t);
+  const kv = makeKv();
+  kv.put = async () => {
+    throw new Error('simulated KV write failure');
+  };
+
+  const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=5') });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.cached, false);
+  assert.ok(json.items.length > 0);
+  assert.ok(errors.some(entry => entry.includes('"phase":"kv_write_news"')));
 });
 
 test('/api/news/health reuses only a snapshot matching source fingerprint and source count', async () => {
@@ -166,4 +221,50 @@ test('/api/news/health regenerates a fingerprint-mismatched snapshot', async t =
   assert.equal(kv.puts.length, 1);
   assert.equal(kv.puts[0].key, SOURCE_HEALTH_KEY);
   assert.equal(kv.puts[0].value.sourceFingerprint, SOURCE_FINGERPRINT);
+});
+
+test('/api/news/health regenerates when KV read fails and emits structured telemetry', async t => {
+  const previousFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+  globalThis.fetch = async () => new Response('ok', { status: 200 });
+  const errors = captureErrors(t);
+  const kv = makeKv();
+  kv.get = async () => {
+    throw new Error('simulated health KV read failure');
+  };
+
+  const response = await getNewsHealth({
+    env: { NEWS_CACHE: kv },
+    request: request('/api/news/health'),
+  });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.totalSources, SOURCES.length);
+  assert.ok(errors.some(entry => entry.includes('"phase":"kv_read_health"')));
+});
+
+test('/api/news/health remains available when snapshot write fails', async t => {
+  const previousFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+  globalThis.fetch = async () => new Response('ok', { status: 200 });
+  const errors = captureErrors(t);
+  const kv = makeKv();
+  kv.put = async () => {
+    throw new Error('simulated health KV write failure');
+  };
+
+  const response = await getNewsHealth({
+    env: { NEWS_CACHE: kv },
+    request: request('/api/news/health'),
+  });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.totalSources, SOURCES.length);
+  assert.ok(errors.some(entry => entry.includes('"phase":"kv_write_health"')));
 });


### PR DESCRIPTION
## News operational telemetry

The news Functions previously had two related observability/availability gaps:

- a `NEWS_CACHE.get()` failure in `/api/news` could escape and fail the public endpoint;
- KV writes, health-cache reads/writes, and translation failures were intentionally best-effort but silently swallowed, leaving no production diagnostic trail.

### Repair
- degrade feed-cache read failures to live source fetch rather than failing `/api/news`
- retain non-fatal behavior for feed/health KV writes and translation failures
- emit structured, non-secret `console.error` events with phase + deployed source fingerprint
- make `/api/news/health` KV read/write failures observable while preserving self-initialization
- add contract tests proving both endpoints remain available across KV read/write failure paths and that the expected structured telemetry phases are emitted

No UI changes and no new external service dependency.