### PR TITLE
GD-013: Add reviewed source provenance registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
           node --check health-prod.js
           node --check tools/stage-deploy.js
           node --check tools/deploy-pages.js
+          node --check tools/verify-intelligence-prod.js
           node --check functions/api/deploy.js
           node --check functions/api/news/health.js
           node --check functions/api/news/coverage.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
           node --check functions/api/deploy.js
           node --check functions/api/news/health.js
           node --check functions/api/news/coverage.js
+          node --check functions/api/news/sources.js
           node --check functions/lib/news-coverage.js
+          node --check functions/lib/news-source-provenance.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,3 +65,6 @@ jobs:
                     echo "Production verification attempt ${attempt} failed; retrying after propagation delay."
                     sleep 10
                   done
+
+            - name: Verify production intelligence APIs
+              run: node tools/verify-intelligence-prod.js --base=https://globaldeets.com

--- a/docs/phase2-source-provenance.md
+++ b/docs/phase2-source-provenance.md
@@ -1,0 +1,89 @@
+# Phase II — Reviewed Source Provenance
+
+GlobalDeets treats source provenance as evidence, not reputation scoring.
+
+## Purpose
+
+The live news pipeline previously knew only a source name, feed URL, coarse region, and feed language. That is sufficient for fetching and health checks but insufficient for answering higher-order questions about what kinds of institutions GlobalDeets is hearing from and what evidence classes are absent.
+
+GD-013 adds a reviewed provenance registry beside the canonical ingestion contract. It does **not** change feed URLs, feed cache identity, source-health keys, parsing, translation, or ranking.
+
+## Registry contract
+
+Every live `SOURCES` entry must map to exactly one provenance record. CI rejects missing, orphaned, duplicate, or structurally invalid records.
+
+Each record contains:
+
+- canonical source ID
+- display/source name
+- organization name
+- source class
+- evidence role
+- geographic scope
+- primary country when applicable
+- locality indicator
+- live feed language(s)
+- ownership/operator when verified, otherwise `null`
+- one or more provenance/evidence URLs
+- review date
+
+Unknown facts stay unknown. The registry must not infer political ideology, factuality, editorial independence, or trustworthiness from a publisher name, country, ownership structure, or funding model.
+
+## Public surfaces
+
+### `GET /api/news/sources`
+
+Returns the source fingerprint, provenance review date, registry validation result, and reviewed source records with their evidence links.
+
+### `GET /api/news/coverage`
+
+Adds provenance-aware inventory dimensions:
+
+- source classes
+- evidence roles
+- geographic scopes
+- source-origin countries
+- provenance integrity
+- unknown ownership/operator records
+
+## New measurable gaps
+
+The current 19-source live contract contains **zero primary-source institutional inputs**. Its evidence roles are reporting and wire services only. This is now a first-class high-severity gap because major stories should eventually be connectable to original evidence such as court filings, regulator releases, government records, sanctions notices, central-bank publications, election authorities, multilateral organizations, and other authoritative primary material.
+
+The live contract also contains **zero subnational/local sources**. National and regional publishers remain essential, but a fuller intelligence system needs the ability to reach below national narratives when a story is fundamentally local.
+
+These signals do not mean that an institutional source is automatically correct or that a local source is automatically superior. They mean GlobalDeets can now measure whether those evidence perspectives are present at all.
+
+## Evidence review examples
+
+The registry uses publisher or operator material where practical. Examples reviewed for this tranche include:
+
+- Associated Press describing itself as an independent news cooperative.
+- Guardian documenting Guardian News & Media and The Scott Trust ownership structure.
+- Al Jazeera identifying Al Jazeera Media Network and disclosing that it is funded in part by the Qatari government.
+- France Médias Monde identifying France 24 as its international news channel.
+- Kyiv Independent documenting its newsroom history and Ukrainian origin.
+- Ukrinform identifying itself as Ukraine's national news agency.
+- CNA identifying Mediacorp and its Singapore base.
+- NPR identifying itself as an independent nonprofit media organization.
+- Australian Broadcasting Corporation identifying itself as Australia's publicly owned public-service media organization.
+- Premium Times identifying Premium Times Services Limited as its publisher.
+- Nation Media Group identifying The EastAfrican as a regional East African title.
+- MercoPress identifying itself as an independent Montevideo-based news agency focused on Mercosur and the South Atlantic.
+
+## Explicit non-goals
+
+This tranche does not create:
+
+- a truth score
+- a political-bias score
+- a reliability score
+- an ideological label
+- automatic ownership inference
+- automatic source promotion or demotion
+
+Those shortcuts would collapse different questions into a misleading single number. GlobalDeets should instead expose concrete provenance, corroboration, contradiction, and primary evidence separately.
+
+## Next gate
+
+GD-014 should introduce canonical entities and events so incoming articles and future primary-source records can attach to durable people, organizations, places, and developing stories rather than remaining isolated feed items.

--- a/docs/phase2-source-provenance.md
+++ b/docs/phase2-source-provenance.md
@@ -8,22 +8,28 @@ The live news pipeline previously knew only a source name, feed URL, coarse regi
 
 GD-013 adds a reviewed provenance registry beside the canonical ingestion contract. It does **not** change feed URLs, feed cache identity, source-health keys, parsing, translation, or ranking.
 
+## Routing region is not geographic scope
+
+The existing `SOURCES.region` field is a feed-routing bucket used by the current product. It must not be interpreted as the publisher's actual reporting footprint or organizational geography. For example, a publisher can be routed through a regional bucket while its reviewed provenance has a global geographic scope.
+
+The provenance fields `geographicScope`, `primaryCountry`, and `locality` exist specifically so future coverage analysis does not confuse routing behavior with source origin, reach, or localness.
+
 ## Registry contract
 
-Every live `SOURCES` entry must map to exactly one provenance record. CI rejects missing, orphaned, duplicate, or structurally invalid records.
+Every live `SOURCES` entry must map to exactly one provenance record. CI rejects missing, orphaned, duplicate, drifted, or structurally invalid records. A source name or feed-language change invalidates the associated provenance record until it is reviewed alongside the source change.
 
 Each record contains:
 
 - canonical source ID
 - display/source name
-- organization name
+- publisher/organization name
 - source class
 - evidence role
 - geographic scope
 - primary country when applicable
 - locality indicator
 - live feed language(s)
-- ownership/operator when verified, otherwise `null`
+- ownership/operator separately from publisher identity
 - one or more provenance/evidence URLs
 - review date
 
@@ -54,17 +60,20 @@ The live contract also contains **zero subnational/local sources**. National and
 
 These signals do not mean that an institutional source is automatically correct or that a local source is automatically superior. They mean GlobalDeets can now measure whether those evidence perspectives are present at all.
 
+GlobalDeets already has a separate Knowledge catalog containing many institutional and research resources. The zero-primary-input signal refers to the **live news/evidence ingestion contract**, not to the absence of institutional links elsewhere in the platform. GD-015 should review and reuse suitable Knowledge entries rather than build a duplicate institutional directory.
+
 ## Evidence review examples
 
 The registry uses publisher or operator material where practical. Examples reviewed for this tranche include:
 
-- Associated Press describing itself as an independent news cooperative.
+- Associated Press documenting its cooperative identity.
 - Guardian documenting Guardian News & Media and The Scott Trust ownership structure.
-- Al Jazeera identifying Al Jazeera Media Network and disclosing that it is funded in part by the Qatari government.
-- France Médias Monde identifying France 24 as its international news channel.
+- Al Jazeera identifying Al Jazeera Media Network.
+- France Medias Monde identifying France 24 as its international news channel.
 - Kyiv Independent documenting its newsroom history and Ukrainian origin.
 - Ukrinform identifying itself as Ukraine's national news agency.
 - CNA identifying Mediacorp and its Singapore base.
+- Dawn identifying Pakistan Herald Publications Private Limited as publisher of Dawn and Dawn.com.
 - NPR identifying itself as an independent nonprofit media organization.
 - Australian Broadcasting Corporation identifying itself as Australia's publicly owned public-service media organization.
 - Premium Times identifying Premium Times Services Limited as its publisher.
@@ -84,6 +93,10 @@ This tranche does not create:
 
 Those shortcuts would collapse different questions into a misleading single number. GlobalDeets should instead expose concrete provenance, corroboration, contradiction, and primary evidence separately.
 
+## Release contract
+
+After the normal exact-commit production health verifier confirms custom-domain convergence, deployment separately verifies the intelligence APIs. `/api/news/coverage` and `/api/news/sources` must agree on the source fingerprint and source count, both registries must validate, and every exposed source must retain evidence URLs before the release can certify.
+
 ## Next gate
 
-GD-014 should introduce canonical entities and events so incoming articles and future primary-source records can attach to durable people, organizations, places, and developing stories rather than remaining isolated feed items.
+GD-014 should introduce canonical entities and events so incoming articles and future primary-source records can attach to durable people, organizations, places, and developing stories rather than remaining isolated feed items. Place entities should also become the canonical geography foundation for the long-planned country library and globe context.

--- a/functions/api/news/sources.js
+++ b/functions/api/news/sources.js
@@ -1,0 +1,50 @@
+// Cloudflare Pages Function - GET /api/news/sources
+
+import { SOURCE_FINGERPRINT } from '../news.js';
+import {
+  PROVENANCE_REVIEW_DATE,
+  SOURCE_PROVENANCE,
+  validateSourceProvenance,
+} from '../../lib/news-source-provenance.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+const BASE_HEADERS = {
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+  'Cache-Control': 'public, max-age=3600',
+};
+
+function getCorsHeaders(request) {
+  const origin = request?.headers?.get('Origin');
+  const allowOrigin = ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com';
+  return {
+    ...BASE_HEADERS,
+    'Access-Control-Allow-Origin': allowOrigin,
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: getCorsHeaders(request) });
+}
+
+export async function onRequestGet({ request }) {
+  const validation = validateSourceProvenance();
+  return new Response(
+    JSON.stringify({
+      sourceFingerprint: SOURCE_FINGERPRINT,
+      reviewedAt: PROVENANCE_REVIEW_DATE,
+      validation,
+      totalSources: SOURCE_PROVENANCE.length,
+      sources: SOURCE_PROVENANCE,
+    }),
+    { headers: getCorsHeaders(request) }
+  );
+}

--- a/functions/lib/news-coverage.js
+++ b/functions/lib/news-coverage.js
@@ -1,46 +1,62 @@
 // Deterministic coverage inventory derived from the canonical news source contract.
-// This module intentionally does not alter feed fetching or cache identity.
+// Provenance enriches observability but intentionally does not alter feed fetching or cache identity.
 
 import { SOURCES, slugifySourceName } from '../api/news.js';
+import { SOURCE_PROVENANCE, validateSourceProvenance } from './news-source-provenance.js';
 
 export const COVERAGE_POLICY = Object.freeze({
   minimumSourcesPerRegion: 2,
   portfolioEnglishConcentrationThreshold: 0.8,
+  minimumPrimarySourceInputs: 1,
 });
 
-export function buildCoverageInventory(sources = SOURCES) {
+export function buildCoverageInventory(sources = SOURCES, provenance = SOURCE_PROVENANCE) {
+  const provenanceValidation = validateSourceProvenance(sources, provenance);
+  const provenanceById = new Map(provenance.map(entry => [entry.sourceId, entry]));
   const normalizedSources = sources
-    .map(source => ({
-      sourceId: slugifySourceName(source.name),
-      name: source.name,
-      region: source.region,
-      lang: source.lang,
-    }))
+    .map(source => {
+      const sourceId = slugifySourceName(source.name);
+      const metadata = provenanceById.get(sourceId) || {};
+      return {
+        sourceId,
+        name: source.name,
+        region: source.region,
+        lang: source.lang,
+        sourceClass: metadata.sourceClass || 'unknown',
+        evidenceRole: metadata.evidenceRole || 'unknown',
+        geographicScope: metadata.geographicScope || 'unknown',
+        primaryCountry: metadata.primaryCountry || null,
+        locality: metadata.locality || 'unknown',
+        ownershipOperatorKnown: Boolean(metadata.ownershipOperator),
+      };
+    })
     .sort((a, b) => a.sourceId.localeCompare(b.sourceId));
 
   const regionGroups = groupSources(normalizedSources, 'region');
   const languageGroups = groupSources(normalizedSources, 'lang');
+  const sourceClassGroups = groupSources(normalizedSources, 'sourceClass');
+  const evidenceRoleGroups = groupSources(normalizedSources, 'evidenceRole');
+  const geographicScopeGroups = groupSources(normalizedSources, 'geographicScope');
+  const countryGroups = groupSources(
+    normalizedSources.filter(source => source.primaryCountry),
+    'primaryCountry'
+  );
 
-  const regions = Object.entries(regionGroups)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([region, members]) => ({
-      region,
-      sourceCount: members.length,
-      languageCount: new Set(members.map(source => source.lang)).size,
-      languages: [...new Set(members.map(source => source.lang))].sort(),
-      sourceIds: members.map(source => source.sourceId).sort(),
-    }));
+  const regions = summarizeGroups(regionGroups, 'region', members => ({
+    languageCount: new Set(members.map(source => source.lang)).size,
+    languages: [...new Set(members.map(source => source.lang))].sort(),
+  }));
+  const languages = summarizeGroups(languageGroups, 'lang');
+  const sourceClasses = summarizeGroups(sourceClassGroups, 'sourceClass');
+  const evidenceRoles = summarizeGroups(evidenceRoleGroups, 'evidenceRole');
+  const geographicScopes = summarizeGroups(geographicScopeGroups, 'geographicScope');
+  const sourceOriginCountries = summarizeGroups(countryGroups, 'country');
 
-  const languages = Object.entries(languageGroups)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([lang, members]) => ({
-      lang,
-      sourceCount: members.length,
-      sourceIds: members.map(source => source.sourceId).sort(),
-    }));
-
-  const gaps = buildGapSignals(normalizedSources, regions);
+  const gaps = buildGapSignals(normalizedSources, regions, provenanceValidation);
   const englishSources = normalizedSources.filter(source => source.lang === 'en').length;
+  const primarySourceInputs = normalizedSources.filter(
+    source => source.evidenceRole === 'primary-source'
+  ).length;
 
   return {
     totalSources: normalizedSources.length,
@@ -51,13 +67,29 @@ export function buildCoverageInventory(sources = SOURCES) {
     nonEnglishSources: normalizedSources
       .filter(source => source.lang !== 'en')
       .map(source => source.sourceId),
+    primarySourceInputs,
+    provenance: {
+      valid: provenanceValidation.valid,
+      reviewedSources: provenance.length,
+      missingSourceIds: provenanceValidation.missingSourceIds,
+      orphanSourceIds: provenanceValidation.orphanSourceIds,
+      duplicateIds: provenanceValidation.duplicateIds,
+      invalidEntries: provenanceValidation.invalidEntries,
+      unknownOwnershipOperatorSourceIds: normalizedSources
+        .filter(source => !source.ownershipOperatorKnown)
+        .map(source => source.sourceId),
+    },
     regions,
     languages,
+    sourceClasses,
+    evidenceRoles,
+    geographicScopes,
+    sourceOriginCountries,
     gaps,
   };
 }
 
-function buildGapSignals(sources, regions) {
+function buildGapSignals(sources, regions, provenanceValidation) {
   const gaps = [];
 
   for (const region of regions) {
@@ -104,7 +136,56 @@ function buildGapSignals(sources, regions) {
     });
   }
 
+  const primarySourceInputs = sources.filter(source => source.evidenceRole === 'primary-source').length;
+  if (primarySourceInputs < COVERAGE_POLICY.minimumPrimarySourceInputs) {
+    gaps.push({
+      id: 'evidence-role:primary-source-inputs',
+      type: 'evidence-role',
+      severity: 'high',
+      region: null,
+      observed: primarySourceInputs,
+      target: COVERAGE_POLICY.minimumPrimarySourceInputs,
+      detail: 'The live source contract contains reporting and wire inputs but no primary-source institutional evidence feeds.',
+    });
+  }
+
+  const subnationalSources = sources.filter(source => source.geographicScope === 'subnational').length;
+  if (subnationalSources === 0) {
+    gaps.push({
+      id: 'geographic-scope:subnational',
+      type: 'geographic-scope',
+      severity: 'medium',
+      region: null,
+      observed: 0,
+      target: 'measurable subnational/local coverage where strategically relevant',
+      detail: 'No current source is classified as a subnational/local source, limiting visibility below national and regional narratives.',
+    });
+  }
+
+  if (!provenanceValidation.valid) {
+    gaps.push({
+      id: 'provenance-registry:invalid',
+      type: 'provenance-integrity',
+      severity: 'critical',
+      region: null,
+      observed: provenanceValidation,
+      target: 'exactly one valid provenance record per live source',
+      detail: 'The provenance registry does not exactly match the canonical live source contract.',
+    });
+  }
+
   return gaps.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function summarizeGroups(groups, keyName, enrich = () => ({})) {
+  return Object.entries(groups)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, members]) => ({
+      [keyName]: key,
+      sourceCount: members.length,
+      sourceIds: members.map(source => source.sourceId).sort(),
+      ...enrich(members),
+    }));
 }
 
 function groupSources(sources, field) {

--- a/functions/lib/news-source-provenance.js
+++ b/functions/lib/news-source-provenance.js
@@ -1,0 +1,88 @@
+// Reviewed provenance metadata for the canonical production news sources.
+// Unknown facts stay explicit. This registry must never be used as a political-bias or truth score.
+
+import { SOURCES, slugifySourceName } from '../api/news.js';
+
+export const PROVENANCE_REVIEW_DATE = '2026-09-03';
+
+export const SOURCE_PROVENANCE = Object.freeze([
+  record('bbc-world', 'BBC World', 'public-service-broadcaster', 'reporting', 'global', 'GB', 'global', 'British Broadcasting Corporation', ['https://www.bbc.com/aboutthebbc']),
+  record('ap', 'AP', 'news-agency', 'wire-service', 'global', 'US', 'global', 'The Associated Press', ['https://www.ap.org/about/']),
+  record('guardian', 'Guardian', 'newsroom', 'reporting', 'global', 'GB', 'global', 'Guardian News & Media; ultimate owner The Scott Trust Limited', ['https://www.theguardian.com/about']),
+  record('al-jazeera', 'Al Jazeera', 'international-news-network', 'reporting', 'global', 'QA', 'global', 'Al Jazeera Media Network; funded in part by the Qatari government', ['https://www.aljazeera.com/about-us']),
+  record('anadolu-agency', 'Anadolu Agency', 'news-agency', 'wire-service', 'global', 'TR', 'global', 'Anadolu Agency', ['https://www.aa.com.tr/en/newsacademy/p/about-us']),
+  record('dw', 'DW', 'public-service-broadcaster', 'reporting', 'global', 'DE', 'global', 'Deutsche Welle', ['https://www.dw.com/en/about-dw/s-30688']),
+  record('france-24', 'France 24', 'public-international-broadcaster', 'reporting', 'global', 'FR', 'global', 'France Médias Monde', ['https://www.francemediasmonde.com/en/our-media/france-24/']),
+  record('kyiv-independent', 'Kyiv Independent', 'digital-newsroom', 'reporting', 'national', 'UA', 'local', 'The Kyiv Independent', ['https://kyivindependent.com/about/']),
+  record('ukrinform', 'Ukrinform', 'national-news-agency', 'wire-service', 'national', 'UA', 'local', 'Ukrainian National News Agency Ukrinform', ['https://www.ukrinform.net/info/about_agency.html']),
+  record('nhk', 'NHK', 'public-service-broadcaster', 'reporting', 'national', 'JP', 'local', 'NHK (Japan Broadcasting Corporation)', ['https://www.nhk.or.jp/corporateinfo/']),
+  record('yonhap', 'Yonhap', 'national-news-agency', 'wire-service', 'national', 'KR', 'local', 'Yonhap News Agency', ['https://en.yna.co.kr/aboutus/index']),
+  record('the-hindu', 'The Hindu', 'newspaper-newsroom', 'reporting', 'national', 'IN', 'local', 'THG Publishing Private Limited / The Hindu Group', ['https://learningcorner.epaper.thehindu.com/privacy']),
+  record('cna', 'CNA', 'regional-news-network', 'reporting', 'regional', 'SG', 'regional', 'Mediacorp', ['https://www.channelnewsasia.com/about-us']),
+  record('dawn', 'Dawn', 'newspaper-newsroom', 'reporting', 'national', 'PK', 'local', null, ['https://www.dawn.com/nayapakistan/about/']),
+  record('npr', 'NPR', 'nonprofit-public-media', 'reporting', 'national', 'US', 'local', 'NPR', ['https://www.npr.org/about/']),
+  record('mercopress', 'Mercopress', 'news-agency', 'reporting', 'regional', 'UY', 'regional', 'MercoPress', ['https://en.mercopress.com/about-mercopress']),
+  record('abc-australia', 'ABC Australia', 'public-service-broadcaster', 'reporting', 'national', 'AU', 'local', 'Australian Broadcasting Corporation', ['https://www.abc.net.au/about/who-we-are']),
+  record('premium-times', 'Premium Times', 'digital-newsroom', 'reporting', 'national', 'NG', 'local', 'Premium Times Services Limited', ['https://www.premiumtimesng.com/about?tztc=1']),
+  record('the-east-african', 'The East African', 'regional-newsroom', 'reporting', 'regional', 'KE', 'regional', 'Nation Media Group', ['https://www.nationmedia.com/brands/the-east-african/', 'https://www.nationmedia.com/who-we-are/']),
+]);
+
+export function validateSourceProvenance(sources = SOURCES, provenance = SOURCE_PROVENANCE) {
+  const sourceIds = sources.map(source => slugifySourceName(source.name));
+  const provenanceIds = provenance.map(entry => entry.sourceId);
+  const duplicateIds = provenanceIds.filter((id, index) => provenanceIds.indexOf(id) !== index);
+  const missingSourceIds = sourceIds.filter(id => !provenanceIds.includes(id));
+  const orphanSourceIds = provenanceIds.filter(id => !sourceIds.includes(id));
+  const invalidEntries = provenance.filter(entry => !isValidEntry(entry)).map(entry => entry.sourceId);
+
+  return {
+    valid:
+      duplicateIds.length === 0 &&
+      missingSourceIds.length === 0 &&
+      orphanSourceIds.length === 0 &&
+      invalidEntries.length === 0,
+    duplicateIds: [...new Set(duplicateIds)].sort(),
+    missingSourceIds: missingSourceIds.sort(),
+    orphanSourceIds: orphanSourceIds.sort(),
+    invalidEntries: invalidEntries.sort(),
+  };
+}
+
+export function getProvenanceBySourceId(sourceId) {
+  return SOURCE_PROVENANCE.find(entry => entry.sourceId === sourceId) || null;
+}
+
+function record(sourceId, name, sourceClass, evidenceRole, geographicScope, primaryCountry, locality, ownershipOperator, evidenceUrls) {
+  const source = SOURCES.find(candidate => slugifySourceName(candidate.name) === sourceId);
+  return Object.freeze({
+    sourceId,
+    name,
+    sourceClass,
+    evidenceRole,
+    geographicScope,
+    primaryCountry,
+    locality,
+    sourceLanguages: source ? [source.lang] : [],
+    ownershipOperator,
+    evidenceUrls,
+    reviewedAt: PROVENANCE_REVIEW_DATE,
+  });
+}
+
+function isValidEntry(entry) {
+  return Boolean(
+    entry &&
+      entry.sourceId &&
+      entry.name &&
+      entry.sourceClass &&
+      entry.evidenceRole &&
+      entry.geographicScope &&
+      entry.locality &&
+      Array.isArray(entry.sourceLanguages) &&
+      entry.sourceLanguages.length > 0 &&
+      Array.isArray(entry.evidenceUrls) &&
+      entry.evidenceUrls.length > 0 &&
+      entry.evidenceUrls.every(url => /^https:\/\//.test(url)) &&
+      entry.reviewedAt
+  );
+}

--- a/functions/lib/news-source-provenance.js
+++ b/functions/lib/news-source-provenance.js
@@ -6,34 +6,251 @@ import { SOURCES, slugifySourceName } from '../api/news.js';
 export const PROVENANCE_REVIEW_DATE = '2026-09-03';
 
 export const SOURCE_PROVENANCE = Object.freeze([
-  record('bbc-world', 'BBC World', 'public-service-broadcaster', 'reporting', 'global', 'GB', 'global', 'British Broadcasting Corporation', ['https://www.bbc.com/aboutthebbc']),
-  record('ap', 'AP', 'news-agency', 'wire-service', 'global', 'US', 'global', 'The Associated Press', ['https://www.ap.org/about/']),
-  record('guardian', 'Guardian', 'newsroom', 'reporting', 'global', 'GB', 'global', 'Guardian News & Media; ultimate owner The Scott Trust Limited', ['https://www.theguardian.com/about']),
-  record('al-jazeera', 'Al Jazeera', 'international-news-network', 'reporting', 'global', 'QA', 'global', 'Al Jazeera Media Network', ['https://www.aljazeera.com/about-us']),
-  record('anadolu-agency', 'Anadolu Agency', 'news-agency', 'wire-service', 'global', 'TR', 'global', 'Anadolu Agency', ['https://www.aa.com.tr/en/newsacademy/p/about-us']),
-  record('dw', 'DW', 'public-service-broadcaster', 'reporting', 'global', 'DE', 'global', 'Deutsche Welle', ['https://www.dw.com/en/about-dw/s-30688']),
-  record('france-24', 'France 24', 'public-international-broadcaster', 'reporting', 'global', 'FR', 'global', 'France Médias Monde', ['https://www.francemediasmonde.com/en/our-media/france-24/']),
-  record('kyiv-independent', 'Kyiv Independent', 'digital-newsroom', 'reporting', 'national', 'UA', 'local', 'The Kyiv Independent', ['https://kyivindependent.com/about/']),
-  record('ukrinform', 'Ukrinform', 'national-news-agency', 'wire-service', 'national', 'UA', 'local', 'Ukrainian National News Agency Ukrinform', ['https://www.ukrinform.net/info/about_agency.html']),
-  record('nhk', 'NHK', 'public-service-broadcaster', 'reporting', 'national', 'JP', 'local', 'NHK (Japan Broadcasting Corporation)', ['https://www.nhk.or.jp/corporateinfo/']),
-  record('yonhap', 'Yonhap', 'national-news-agency', 'wire-service', 'national', 'KR', 'local', 'Yonhap News Agency', ['https://en.yna.co.kr/aboutus/index']),
-  record('the-hindu', 'The Hindu', 'newspaper-newsroom', 'reporting', 'national', 'IN', 'local', 'THG Publishing Private Limited / The Hindu Group', ['https://learningcorner.epaper.thehindu.com/privacy']),
-  record('cna', 'CNA', 'regional-news-network', 'reporting', 'regional', 'SG', 'regional', 'Mediacorp', ['https://www.channelnewsasia.com/about-us']),
-  record('dawn', 'Dawn', 'newspaper-newsroom', 'reporting', 'national', 'PK', 'local', null, ['https://www.dawn.com/nayapakistan/about/']),
-  record('npr', 'NPR', 'nonprofit-public-media', 'reporting', 'national', 'US', 'local', 'NPR', ['https://www.npr.org/about/']),
-  record('mercopress', 'Mercopress', 'news-agency', 'reporting', 'regional', 'UY', 'regional', 'MercoPress', ['https://en.mercopress.com/about-mercopress']),
-  record('abc-australia', 'ABC Australia', 'public-service-broadcaster', 'reporting', 'national', 'AU', 'local', 'Australian Broadcasting Corporation', ['https://www.abc.net.au/about/who-we-are']),
-  record('premium-times', 'Premium Times', 'digital-newsroom', 'reporting', 'national', 'NG', 'local', 'Premium Times Services Limited', ['https://www.premiumtimesng.com/about?tztc=1']),
-  record('the-east-african', 'The East African', 'regional-newsroom', 'reporting', 'regional', 'KE', 'regional', 'Nation Media Group', ['https://www.nationmedia.com/brands/the-east-african/', 'https://www.nationmedia.com/who-we-are/']),
+  record({
+    sourceId: 'bbc-world',
+    name: 'BBC World',
+    organizationName: 'British Broadcasting Corporation',
+    sourceClass: 'public-service-broadcaster',
+    evidenceRole: 'reporting',
+    geographicScope: 'global',
+    primaryCountry: 'GB',
+    locality: 'global',
+    ownershipOperator: 'British Broadcasting Corporation',
+    evidenceUrls: ['https://www.bbc.com/aboutthebbc'],
+  }),
+  record({
+    sourceId: 'ap',
+    name: 'AP',
+    organizationName: 'The Associated Press',
+    sourceClass: 'news-agency',
+    evidenceRole: 'wire-service',
+    geographicScope: 'global',
+    primaryCountry: 'US',
+    locality: 'global',
+    ownershipOperator: 'The Associated Press',
+    evidenceUrls: ['https://www.ap.org/about/'],
+  }),
+  record({
+    sourceId: 'guardian',
+    name: 'Guardian',
+    organizationName: 'Guardian News & Media',
+    sourceClass: 'newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'global',
+    primaryCountry: 'GB',
+    locality: 'global',
+    ownershipOperator: 'The Scott Trust Limited',
+    evidenceUrls: ['https://www.theguardian.com/about'],
+  }),
+  record({
+    sourceId: 'al-jazeera',
+    name: 'Al Jazeera',
+    organizationName: 'Al Jazeera Media Network',
+    sourceClass: 'international-news-network',
+    evidenceRole: 'reporting',
+    geographicScope: 'global',
+    primaryCountry: 'QA',
+    locality: 'global',
+    ownershipOperator: 'Al Jazeera Media Network',
+    evidenceUrls: ['https://www.aljazeera.com/about-us'],
+  }),
+  record({
+    sourceId: 'anadolu-agency',
+    name: 'Anadolu Agency',
+    organizationName: 'Anadolu Agency',
+    sourceClass: 'news-agency',
+    evidenceRole: 'wire-service',
+    geographicScope: 'global',
+    primaryCountry: 'TR',
+    locality: 'global',
+    ownershipOperator: 'Anadolu Agency',
+    evidenceUrls: ['https://www.aa.com.tr/en/newsacademy/p/about-us'],
+  }),
+  record({
+    sourceId: 'dw',
+    name: 'DW',
+    organizationName: 'Deutsche Welle',
+    sourceClass: 'public-service-broadcaster',
+    evidenceRole: 'reporting',
+    geographicScope: 'global',
+    primaryCountry: 'DE',
+    locality: 'global',
+    ownershipOperator: 'Deutsche Welle',
+    evidenceUrls: ['https://www.dw.com/en/about-dw/s-30688'],
+  }),
+  record({
+    sourceId: 'france-24',
+    name: 'France 24',
+    organizationName: 'France 24',
+    sourceClass: 'public-international-broadcaster',
+    evidenceRole: 'reporting',
+    geographicScope: 'global',
+    primaryCountry: 'FR',
+    locality: 'global',
+    ownershipOperator: 'France Medias Monde',
+    evidenceUrls: ['https://www.francemediasmonde.com/en/our-media/france-24/'],
+  }),
+  record({
+    sourceId: 'kyiv-independent',
+    name: 'Kyiv Independent',
+    organizationName: 'The Kyiv Independent',
+    sourceClass: 'digital-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'UA',
+    locality: 'local',
+    ownershipOperator: 'The Kyiv Independent',
+    evidenceUrls: ['https://kyivindependent.com/about/'],
+  }),
+  record({
+    sourceId: 'ukrinform',
+    name: 'Ukrinform',
+    organizationName: 'Ukrainian National News Agency Ukrinform',
+    sourceClass: 'national-news-agency',
+    evidenceRole: 'wire-service',
+    geographicScope: 'national',
+    primaryCountry: 'UA',
+    locality: 'local',
+    ownershipOperator: 'Ukrainian National News Agency Ukrinform',
+    evidenceUrls: ['https://www.ukrinform.net/info/about_agency.html'],
+  }),
+  record({
+    sourceId: 'nhk',
+    name: 'NHK',
+    organizationName: 'NHK (Japan Broadcasting Corporation)',
+    sourceClass: 'public-service-broadcaster',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'JP',
+    locality: 'local',
+    ownershipOperator: 'NHK (Japan Broadcasting Corporation)',
+    evidenceUrls: ['https://www.nhk.or.jp/corporateinfo/'],
+  }),
+  record({
+    sourceId: 'yonhap',
+    name: 'Yonhap',
+    organizationName: 'Yonhap News Agency',
+    sourceClass: 'national-news-agency',
+    evidenceRole: 'wire-service',
+    geographicScope: 'national',
+    primaryCountry: 'KR',
+    locality: 'local',
+    ownershipOperator: 'Yonhap News Agency',
+    evidenceUrls: ['https://en.yna.co.kr/aboutus/index'],
+  }),
+  record({
+    sourceId: 'the-hindu',
+    name: 'The Hindu',
+    organizationName: 'The Hindu',
+    sourceClass: 'newspaper-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'IN',
+    locality: 'local',
+    ownershipOperator: 'THG Publishing Private Limited',
+    evidenceUrls: ['https://learningcorner.epaper.thehindu.com/privacy'],
+  }),
+  record({
+    sourceId: 'cna',
+    name: 'CNA',
+    organizationName: 'CNA',
+    sourceClass: 'regional-news-network',
+    evidenceRole: 'reporting',
+    geographicScope: 'regional',
+    primaryCountry: 'SG',
+    locality: 'regional',
+    ownershipOperator: 'Mediacorp',
+    evidenceUrls: ['https://www.channelnewsasia.com/about-us'],
+  }),
+  record({
+    sourceId: 'dawn',
+    name: 'Dawn',
+    organizationName: 'Dawn',
+    sourceClass: 'newspaper-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'PK',
+    locality: 'local',
+    ownershipOperator: null,
+    evidenceUrls: ['https://www.dawn.com/nayapakistan/about/'],
+  }),
+  record({
+    sourceId: 'npr',
+    name: 'NPR',
+    organizationName: 'NPR',
+    sourceClass: 'nonprofit-public-media',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'US',
+    locality: 'local',
+    ownershipOperator: 'NPR',
+    evidenceUrls: ['https://www.npr.org/about/'],
+  }),
+  record({
+    sourceId: 'mercopress',
+    name: 'Mercopress',
+    organizationName: 'MercoPress',
+    sourceClass: 'news-agency',
+    evidenceRole: 'reporting',
+    geographicScope: 'regional',
+    primaryCountry: 'UY',
+    locality: 'regional',
+    ownershipOperator: 'MercoPress',
+    evidenceUrls: ['https://en.mercopress.com/about-mercopress'],
+  }),
+  record({
+    sourceId: 'abc-australia',
+    name: 'ABC Australia',
+    organizationName: 'Australian Broadcasting Corporation',
+    sourceClass: 'public-service-broadcaster',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'AU',
+    locality: 'local',
+    ownershipOperator: 'Australian Broadcasting Corporation',
+    evidenceUrls: ['https://www.abc.net.au/about/who-we-are'],
+  }),
+  record({
+    sourceId: 'premium-times',
+    name: 'Premium Times',
+    organizationName: 'Premium Times',
+    sourceClass: 'digital-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'national',
+    primaryCountry: 'NG',
+    locality: 'local',
+    ownershipOperator: 'Premium Times Services Limited',
+    evidenceUrls: ['https://www.premiumtimesng.com/about?tztc=1'],
+  }),
+  record({
+    sourceId: 'the-east-african',
+    name: 'The East African',
+    organizationName: 'The EastAfrican',
+    sourceClass: 'regional-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'regional',
+    primaryCountry: 'KE',
+    locality: 'regional',
+    ownershipOperator: 'Nation Media Group',
+    evidenceUrls: [
+      'https://www.nationmedia.com/brands/the-east-african/',
+      'https://www.nationmedia.com/who-we-are/',
+    ],
+  }),
 ]);
 
 export function validateSourceProvenance(sources = SOURCES, provenance = SOURCE_PROVENANCE) {
-  const sourceIds = sources.map(source => slugifySourceName(source.name));
+  const sourceById = new Map(
+    sources.map(source => [slugifySourceName(source.name), source])
+  );
+  const sourceIds = [...sourceById.keys()];
   const provenanceIds = provenance.map(entry => entry.sourceId);
   const duplicateIds = provenanceIds.filter((id, index) => provenanceIds.indexOf(id) !== index);
   const missingSourceIds = sourceIds.filter(id => !provenanceIds.includes(id));
-  const orphanSourceIds = provenanceIds.filter(id => !sourceIds.includes(id));
-  const invalidEntries = provenance.filter(entry => !isValidEntry(entry)).map(entry => entry.sourceId);
+  const orphanSourceIds = provenanceIds.filter(id => !sourceById.has(id));
+  const invalidEntries = provenance
+    .filter(entry => !isValidEntry(entry, sourceById.get(entry.sourceId)))
+    .map(entry => entry.sourceId);
 
   return {
     valid:
@@ -44,7 +261,7 @@ export function validateSourceProvenance(sources = SOURCES, provenance = SOURCE_
     duplicateIds: [...new Set(duplicateIds)].sort(),
     missingSourceIds: missingSourceIds.sort(),
     orphanSourceIds: orphanSourceIds.sort(),
-    invalidEntries: invalidEntries.sort(),
+    invalidEntries: [...new Set(invalidEntries)].sort(),
   };
 }
 
@@ -52,36 +269,29 @@ export function getProvenanceBySourceId(sourceId) {
   return SOURCE_PROVENANCE.find(entry => entry.sourceId === sourceId) || null;
 }
 
-function record(sourceId, name, sourceClass, evidenceRole, geographicScope, primaryCountry, locality, ownershipOperator, evidenceUrls) {
-  const source = SOURCES.find(candidate => slugifySourceName(candidate.name) === sourceId);
+function record(definition) {
+  const source = SOURCES.find(candidate => slugifySourceName(candidate.name) === definition.sourceId);
   return Object.freeze({
-    sourceId,
-    name,
-    organizationName: ownershipOperator || name,
-    sourceClass,
-    evidenceRole,
-    geographicScope,
-    primaryCountry,
-    locality,
+    ...definition,
     sourceLanguages: source ? [source.lang] : [],
-    ownershipOperator,
-    evidenceUrls,
     reviewedAt: PROVENANCE_REVIEW_DATE,
   });
 }
 
-function isValidEntry(entry) {
+function isValidEntry(entry, source) {
   return Boolean(
     entry &&
-      entry.sourceId &&
-      entry.name &&
+      source &&
+      entry.sourceId === slugifySourceName(source.name) &&
+      entry.name === source.name &&
       entry.organizationName &&
       entry.sourceClass &&
       entry.evidenceRole &&
       entry.geographicScope &&
       entry.locality &&
       Array.isArray(entry.sourceLanguages) &&
-      entry.sourceLanguages.length > 0 &&
+      entry.sourceLanguages.length === 1 &&
+      entry.sourceLanguages[0] === source.lang &&
       Array.isArray(entry.evidenceUrls) &&
       entry.evidenceUrls.length > 0 &&
       entry.evidenceUrls.every(url => /^https:\/\//.test(url)) &&

--- a/functions/lib/news-source-provenance.js
+++ b/functions/lib/news-source-provenance.js
@@ -171,8 +171,8 @@ export const SOURCE_PROVENANCE = Object.freeze([
     geographicScope: 'national',
     primaryCountry: 'PK',
     locality: 'local',
-    ownershipOperator: null,
-    evidenceUrls: ['https://www.dawn.com/nayapakistan/about/'],
+    ownershipOperator: 'Pakistan Herald Publications Private Limited',
+    evidenceUrls: ['https://www.dawn.com/news/1753517'],
   }),
   record({
     sourceId: 'npr',
@@ -240,9 +240,7 @@ export const SOURCE_PROVENANCE = Object.freeze([
 ]);
 
 export function validateSourceProvenance(sources = SOURCES, provenance = SOURCE_PROVENANCE) {
-  const sourceById = new Map(
-    sources.map(source => [slugifySourceName(source.name), source])
-  );
+  const sourceById = new Map(sources.map(source => [slugifySourceName(source.name), source]));
   const sourceIds = [...sourceById.keys()];
   const provenanceIds = provenance.map(entry => entry.sourceId);
   const duplicateIds = provenanceIds.filter((id, index) => provenanceIds.indexOf(id) !== index);

--- a/functions/lib/news-source-provenance.js
+++ b/functions/lib/news-source-provenance.js
@@ -9,7 +9,7 @@ export const SOURCE_PROVENANCE = Object.freeze([
   record('bbc-world', 'BBC World', 'public-service-broadcaster', 'reporting', 'global', 'GB', 'global', 'British Broadcasting Corporation', ['https://www.bbc.com/aboutthebbc']),
   record('ap', 'AP', 'news-agency', 'wire-service', 'global', 'US', 'global', 'The Associated Press', ['https://www.ap.org/about/']),
   record('guardian', 'Guardian', 'newsroom', 'reporting', 'global', 'GB', 'global', 'Guardian News & Media; ultimate owner The Scott Trust Limited', ['https://www.theguardian.com/about']),
-  record('al-jazeera', 'Al Jazeera', 'international-news-network', 'reporting', 'global', 'QA', 'global', 'Al Jazeera Media Network; funded in part by the Qatari government', ['https://www.aljazeera.com/about-us']),
+  record('al-jazeera', 'Al Jazeera', 'international-news-network', 'reporting', 'global', 'QA', 'global', 'Al Jazeera Media Network', ['https://www.aljazeera.com/about-us']),
   record('anadolu-agency', 'Anadolu Agency', 'news-agency', 'wire-service', 'global', 'TR', 'global', 'Anadolu Agency', ['https://www.aa.com.tr/en/newsacademy/p/about-us']),
   record('dw', 'DW', 'public-service-broadcaster', 'reporting', 'global', 'DE', 'global', 'Deutsche Welle', ['https://www.dw.com/en/about-dw/s-30688']),
   record('france-24', 'France 24', 'public-international-broadcaster', 'reporting', 'global', 'FR', 'global', 'France Médias Monde', ['https://www.francemediasmonde.com/en/our-media/france-24/']),
@@ -57,6 +57,7 @@ function record(sourceId, name, sourceClass, evidenceRole, geographicScope, prim
   return Object.freeze({
     sourceId,
     name,
+    organizationName: ownershipOperator || name,
     sourceClass,
     evidenceRole,
     geographicScope,
@@ -74,6 +75,7 @@ function isValidEntry(entry) {
     entry &&
       entry.sourceId &&
       entry.name &&
+      entry.organizationName &&
       entry.sourceClass &&
       entry.evidenceRole &&
       entry.geographicScope &&

--- a/functions/lib/news-source-provenance.js
+++ b/functions/lib/news-source-provenance.js
@@ -257,8 +257,8 @@ export function validateSourceProvenance(sources = SOURCES, provenance = SOURCE_
       orphanSourceIds.length === 0 &&
       invalidEntries.length === 0,
     duplicateIds: [...new Set(duplicateIds)].sort(),
-    missingSourceIds: missingSourceIds.sort(),
-    orphanSourceIds: orphanSourceIds.sort(),
+    missingSourceIds: [...new Set(missingSourceIds)].sort(),
+    orphanSourceIds: [...new Set(orphanSourceIds)].sort(),
     invalidEntries: [...new Set(invalidEntries)].sort(),
   };
 }

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -80,41 +80,47 @@ test('provenance registry maps exactly once to every canonical live source', () 
 
 test('provenance validation rejects missing, orphaned, duplicate, drifted, and invalid records', () => {
   const base = SOURCE_PROVENANCE.map(entry => ({ ...entry }));
+  const target = base[0];
+  const targetId = target.sourceId;
+
   const missing = validateSourceProvenance(SOURCES, base.slice(1));
   assert.equal(missing.valid, false);
-  assert.ok(missing.missingSourceIds.includes('bbc-world'));
+  assert.deepEqual(missing.missingSourceIds, [targetId]);
 
+  const orphanEntry = { ...target, sourceId: 'not-a-live-source' };
   const orphan = validateSourceProvenance(SOURCES, [
     ...base,
-    { ...base[0], sourceId: 'not-a-live-source' },
+    orphanEntry,
+    { ...orphanEntry },
   ]);
   assert.equal(orphan.valid, false);
-  assert.ok(orphan.orphanSourceIds.includes('not-a-live-source'));
+  assert.deepEqual(orphan.orphanSourceIds, ['not-a-live-source']);
 
-  const duplicate = validateSourceProvenance(SOURCES, [...base, { ...base[0] }]);
+  const duplicate = validateSourceProvenance(SOURCES, [...base, { ...target }]);
   assert.equal(duplicate.valid, false);
-  assert.ok(duplicate.duplicateIds.includes('bbc-world'));
+  assert.ok(duplicate.duplicateIds.includes(targetId));
 
   const invalid = validateSourceProvenance(SOURCES, [
-    { ...base[0], evidenceUrls: [] },
+    { ...target, evidenceUrls: [] },
     ...base.slice(1),
   ]);
   assert.equal(invalid.valid, false);
-  assert.ok(invalid.invalidEntries.includes('bbc-world'));
+  assert.ok(invalid.invalidEntries.includes(targetId));
 
   const nameDrift = validateSourceProvenance(SOURCES, [
-    { ...base[0], name: 'BBC World Renamed' },
+    { ...target, name: `${target.name} Renamed` },
     ...base.slice(1),
   ]);
   assert.equal(nameDrift.valid, false);
-  assert.ok(nameDrift.invalidEntries.includes('bbc-world'));
+  assert.ok(nameDrift.invalidEntries.includes(targetId));
 
+  const alternateLanguage = target.sourceLanguages[0] === 'fr' ? 'en' : 'fr';
   const languageDrift = validateSourceProvenance(SOURCES, [
-    { ...base[0], sourceLanguages: ['fr'] },
+    { ...target, sourceLanguages: [alternateLanguage] },
     ...base.slice(1),
   ]);
   assert.equal(languageDrift.valid, false);
-  assert.ok(languageDrift.invalidEntries.includes('bbc-world'));
+  assert.ok(languageDrift.invalidEntries.includes(targetId));
 });
 
 test('coverage inventory is deterministic and enriched from reviewed provenance', () => {

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -10,6 +10,7 @@ const fixtureFunctions = join(fixtureRoot, 'functions');
 const fixtureNews = join(fixtureFunctions, 'api', 'news.js');
 const fixtureCoverageApi = join(fixtureFunctions, 'api', 'news', 'coverage.js');
 const fixtureCoverageLib = join(fixtureFunctions, 'lib', 'news-coverage.js');
+const fixtureProvenanceLib = join(fixtureFunctions, 'lib', 'news-source-provenance.js');
 
 mkdirSync(dirname(fixtureCoverageApi), { recursive: true });
 mkdirSync(dirname(fixtureCoverageLib), { recursive: true });
@@ -23,12 +24,18 @@ copyFileSync(
   fileURLToPath(new URL('../functions/lib/news-coverage.js', import.meta.url)),
   fixtureCoverageLib
 );
+copyFileSync(
+  fileURLToPath(new URL('../functions/lib/news-source-provenance.js', import.meta.url)),
+  fixtureProvenanceLib
+);
 
 const newsModule = await import(pathToFileURL(fixtureNews).href);
+const provenanceModule = await import(pathToFileURL(fixtureProvenanceLib).href);
 const coverageModule = await import(pathToFileURL(fixtureCoverageLib).href);
 const coverageApiModule = await import(pathToFileURL(fixtureCoverageApi).href);
 
 const { SOURCES, SOURCE_FINGERPRINT } = newsModule;
+const { SOURCE_PROVENANCE, validateSourceProvenance } = provenanceModule;
 const { buildCoverageInventory } = coverageModule;
 const { onRequestGet: getCoverage } = coverageApiModule;
 
@@ -38,23 +45,71 @@ function request(path = '/api/news/coverage') {
   });
 }
 
-test('coverage inventory is deterministic and derived from the canonical source contract', () => {
-  const first = buildCoverageInventory(SOURCES);
-  const second = buildCoverageInventory(SOURCES.map(source => ({ ...source })));
+test('provenance registry maps exactly once to every canonical live source', () => {
+  const validation = validateSourceProvenance(SOURCES, SOURCE_PROVENANCE);
+
+  assert.equal(validation.valid, true);
+  assert.equal(SOURCE_PROVENANCE.length, SOURCES.length);
+  assert.equal(SOURCE_PROVENANCE.length, 19);
+  assert.deepEqual(validation.duplicateIds, []);
+  assert.deepEqual(validation.missingSourceIds, []);
+  assert.deepEqual(validation.orphanSourceIds, []);
+  assert.deepEqual(validation.invalidEntries, []);
+  assert.ok(SOURCE_PROVENANCE.every(entry => entry.evidenceUrls.length > 0));
+});
+
+test('provenance validation rejects missing, orphaned, duplicate, and structurally invalid records', () => {
+  const base = SOURCE_PROVENANCE.map(entry => ({ ...entry }));
+  const missing = validateSourceProvenance(SOURCES, base.slice(1));
+  assert.equal(missing.valid, false);
+  assert.ok(missing.missingSourceIds.includes('bbc-world'));
+
+  const orphan = validateSourceProvenance(SOURCES, [
+    ...base,
+    { ...base[0], sourceId: 'not-a-live-source' },
+  ]);
+  assert.equal(orphan.valid, false);
+  assert.ok(orphan.orphanSourceIds.includes('not-a-live-source'));
+
+  const duplicate = validateSourceProvenance(SOURCES, [...base, { ...base[0] }]);
+  assert.equal(duplicate.valid, false);
+  assert.ok(duplicate.duplicateIds.includes('bbc-world'));
+
+  const invalid = validateSourceProvenance(SOURCES, [
+    { ...base[0], evidenceUrls: [] },
+    ...base.slice(1),
+  ]);
+  assert.equal(invalid.valid, false);
+  assert.ok(invalid.invalidEntries.includes('bbc-world'));
+});
+
+test('coverage inventory is deterministic and enriched from reviewed provenance', () => {
+  const first = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE);
+  const second = buildCoverageInventory(
+    SOURCES.map(source => ({ ...source })),
+    SOURCE_PROVENANCE.map(entry => ({ ...entry }))
+  );
 
   assert.deepEqual(first, second);
-  assert.equal(first.totalSources, SOURCES.length);
   assert.equal(first.totalSources, 19);
   assert.equal(first.totalRegions, 7);
   assert.equal(first.totalLanguages, 2);
+  assert.equal(first.provenance.valid, true);
+  assert.equal(first.provenance.reviewedSources, 19);
   assert.equal(first.nonEnglishSources.length, 1);
   assert.ok(first.nonEnglishSources.includes('nhk'));
+  assert.ok(first.sourceClasses.some(group => group.sourceClass === 'news-agency'));
+  assert.ok(first.geographicScopes.some(group => group.geographicScope === 'national'));
+  assert.ok(first.sourceOriginCountries.some(group => group.country === 'UA'));
 });
 
-test('coverage inventory surfaces current regional redundancy and source-language blind spots', () => {
-  const inventory = buildCoverageInventory(SOURCES);
+test('coverage inventory surfaces current evidence, locality, redundancy, and language blind spots', () => {
+  const inventory = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE);
   const gapIds = new Set(inventory.gaps.map(gap => gap.id));
 
+  assert.equal(inventory.primarySourceInputs, 0);
+  assert.ok(gapIds.has('evidence-role:primary-source-inputs'));
+  assert.ok(gapIds.has('geographic-scope:subnational'));
   assert.ok(gapIds.has('regional-redundancy:pacific'));
   assert.ok(gapIds.has('portfolio-language-concentration:en'));
   assert.ok(gapIds.has('source-language-diversity:africa'));
@@ -62,24 +117,39 @@ test('coverage inventory surfaces current regional redundancy and source-languag
   assert.ok(gapIds.has('source-language-diversity:europe'));
   assert.ok(gapIds.has('source-language-diversity:middle-east'));
   assert.ok(gapIds.has('source-language-diversity:pacific'));
+  assert.ok(inventory.provenance.unknownOwnershipOperatorSourceIds.includes('dawn'));
 });
 
-test('coverage gap logic responds to stronger regional and language diversity', () => {
+test('coverage gap logic responds to stronger regional, language, primary-source, and local diversity', () => {
   const sample = [
     { name: 'A', url: 'https://a.example/rss', region: 'alpha', lang: 'en' },
     { name: 'B', url: 'https://b.example/rss', region: 'alpha', lang: 'fr' },
     { name: 'C', url: 'https://c.example/rss', region: 'beta', lang: 'es' },
     { name: 'D', url: 'https://d.example/rss', region: 'beta', lang: 'pt' },
   ];
-  const inventory = buildCoverageInventory(sample);
+  const sampleProvenance = sample.map((source, index) => ({
+    sourceId: source.name.toLowerCase(),
+    name: source.name,
+    sourceClass: index === 0 ? 'institution' : 'newsroom',
+    evidenceRole: index === 0 ? 'primary-source' : 'reporting',
+    geographicScope: index === 0 ? 'subnational' : 'national',
+    primaryCountry: ['AA', 'BB', 'CC', 'DD'][index],
+    locality: 'local',
+    sourceLanguages: [source.lang],
+    ownershipOperator: null,
+    evidenceUrls: [`https://${source.name.toLowerCase()}.example/about`],
+    reviewedAt: '2026-09-03',
+  }));
+  const inventory = buildCoverageInventory(sample, sampleProvenance);
 
   assert.equal(inventory.gaps.length, 0);
   assert.equal(inventory.totalRegions, 2);
   assert.equal(inventory.totalLanguages, 4);
   assert.equal(inventory.englishSourceShare, 0.25);
+  assert.equal(inventory.primarySourceInputs, 1);
 });
 
-test('/api/news/coverage exposes the current source fingerprint and inventory', async () => {
+test('/api/news/coverage exposes source fingerprint, provenance integrity, and actionable inventory', async () => {
   const response = await getCoverage({ request: request() });
   const json = await response.json();
 
@@ -87,7 +157,11 @@ test('/api/news/coverage exposes the current source fingerprint and inventory', 
   assert.equal(json.sourceFingerprint, SOURCE_FINGERPRINT);
   assert.equal(json.totalSources, SOURCES.length);
   assert.equal(json.totalRegions, 7);
-  assert.ok(Array.isArray(json.gaps));
-  assert.ok(json.gaps.length > 0);
+  assert.equal(json.provenance.valid, true);
+  assert.equal(json.provenance.reviewedSources, 19);
+  assert.ok(Array.isArray(json.sourceClasses));
+  assert.ok(Array.isArray(json.evidenceRoles));
+  assert.ok(Array.isArray(json.sourceOriginCountries));
+  assert.ok(json.gaps.some(gap => gap.id === 'evidence-role:primary-source-inputs'));
   assert.match(json.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -64,9 +64,21 @@ test('provenance registry maps exactly once to every canonical live source', () 
   assert.deepEqual(validation.invalidEntries, []);
   assert.ok(SOURCE_PROVENANCE.every(entry => entry.evidenceUrls.length > 0));
   assert.ok(SOURCE_PROVENANCE.every(entry => entry.organizationName));
+
+  const guardian = SOURCE_PROVENANCE.find(entry => entry.sourceId === 'guardian');
+  assert.equal(guardian.organizationName, 'Guardian News & Media');
+  assert.equal(guardian.ownershipOperator, 'The Scott Trust Limited');
+
+  const cna = SOURCE_PROVENANCE.find(entry => entry.sourceId === 'cna');
+  assert.equal(cna.organizationName, 'CNA');
+  assert.equal(cna.ownershipOperator, 'Mediacorp');
+
+  const dawn = SOURCE_PROVENANCE.find(entry => entry.sourceId === 'dawn');
+  assert.equal(dawn.organizationName, 'Dawn');
+  assert.equal(dawn.ownershipOperator, 'Pakistan Herald Publications Private Limited');
 });
 
-test('provenance validation rejects missing, orphaned, duplicate, and structurally invalid records', () => {
+test('provenance validation rejects missing, orphaned, duplicate, drifted, and invalid records', () => {
   const base = SOURCE_PROVENANCE.map(entry => ({ ...entry }));
   const missing = validateSourceProvenance(SOURCES, base.slice(1));
   assert.equal(missing.valid, false);
@@ -89,6 +101,20 @@ test('provenance validation rejects missing, orphaned, duplicate, and structural
   ]);
   assert.equal(invalid.valid, false);
   assert.ok(invalid.invalidEntries.includes('bbc-world'));
+
+  const nameDrift = validateSourceProvenance(SOURCES, [
+    { ...base[0], name: 'BBC World Renamed' },
+    ...base.slice(1),
+  ]);
+  assert.equal(nameDrift.valid, false);
+  assert.ok(nameDrift.invalidEntries.includes('bbc-world'));
+
+  const languageDrift = validateSourceProvenance(SOURCES, [
+    { ...base[0], sourceLanguages: ['fr'] },
+    ...base.slice(1),
+  ]);
+  assert.equal(languageDrift.valid, false);
+  assert.ok(languageDrift.invalidEntries.includes('bbc-world'));
 });
 
 test('coverage inventory is deterministic and enriched from reviewed provenance', () => {
@@ -104,6 +130,7 @@ test('coverage inventory is deterministic and enriched from reviewed provenance'
   assert.equal(first.totalLanguages, 2);
   assert.equal(first.provenance.valid, true);
   assert.equal(first.provenance.reviewedSources, 19);
+  assert.deepEqual(first.provenance.unknownOwnershipOperatorSourceIds, []);
   assert.equal(first.nonEnglishSources.length, 1);
   assert.ok(first.nonEnglishSources.includes('nhk'));
   assert.ok(first.sourceClasses.some(group => group.sourceClass === 'news-agency'));
@@ -125,7 +152,6 @@ test('coverage inventory surfaces current evidence, locality, redundancy, and la
   assert.ok(gapIds.has('source-language-diversity:europe'));
   assert.ok(gapIds.has('source-language-diversity:middle-east'));
   assert.ok(gapIds.has('source-language-diversity:pacific'));
-  assert.ok(inventory.provenance.unknownOwnershipOperatorSourceIds.includes('dawn'));
 });
 
 test('coverage gap logic responds to stronger regional, language, primary-source, and local diversity', () => {
@@ -145,7 +171,7 @@ test('coverage gap logic responds to stronger regional, language, primary-source
     primaryCountry: ['AA', 'BB', 'CC', 'DD'][index],
     locality: 'local',
     sourceLanguages: [source.lang],
-    ownershipOperator: null,
+    ownershipOperator: `${source.name} Organization`,
     evidenceUrls: [`https://${source.name.toLowerCase()}.example/about`],
     reviewedAt: '2026-09-03',
   }));

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -9,6 +9,7 @@ const fixtureRoot = mkdtempSync(join(tmpdir(), 'globaldeets-coverage-'));
 const fixtureFunctions = join(fixtureRoot, 'functions');
 const fixtureNews = join(fixtureFunctions, 'api', 'news.js');
 const fixtureCoverageApi = join(fixtureFunctions, 'api', 'news', 'coverage.js');
+const fixtureSourcesApi = join(fixtureFunctions, 'api', 'news', 'sources.js');
 const fixtureCoverageLib = join(fixtureFunctions, 'lib', 'news-coverage.js');
 const fixtureProvenanceLib = join(fixtureFunctions, 'lib', 'news-source-provenance.js');
 
@@ -19,6 +20,10 @@ copyFileSync(fileURLToPath(new URL('../functions/api/news.js', import.meta.url))
 copyFileSync(
   fileURLToPath(new URL('../functions/api/news/coverage.js', import.meta.url)),
   fixtureCoverageApi
+);
+copyFileSync(
+  fileURLToPath(new URL('../functions/api/news/sources.js', import.meta.url)),
+  fixtureSourcesApi
 );
 copyFileSync(
   fileURLToPath(new URL('../functions/lib/news-coverage.js', import.meta.url)),
@@ -33,11 +38,13 @@ const newsModule = await import(pathToFileURL(fixtureNews).href);
 const provenanceModule = await import(pathToFileURL(fixtureProvenanceLib).href);
 const coverageModule = await import(pathToFileURL(fixtureCoverageLib).href);
 const coverageApiModule = await import(pathToFileURL(fixtureCoverageApi).href);
+const sourcesApiModule = await import(pathToFileURL(fixtureSourcesApi).href);
 
 const { SOURCES, SOURCE_FINGERPRINT } = newsModule;
 const { SOURCE_PROVENANCE, validateSourceProvenance } = provenanceModule;
 const { buildCoverageInventory } = coverageModule;
 const { onRequestGet: getCoverage } = coverageApiModule;
+const { onRequestGet: getSources } = sourcesApiModule;
 
 function request(path = '/api/news/coverage') {
   return new Request(`https://globaldeets.com${path}`, {
@@ -56,6 +63,7 @@ test('provenance registry maps exactly once to every canonical live source', () 
   assert.deepEqual(validation.orphanSourceIds, []);
   assert.deepEqual(validation.invalidEntries, []);
   assert.ok(SOURCE_PROVENANCE.every(entry => entry.evidenceUrls.length > 0));
+  assert.ok(SOURCE_PROVENANCE.every(entry => entry.organizationName));
 });
 
 test('provenance validation rejects missing, orphaned, duplicate, and structurally invalid records', () => {
@@ -130,6 +138,7 @@ test('coverage gap logic responds to stronger regional, language, primary-source
   const sampleProvenance = sample.map((source, index) => ({
     sourceId: source.name.toLowerCase(),
     name: source.name,
+    organizationName: `${source.name} Organization`,
     sourceClass: index === 0 ? 'institution' : 'newsroom',
     evidenceRole: index === 0 ? 'primary-source' : 'reporting',
     geographicScope: index === 0 ? 'subnational' : 'national',
@@ -164,4 +173,17 @@ test('/api/news/coverage exposes source fingerprint, provenance integrity, and a
   assert.ok(Array.isArray(json.sourceOriginCountries));
   assert.ok(json.gaps.some(gap => gap.id === 'evidence-role:primary-source-inputs'));
   assert.match(json.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('/api/news/sources exposes the reviewed registry and its evidence links', async () => {
+  const response = await getSources({ request: request('/api/news/sources') });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.sourceFingerprint, SOURCE_FINGERPRINT);
+  assert.equal(json.validation.valid, true);
+  assert.equal(json.totalSources, SOURCES.length);
+  assert.equal(json.sources.length, 19);
+  assert.ok(json.sources.every(source => source.organizationName));
+  assert.ok(json.sources.every(source => source.evidenceUrls.every(url => url.startsWith('https://'))));
 });

--- a/tools/verify-intelligence-prod.js
+++ b/tools/verify-intelligence-prod.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+function getArgValue(name) {
+  const arg = process.argv.find(value => value.startsWith(name));
+  return arg ? arg.slice(name.length) : null;
+}
+
+const BASE = (getArgValue('--base=') || 'https://globaldeets.com').replace(/\/$/, '');
+const TIMEOUT_MS = 12_000;
+
+async function fetchJson(path) {
+  const response = await fetch(`${BASE}${path}`, {
+    headers: {
+      'User-Agent': 'GlobalDeets-IntelligenceVerifier/1.0',
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+    },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+
+  if (response.status !== 200) {
+    throw new Error(`${path} returned HTTP ${response.status}`);
+  }
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('application/json')) {
+    throw new Error(`${path} returned unexpected content-type ${contentType}`);
+  }
+
+  return response.json();
+}
+
+function requireCondition(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+(async () => {
+  const [coverage, sources] = await Promise.all([
+    fetchJson('/api/news/coverage'),
+    fetchJson('/api/news/sources'),
+  ]);
+
+  requireCondition(typeof coverage.sourceFingerprint === 'string', 'coverage fingerprint missing');
+  requireCondition(typeof sources.sourceFingerprint === 'string', 'sources fingerprint missing');
+  requireCondition(
+    coverage.sourceFingerprint === sources.sourceFingerprint,
+    'coverage and source provenance fingerprints disagree'
+  );
+  requireCondition(coverage.provenance?.valid === true, 'coverage provenance validation failed');
+  requireCondition(sources.validation?.valid === true, 'source registry validation failed');
+  requireCondition(Number.isInteger(coverage.totalSources), 'coverage totalSources missing');
+  requireCondition(Number.isInteger(sources.totalSources), 'sources totalSources missing');
+  requireCondition(Array.isArray(sources.sources), 'sources array missing');
+  requireCondition(Array.isArray(coverage.gaps), 'coverage gaps array missing');
+  requireCondition(
+    coverage.totalSources === sources.totalSources && sources.totalSources === sources.sources.length,
+    'source counts disagree across intelligence APIs'
+  );
+  requireCondition(
+    sources.sources.every(source =>
+      Array.isArray(source.evidenceUrls) && source.evidenceUrls.length > 0
+    ),
+    'one or more source provenance records lack evidence URLs'
+  );
+
+  console.log(
+    `Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} active coverage gaps, fingerprint ${coverage.sourceFingerprint}`
+  );
+})().catch(error => {
+  console.error(`Intelligence API verification failed: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Phase II — Reviewed source provenance

Builds the evidence-backed provenance layer on top of merged GD-012.

### What changes
- Adds exactly one reviewed provenance record for each of the 19 canonical live sources.
- Separates publisher/organization identity from ownership/operator identity.
- Records source class, evidence role, geographic scope, primary country where applicable, locality, live feed language, evidence URLs, and review date.
- Adds strict validation for missing, orphaned, duplicate, structurally invalid, source-name-drifted, or feed-language-drifted provenance records.
- Exposes `GET /api/news/sources` so provenance and supporting links are inspectable.
- Enriches `GET /api/news/coverage` with source classes, evidence roles, geographic scopes, source-origin countries, and provenance integrity.
- Explicitly distinguishes the legacy `SOURCES.region` routing bucket from reviewed publisher geographic scope.
- Surfaces two new structural gaps: zero primary-source institutional inputs in the live news/evidence contract and zero subnational/local sources.
- Adds CI syntax and contract coverage for the new modules and API.
- Adds a focused post-convergence production verifier that requires coverage/source fingerprint agreement, valid registries, matching source counts, and evidence URLs before the deploy run can certify the release.

### Safety / epistemic boundary
This PR does not create political-bias, truth, factuality, ideological, or synthetic reliability scores. Unknown facts remain explicit. Provenance metadata does not alter the stabilized feed-cache/source fingerprint unless the live feed definition itself changes.

### Evidence review
The registry uses publisher/operator material where practical, including AP, Guardian, Al Jazeera, France Medias Monde, Kyiv Independent, Ukrinform, CNA/Mediacorp, Dawn/Pakistan Herald Publications, NPR, ABC, Premium Times, Nation Media Group, and MercoPress. Evidence URLs were manually reviewed during this tranche; external sites are not made a production-deploy dependency.

### Follow-on discoveries
- The existing Knowledge catalog already contains many institutional/research resources; GD-015 will review/reuse them instead of creating a duplicate primary-source directory.
- Source expansion now has a separate admission/usage-rights gate (#20) after candidate research showed that technically valid first-party feeds can still have restrictive or item-dependent reuse terms.

Closes #13 after merge.