### PR TITLE
GD-012: Add deterministic coverage observatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           node --check tools/deploy-pages.js
           node --check functions/api/deploy.js
           node --check functions/api/news/health.js
+          node --check functions/api/news/coverage.js
+          node --check functions/lib/news-coverage.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
 

--- a/docs/coverage-observatory.md
+++ b/docs/coverage-observatory.md
@@ -1,0 +1,62 @@
+# GlobalDeets Coverage Observatory
+
+Phase II begins by measuring what the production news contract can and cannot see before adding more feeds.
+
+## Current production baseline
+
+The observatory derives its inventory directly from `SOURCES` in `functions/api/news.js` so the analysis cannot silently drift from the deployed ingestion contract.
+
+At the Phase II baseline (`0fc253fb2d3297f5b15c3dbfface64db1ee8a597`):
+
+- 19 configured sources
+- 7 coarse regions
+- 2 source languages
+- 18/19 sources are English-language inputs
+- NHK is the only non-English source-language input
+- Pacific has one configured source, so it has no feed-level redundancy
+- Africa, Americas, Europe, Middle East, and Pacific have only English-language source inputs in the present contract
+
+These are coverage signals, not judgments about truth, ideology, or publisher quality.
+
+## API
+
+`GET /api/news/coverage`
+
+Returns a deterministic inventory containing:
+
+- current source fingerprint
+- total sources, regions, and source languages
+- English-language concentration
+- per-region source counts and language diversity
+- per-language source counts
+- explicit gap signals generated from a small documented policy
+
+The endpoint is intentionally read-only and does not probe feeds. Operational availability remains the responsibility of `/api/news/health`.
+
+## Initial gap policy
+
+The first policy is intentionally narrow and auditable:
+
+1. A region with fewer than two configured feeds emits a high-severity `regional-redundancy` signal.
+2. A non-global region with English-only source inputs emits a medium-severity `source-language-diversity` signal.
+3. If at least 80% of the complete source portfolio is English-language input, the portfolio emits a high-severity `portfolio-language-concentration` signal.
+
+These thresholds are diagnostics, not permanent editorial doctrine. They create a measurable baseline from which better source research can proceed.
+
+## Deliberate non-goals of GD-012
+
+This tranche does **not** yet claim to measure:
+
+- publisher ownership or independence
+- primary-vs-secondary evidence
+- country-level geographic coverage
+- topic/beat coverage
+- viewpoint or political diversity
+- article-level corroboration or contradiction
+- source reliability or factual accuracy
+
+Those require explicit provenance metadata and evidence modeling rather than guesses inferred from a publisher name or feed URL.
+
+## Next tranche
+
+GD-013 should add a reviewed source-provenance registry beside the runtime feed definitions. The registry should use explicit fields for source class, geographic scope, locality, organization type, languages, and evidence role, with validation that every live feed has a provenance record. That will allow the observatory to expose substantially more meaningful blind spots without contaminating the feed-cache identity contract.

--- a/functions/api/news/coverage.js
+++ b/functions/api/news/coverage.js
@@ -1,0 +1,45 @@
+// Cloudflare Pages Function - GET /api/news/coverage
+
+import { buildCoverageInventory } from '../../lib/news-coverage.js';
+import { SOURCE_FINGERPRINT } from '../news.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+const BASE_HEADERS = {
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+  'Cache-Control': 'public, max-age=300',
+};
+
+function getCorsHeaders(request) {
+  const origin = request?.headers?.get('Origin');
+  const allowOrigin = ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com';
+
+  return {
+    ...BASE_HEADERS,
+    'Access-Control-Allow-Origin': allowOrigin,
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: getCorsHeaders(request) });
+}
+
+export async function onRequestGet({ request }) {
+  const inventory = buildCoverageInventory();
+  return new Response(
+    JSON.stringify({
+      generatedAt: new Date().toISOString(),
+      sourceFingerprint: SOURCE_FINGERPRINT,
+      ...inventory,
+    }),
+    { headers: getCorsHeaders(request) }
+  );
+}

--- a/functions/lib/news-coverage.js
+++ b/functions/lib/news-coverage.js
@@ -1,0 +1,121 @@
+// Deterministic coverage inventory derived from the canonical news source contract.
+// This module intentionally does not alter feed fetching or cache identity.
+
+import { SOURCES, slugifySourceName } from '../api/news.js';
+
+export const COVERAGE_POLICY = Object.freeze({
+  minimumSourcesPerRegion: 2,
+  portfolioEnglishConcentrationThreshold: 0.8,
+});
+
+export function buildCoverageInventory(sources = SOURCES) {
+  const normalizedSources = sources
+    .map(source => ({
+      sourceId: slugifySourceName(source.name),
+      name: source.name,
+      region: source.region,
+      lang: source.lang,
+    }))
+    .sort((a, b) => a.sourceId.localeCompare(b.sourceId));
+
+  const regionGroups = groupSources(normalizedSources, 'region');
+  const languageGroups = groupSources(normalizedSources, 'lang');
+
+  const regions = Object.entries(regionGroups)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([region, members]) => ({
+      region,
+      sourceCount: members.length,
+      languageCount: new Set(members.map(source => source.lang)).size,
+      languages: [...new Set(members.map(source => source.lang))].sort(),
+      sourceIds: members.map(source => source.sourceId).sort(),
+    }));
+
+  const languages = Object.entries(languageGroups)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([lang, members]) => ({
+      lang,
+      sourceCount: members.length,
+      sourceIds: members.map(source => source.sourceId).sort(),
+    }));
+
+  const gaps = buildGapSignals(normalizedSources, regions);
+  const englishSources = normalizedSources.filter(source => source.lang === 'en').length;
+
+  return {
+    totalSources: normalizedSources.length,
+    totalRegions: regions.length,
+    totalLanguages: languages.length,
+    englishSourceShare:
+      normalizedSources.length === 0 ? 0 : roundRatio(englishSources / normalizedSources.length),
+    nonEnglishSources: normalizedSources
+      .filter(source => source.lang !== 'en')
+      .map(source => source.sourceId),
+    regions,
+    languages,
+    gaps,
+  };
+}
+
+function buildGapSignals(sources, regions) {
+  const gaps = [];
+
+  for (const region of regions) {
+    if (region.sourceCount < COVERAGE_POLICY.minimumSourcesPerRegion) {
+      gaps.push({
+        id: `regional-redundancy:${region.region}`,
+        type: 'regional-redundancy',
+        severity: 'high',
+        region: region.region,
+        observed: region.sourceCount,
+        target: COVERAGE_POLICY.minimumSourcesPerRegion,
+        detail: `${region.region} has fewer than ${COVERAGE_POLICY.minimumSourcesPerRegion} independent feed inputs in the current contract.`,
+      });
+    }
+  }
+
+  const englishOnlyRegions = regions.filter(
+    region => region.region !== 'global' && region.languages.length === 1 && region.languages[0] === 'en'
+  );
+
+  for (const region of englishOnlyRegions) {
+    gaps.push({
+      id: `source-language-diversity:${region.region}`,
+      type: 'source-language-diversity',
+      severity: 'medium',
+      region: region.region,
+      observed: region.languages,
+      target: 'include at least one non-English source-language input where reliable coverage exists',
+      detail: `${region.region} currently depends entirely on English-language feed inputs.`,
+    });
+  }
+
+  const englishCount = sources.filter(source => source.lang === 'en').length;
+  const englishShare = sources.length === 0 ? 0 : englishCount / sources.length;
+  if (englishShare >= COVERAGE_POLICY.portfolioEnglishConcentrationThreshold) {
+    gaps.push({
+      id: 'portfolio-language-concentration:en',
+      type: 'portfolio-language-concentration',
+      severity: 'high',
+      region: null,
+      observed: roundRatio(englishShare),
+      target: `< ${COVERAGE_POLICY.portfolioEnglishConcentrationThreshold}`,
+      detail: 'The source portfolio is highly concentrated in English-language feed inputs.',
+    });
+  }
+
+  return gaps.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function groupSources(sources, field) {
+  return sources.reduce((groups, source) => {
+    const key = source[field] || 'unknown';
+    groups[key] ||= [];
+    groups[key].push(source);
+    return groups;
+  }, {});
+}
+
+function roundRatio(value) {
+  return Math.round(value * 10000) / 10000;
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), 'globaldeets-coverage-'));
+const fixtureFunctions = join(fixtureRoot, 'functions');
+const fixtureNews = join(fixtureFunctions, 'api', 'news.js');
+const fixtureCoverageApi = join(fixtureFunctions, 'api', 'news', 'coverage.js');
+const fixtureCoverageLib = join(fixtureFunctions, 'lib', 'news-coverage.js');
+
+mkdirSync(dirname(fixtureCoverageApi), { recursive: true });
+mkdirSync(dirname(fixtureCoverageLib), { recursive: true });
+writeFileSync(join(fixtureFunctions, 'package.json'), '{"type":"module"}\n');
+copyFileSync(fileURLToPath(new URL('../functions/api/news.js', import.meta.url)), fixtureNews);
+copyFileSync(
+  fileURLToPath(new URL('../functions/api/news/coverage.js', import.meta.url)),
+  fixtureCoverageApi
+);
+copyFileSync(
+  fileURLToPath(new URL('../functions/lib/news-coverage.js', import.meta.url)),
+  fixtureCoverageLib
+);
+
+const newsModule = await import(pathToFileURL(fixtureNews).href);
+const coverageModule = await import(pathToFileURL(fixtureCoverageLib).href);
+const coverageApiModule = await import(pathToFileURL(fixtureCoverageApi).href);
+
+const { SOURCES, SOURCE_FINGERPRINT } = newsModule;
+const { buildCoverageInventory } = coverageModule;
+const { onRequestGet: getCoverage } = coverageApiModule;
+
+function request(path = '/api/news/coverage') {
+  return new Request(`https://globaldeets.com${path}`, {
+    headers: { Origin: 'https://globaldeets.com' },
+  });
+}
+
+test('coverage inventory is deterministic and derived from the canonical source contract', () => {
+  const first = buildCoverageInventory(SOURCES);
+  const second = buildCoverageInventory(SOURCES.map(source => ({ ...source })));
+
+  assert.deepEqual(first, second);
+  assert.equal(first.totalSources, SOURCES.length);
+  assert.equal(first.totalSources, 19);
+  assert.equal(first.totalRegions, 7);
+  assert.equal(first.totalLanguages, 2);
+  assert.equal(first.nonEnglishSources.length, 1);
+  assert.ok(first.nonEnglishSources.includes('nhk'));
+});
+
+test('coverage inventory surfaces current regional redundancy and source-language blind spots', () => {
+  const inventory = buildCoverageInventory(SOURCES);
+  const gapIds = new Set(inventory.gaps.map(gap => gap.id));
+
+  assert.ok(gapIds.has('regional-redundancy:pacific'));
+  assert.ok(gapIds.has('portfolio-language-concentration:en'));
+  assert.ok(gapIds.has('source-language-diversity:africa'));
+  assert.ok(gapIds.has('source-language-diversity:americas'));
+  assert.ok(gapIds.has('source-language-diversity:europe'));
+  assert.ok(gapIds.has('source-language-diversity:middle-east'));
+  assert.ok(gapIds.has('source-language-diversity:pacific'));
+});
+
+test('coverage gap logic responds to stronger regional and language diversity', () => {
+  const sample = [
+    { name: 'A', url: 'https://a.example/rss', region: 'alpha', lang: 'en' },
+    { name: 'B', url: 'https://b.example/rss', region: 'alpha', lang: 'fr' },
+    { name: 'C', url: 'https://c.example/rss', region: 'beta', lang: 'es' },
+    { name: 'D', url: 'https://d.example/rss', region: 'beta', lang: 'pt' },
+  ];
+  const inventory = buildCoverageInventory(sample);
+
+  assert.equal(inventory.gaps.length, 0);
+  assert.equal(inventory.totalRegions, 2);
+  assert.equal(inventory.totalLanguages, 4);
+  assert.equal(inventory.englishSourceShare, 0.25);
+});
+
+test('/api/news/coverage exposes the current source fingerprint and inventory', async () => {
+  const response = await getCoverage({ request: request() });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.sourceFingerprint, SOURCE_FINGERPRINT);
+  assert.equal(json.totalSources, SOURCES.length);
+  assert.equal(json.totalRegions, 7);
+  assert.ok(Array.isArray(json.gaps));
+  assert.ok(json.gaps.length > 0);
+  assert.match(json.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+});


### PR DESCRIPTION
## Phase II — Coverage Observatory

Starts the post-stabilization intelligence phase by making coverage gaps measurable before adding more feeds.

### What changes
- Adds a deterministic coverage inventory derived directly from the canonical `SOURCES` contract.
- Adds `GET /api/news/coverage` with source fingerprint, region/language inventory, concentration metrics, and explicit gap signals.
- Adds contract tests for deterministic inventory, current baseline blind spots, policy responsiveness, and the API surface.
- Expands the Function test command so both news-health and coverage contracts run in CI.
- Adds syntax checks for the new Function/library modules.
- Documents the baseline, policy, non-goals, and the boundary for GD-013 provenance work.

### Baseline surfaced
- 19 configured sources
- 7 coarse regions
- 2 source languages
- 18/19 sources are English-language inputs
- NHK is the sole non-English input
- Pacific has only one configured source
- Africa, Americas, Europe, Middle East, and Pacific currently have English-only source inputs

### Safety / scope
This PR does not change feed URLs, cache keys, feed fetching, translation, source health, or production ingestion behavior. It intentionally does not infer publisher reliability, ownership, ideology, or factual quality from names/URLs.

Base: `0fc253fb2d3297f5b15c3dbfface64db1ee8a597`