### PR TITLE
GD-014: Add canonical entity and event identity model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,15 @@ jobs:
 
       - name: Verify GA4 tag present
         run: |
-          echo "Checking for GA4..."
           grep -q "G-WM6Q66W9W0" index.html || (echo "MISSING: GA4 tag" && exit 1)
-          echo "GA4 tag confirmed."
 
       - name: Verify HSTS header present
         run: |
-          echo "Checking for HSTS..."
           grep -q "Strict-Transport-Security" _headers || (echo "MISSING: HSTS in _headers" && exit 1)
-          echo "HSTS confirmed."
 
       - name: Verify error monitoring present
         run: |
-          echo "Checking for onerror..."
           grep -q "window.onerror" index.html || (echo "MISSING: window.onerror" && exit 1)
-          echo "Error monitoring confirmed."
 
       - name: JavaScript syntax check
         run: |
@@ -55,10 +49,14 @@ jobs:
           node --check functions/api/news/health.js
           node --check functions/api/news/coverage.js
           node --check functions/api/news/sources.js
+          node --check functions/api/intelligence/schema.js
           node --check functions/lib/news-coverage.js
           node --check functions/lib/news-source-provenance.js
+          node --check functions/lib/intelligence-model.js
+          node --check functions/lib/m49-place-seed.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
+          node --check tests/intelligence-model.test.mjs
 
       - name: Lint JavaScript
         run: npm run lint

--- a/docs/phase2-entity-event-model.md
+++ b/docs/phase2-entity-event-model.md
@@ -1,0 +1,92 @@
+# Phase II — Canonical Entity and Event Identity
+
+GD-014 creates the durable identity layer required for place-aware intelligence, claims/evidence, and later story dossiers.
+
+## Governing rule
+
+Similarity is not identity.
+
+GlobalDeets does not merge people, organizations, places, or events merely because names or headlines look alike. Durable records require an explicit identity key or a reviewed standard identifier. Ambiguity remains visible until evidence resolves it.
+
+## Entities
+
+The initial model supports:
+
+- person
+- organization
+- government/public body
+- company
+- place
+- multilateral body
+
+Every entity has a stable ID derived from an explicit identity key. Display names can change without changing identity. Aliases are optional, but every alias must carry at least one evidence reference; raw unreferenced alias strings are rejected.
+
+Alias lookup returns one of three states:
+
+- `matched`
+- `ambiguous`
+- `no-match`
+
+An ambiguous alias never silently selects a winner.
+
+## Places and UN M49
+
+Country/area identity uses the United Nations Statistics Division M49 standard where available. M49 identity retains the M49 numeric code plus ISO alpha-2 and alpha-3 identifiers.
+
+The initial committed seed is deliberately **partial**: it contains the countries represented by the current live-news source-origin provenance records. It does not claim to be a complete world-country dataset.
+
+The production runtime does not fetch M49 data live. M49 is source material for a committed, reviewable snapshot/import process so identity cannot change unexpectedly because an upstream page changes.
+
+UN region/subregion classifications are retained as statistical metadata only. They must not be treated as GlobalDeets positions on sovereignty, boundaries, political status, or legal affiliation.
+
+Capitals, languages, coordinates, culture links, political/legal context, emergency resources, and similar facts are attributes, not identity. They require separate provenance.
+
+## Events
+
+Events require an explicit stable `eventKey`. The event ID is derived from that key, not from title/headline prose.
+
+Therefore:
+
+- changing a title does not create a new event;
+- identical titles do not merge distinct events;
+- article relationships can be many-to-many;
+- linked people/organizations/places remain explicit;
+- unresolved facts are preserved in an `unknowns` collection;
+- event status describes record state (`developing`, `confirmed`, `closed`, `disputed`) rather than a truth score.
+
+## Graph integrity
+
+Validation detects:
+
+- duplicate entity IDs
+- duplicate event IDs
+- orphan entity references
+- orphan place references
+- non-place entities used as place references
+- structurally invalid entity/event identities
+
+History and contradictions will be modeled in later claim/evidence gates rather than overwritten by this identity layer.
+
+## Legacy globe migration
+
+The existing webcam/worldmap catalog remains authoritative for its current IDs, location strings, coordinates, timezones, stream/source URLs, and other operational metadata. GD-014 establishes the place identity boundary but does not silently reinterpret free-text webcam geography.
+
+A later reviewed migration may add `placeEntityId` links. Ambiguous locations must remain unlinked until reviewed.
+
+## Public schema
+
+`GET /api/intelligence/schema` exposes the model version, entity/event enums, identity rules, and place-seed metadata. It intentionally does not expose the partial seed as if it were a complete country directory.
+
+## Explicit non-goals
+
+GD-014 does not add:
+
+- LLM entity extraction
+- fuzzy automatic identity merges
+- AI-written story summaries
+- truth/reliability scores
+- claim resolution
+- automatic event clustering from headline similarity
+- unreviewed capital/language/culture enrichment
+
+The next gate, GD-015, can build claims and primary evidence on top of these durable identities without having to reinvent who/what/where each record refers to.

--- a/functions/api/intelligence/schema.js
+++ b/functions/api/intelligence/schema.js
@@ -1,0 +1,53 @@
+// Cloudflare Pages Function - GET /api/intelligence/schema
+import {
+  ENTITY_TYPES,
+  EVENT_STATUSES,
+  INTELLIGENCE_MODEL_VERSION,
+} from '../../lib/intelligence-model.js';
+import { M49_PLACE_SEED, M49_SEED_METADATA } from '../../lib/m49-place-seed.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+function headers(request) {
+  const origin = request?.headers?.get('Origin');
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=3600',
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: headers(request) });
+}
+
+export async function onRequestGet({ request }) {
+  return new Response(
+    JSON.stringify({
+      modelVersion: INTELLIGENCE_MODEL_VERSION,
+      entityTypes: ENTITY_TYPES,
+      eventStatuses: EVENT_STATUSES,
+      identityRules: {
+        explicitEntityIdentityKey: true,
+        explicitEventKey: true,
+        automaticNameMerge: false,
+        ambiguousAliasResolution: 'ambiguous',
+        aliasesRequireEvidence: true,
+        placeIdentityStandard: 'UN M49',
+      },
+      placeSeed: {
+        ...M49_SEED_METADATA,
+        count: M49_PLACE_SEED.length,
+      },
+    }),
+    { headers: headers(request) }
+  );
+}

--- a/functions/lib/intelligence-model.js
+++ b/functions/lib/intelligence-model.js
@@ -1,78 +1,51 @@
-// Deterministic intelligence primitives for GlobalDeets.
-// Identity is explicit. Similar names, headlines, or aliases never create an automatic merge.
-
+// Deterministic intelligence primitives. Identity is explicit; fuzzy similarity never merges records.
 export const INTELLIGENCE_MODEL_VERSION = '2026-09-03.1';
-
 export const ENTITY_TYPES = Object.freeze([
-  'person',
-  'organization',
-  'government-public-body',
-  'company',
-  'place',
-  'multilateral-body',
+  'person', 'organization', 'government-public-body', 'company', 'place', 'multilateral-body',
 ]);
-
-export const EVENT_STATUSES = Object.freeze([
-  'developing',
-  'confirmed',
-  'closed',
-  'disputed',
-]);
-
+export const EVENT_STATUSES = Object.freeze(['developing', 'confirmed', 'closed', 'disputed']);
 const ENTITY_TYPE_SET = new Set(ENTITY_TYPES);
 const EVENT_STATUS_SET = new Set(EVENT_STATUSES);
 
 export function createEntity(definition) {
-  requireObject(definition, 'entity definition');
-  requireNonEmptyString(definition.identityKey, 'entity.identityKey');
-  requireNonEmptyString(definition.displayName, 'entity.displayName');
-  requireOneOf(definition.type, ENTITY_TYPE_SET, 'entity.type');
-
-  const aliases = normalizeAliasRecords(definition.aliases || []);
-  const evidenceRefs = normalizeStringList(definition.evidenceRefs || []);
-  const attributes = clonePlainValue(definition.attributes ?? {});
-
+  object(definition, 'entity definition');
+  text(definition.identityKey, 'entity.identityKey');
+  text(definition.displayName, 'entity.displayName');
+  oneOf(definition.type, ENTITY_TYPE_SET, 'entity.type');
   return Object.freeze({
     id: makeStableEntityId(definition.type, definition.identityKey),
     identityKey: definition.identityKey,
     type: definition.type,
     displayName: definition.displayName,
-    aliases,
-    evidenceRefs,
+    aliases: aliasRecords(definition.aliases || []),
+    evidenceRefs: stringList(definition.evidenceRefs || []),
     countryEntityId: definition.countryEntityId || null,
-    standardIds: normalizeStandardIds(definition.standardIds || null),
-    attributes,
+    standardIds: standardIds(definition.standardIds || null),
+    attributes: clone(definition.attributes ?? {}),
     createdAt: definition.createdAt || null,
     reviewedAt: definition.reviewedAt || null,
   });
 }
 
 export function createM49PlaceEntity(definition) {
-  requireObject(definition, 'M49 place definition');
-  const m49 = normalizeM49(definition.m49);
-  const isoAlpha2 = normalizeIso(definition.isoAlpha2, 2, 'place.isoAlpha2');
-  const isoAlpha3 = normalizeIso(definition.isoAlpha3, 3, 'place.isoAlpha3');
-
+  object(definition, 'M49 place definition');
+  const m49 = m49Code(definition.m49);
+  const isoAlpha2 = isoCode(definition.isoAlpha2, 2, 'place.isoAlpha2');
+  const isoAlpha3 = isoCode(definition.isoAlpha3, 3, 'place.isoAlpha3');
   return createEntity({
     ...definition,
     identityKey: `m49:${m49}`,
     type: 'place',
-    standardIds: {
-      ...(definition.standardIds || {}),
-      m49,
-      isoAlpha2,
-      isoAlpha3,
-    },
+    standardIds: { ...(definition.standardIds || {}), m49, isoAlpha2, isoAlpha3 },
   });
 }
 
 export function createEvent(definition) {
-  requireObject(definition, 'event definition');
-  requireNonEmptyString(definition.eventKey, 'event.eventKey');
-  requireNonEmptyString(definition.title, 'event.title');
-  requireNonEmptyString(definition.eventType, 'event.eventType');
-  requireOneOf(definition.status, EVENT_STATUS_SET, 'event.status');
-
+  object(definition, 'event definition');
+  text(definition.eventKey, 'event.eventKey');
+  text(definition.title, 'event.title');
+  text(definition.eventType, 'event.eventType');
+  oneOf(definition.status, EVENT_STATUS_SET, 'event.status');
   return Object.freeze({
     id: makeStableEventId(definition.eventKey),
     eventKey: definition.eventKey,
@@ -82,33 +55,31 @@ export function createEvent(definition) {
     observedAt: definition.observedAt || null,
     startedAt: definition.startedAt || null,
     endedAt: definition.endedAt || null,
-    entityIds: normalizeStringList(definition.entityIds || []),
-    placeEntityIds: normalizeStringList(definition.placeEntityIds || []),
-    articleIds: normalizeStringList(definition.articleIds || []),
-    unknowns: normalizeStringList(definition.unknowns || []),
-    evidenceRefs: normalizeStringList(definition.evidenceRefs || []),
+    entityIds: stringList(definition.entityIds || []),
+    placeEntityIds: stringList(definition.placeEntityIds || []),
+    articleIds: stringList(definition.articleIds || []),
+    unknowns: stringList(definition.unknowns || []),
+    evidenceRefs: stringList(definition.evidenceRefs || []),
     createdAt: definition.createdAt || null,
     reviewedAt: definition.reviewedAt || null,
   });
 }
 
 export function makeStableEntityId(type, identityKey) {
-  requireOneOf(type, ENTITY_TYPE_SET, 'entity.type');
-  requireNonEmptyString(identityKey, 'entity.identityKey');
-  if (type === 'place' && /^m49:\d{3}$/.test(identityKey)) {
-    return `place:${identityKey}`;
-  }
+  oneOf(type, ENTITY_TYPE_SET, 'entity.type');
+  text(identityKey, 'entity.identityKey');
+  if (type === 'place' && /^m49:\d{3}$/.test(identityKey)) return `place:${identityKey}`;
   return `entity:${type}:${fnv1a(`${type}\u001f${identityKey}`)}`;
 }
 
 export function makeStableEventId(eventKey) {
-  requireNonEmptyString(eventKey, 'event.eventKey');
+  text(eventKey, 'event.eventKey');
   return `event:${fnv1a(eventKey)}`;
 }
 
 export function normalizeAlias(value) {
-  requireNonEmptyString(value, 'alias');
-  return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase('und');
+  text(value, 'alias');
+  return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLowerCase();
 }
 
 export function buildAliasIndex(entities) {
@@ -122,104 +93,88 @@ export function buildAliasIndex(entities) {
 
 export function resolveEntityAlias(value, entities) {
   const normalized = normalizeAlias(value);
-  const index = buildAliasIndex(entities);
-  const matches = [...(index.get(normalized) || [])].sort();
-
-  if (matches.length === 0) return { status: 'no-match', normalized, entityIds: [] };
-  if (matches.length === 1) {
-    return { status: 'matched', normalized, entityId: matches[0], entityIds: matches };
-  }
+  const matches = [...(buildAliasIndex(entities).get(normalized) || [])].sort();
+  if (!matches.length) return { status: 'no-match', normalized, entityIds: [] };
+  if (matches.length === 1) return { status: 'matched', normalized, entityId: matches[0], entityIds: matches };
   return { status: 'ambiguous', normalized, entityIds: matches };
 }
 
 export function validateIntelligenceGraph({ entities = [], events = [] } = {}) {
-  const entityIds = entities.map(entity => entity.id);
-  const eventIds = events.map(event => event.id);
-  const duplicateEntityIds = duplicates(entityIds);
-  const duplicateEventIds = duplicates(eventIds);
   const entityById = new Map(entities.map(entity => [entity.id, entity]));
   const orphanEntityRefs = [];
   const orphanPlaceRefs = [];
   const nonPlaceRefs = [];
-
   for (const event of events) {
-    for (const entityId of event.entityIds || []) {
-      if (!entityById.has(entityId)) orphanEntityRefs.push(`${event.id}:${entityId}`);
-    }
-    for (const placeId of event.placeEntityIds || []) {
-      const entity = entityById.get(placeId);
-      if (!entity) orphanPlaceRefs.push(`${event.id}:${placeId}`);
-      else if (entity.type !== 'place') nonPlaceRefs.push(`${event.id}:${placeId}`);
+    for (const id of event.entityIds || []) if (!entityById.has(id)) orphanEntityRefs.push(`${event.id}:${id}`);
+    for (const id of event.placeEntityIds || []) {
+      const entity = entityById.get(id);
+      if (!entity) orphanPlaceRefs.push(`${event.id}:${id}`);
+      else if (entity.type !== 'place') nonPlaceRefs.push(`${event.id}:${id}`);
     }
   }
-
-  const invalidEntityIds = entities
-    .filter(entity => !isStructurallyValidEntity(entity))
-    .map(entity => entity.id || '(missing-id)');
-  const invalidEventIds = events
-    .filter(event => !isStructurallyValidEvent(event))
-    .map(event => event.id || '(missing-id)');
-
   const result = {
-    duplicateEntityIds,
-    duplicateEventIds,
-    orphanEntityRefs: [...new Set(orphanEntityRefs)].sort(),
-    orphanPlaceRefs: [...new Set(orphanPlaceRefs)].sort(),
-    nonPlaceRefs: [...new Set(nonPlaceRefs)].sort(),
-    invalidEntityIds: [...new Set(invalidEntityIds)].sort(),
-    invalidEventIds: [...new Set(invalidEventIds)].sort(),
+    duplicateEntityIds: duplicates(entities.map(entity => entity.id)),
+    duplicateEventIds: duplicates(events.map(event => event.id)),
+    orphanEntityRefs: unique(orphanEntityRefs),
+    orphanPlaceRefs: unique(orphanPlaceRefs),
+    nonPlaceRefs: unique(nonPlaceRefs),
+    invalidEntityIds: unique(entities.filter(entity => !validEntity(entity)).map(entity => entity.id || '(missing-id)')),
+    invalidEventIds: unique(events.filter(event => !validEvent(event)).map(event => event.id || '(missing-id)')),
   };
-
-  return {
-    valid: Object.values(result).every(values => values.length === 0),
-    ...result,
-  };
+  return { valid: Object.values(result).every(values => values.length === 0), ...result };
 }
 
-function normalizeAliasRecords(aliases) {
+function aliasRecords(aliases) {
   if (!Array.isArray(aliases)) throw new TypeError('entity.aliases must be an array');
   return aliases.map(alias => {
-    if (typeof alias === 'string') {
-      return Object.freeze({ value: alias, normalized: normalizeAlias(alias), evidenceRefs: [] });
-    }
-    requireObject(alias, 'entity alias');
-    requireNonEmptyString(alias.value, 'entity alias.value');
-    return Object.freeze({
-      value: alias.value,
-      normalized: normalizeAlias(alias.value),
-      evidenceRefs: normalizeStringList(alias.evidenceRefs || []),
-      sourceNative: alias.sourceNative === true,
-    });
+    object(alias, 'entity alias');
+    text(alias.value, 'entity alias.value');
+    const evidenceRefs = stringList(alias.evidenceRefs || []);
+    if (!evidenceRefs.length) throw new TypeError('entity alias.evidenceRefs must not be empty');
+    return Object.freeze({ value: alias.value, normalized: normalizeAlias(alias.value), evidenceRefs, sourceNative: alias.sourceNative === true });
   });
 }
 
-function normalizeStringList(values) {
+function stringList(values) {
   if (!Array.isArray(values)) throw new TypeError('expected an array');
-  return [...new Set(values.filter(value => typeof value === 'string' && value.trim()).map(value => value.trim()))].sort();
+  return unique(values.filter(value => typeof value === 'string' && value.trim()).map(value => value.trim()));
 }
 
-function normalizeStandardIds(value) {
+function standardIds(value) {
   if (value == null) return null;
-  requireObject(value, 'entity.standardIds');
-  const normalized = { ...value };
-  if (normalized.m49 != null) normalized.m49 = normalizeM49(normalized.m49);
-  if (normalized.isoAlpha2 != null) normalized.isoAlpha2 = normalizeIso(normalized.isoAlpha2, 2, 'standardIds.isoAlpha2');
-  if (normalized.isoAlpha3 != null) normalized.isoAlpha3 = normalizeIso(normalized.isoAlpha3, 3, 'standardIds.isoAlpha3');
-  return Object.freeze(normalized);
+  object(value, 'entity.standardIds');
+  const out = { ...value };
+  if (out.m49 != null) out.m49 = m49Code(out.m49);
+  if (out.isoAlpha2 != null) out.isoAlpha2 = isoCode(out.isoAlpha2, 2, 'standardIds.isoAlpha2');
+  if (out.isoAlpha3 != null) out.isoAlpha3 = isoCode(out.isoAlpha3, 3, 'standardIds.isoAlpha3');
+  return Object.freeze(out);
 }
 
-function normalizeM49(value) {
-  const m49 = String(value || '').padStart(3, '0');
-  if (!/^\d{3}$/.test(m49)) throw new TypeError('place.m49 must be a three-digit code');
-  return m49;
-}
-
-function normalizeIso(value, length, field) {
-  const normalized = String(value || '').trim().toUpperCase();
-  if (!new RegExp(`^[A-Z]{${length}}$`).test(normalized)) {
-    throw new TypeError(`${field} must be ${length} ASCII letters`);
-  }
+function m49Code(value) {
+  const raw = String(value ?? '').trim();
+  if (!/^\d{1,3}$/.test(raw)) throw new TypeError('place.m49 must be a one-to-three digit code');
+  const normalized = raw.padStart(3, '0');
+  if (normalized === '000') throw new TypeError('place.m49 000 is not a valid country/area identity code');
   return normalized;
+}
+
+function isoCode(value, length, field) {
+  const normalized = String(value ?? '').trim().toUpperCase();
+  if (!new RegExp(`^[A-Z]{${length}}$`).test(normalized)) throw new TypeError(`${field} must be ${length} ASCII letters`);
+  return normalized;
+}
+
+function validEntity(entity) {
+  return Boolean(entity && typeof entity.id === 'string' && ENTITY_TYPE_SET.has(entity.type) &&
+    typeof entity.identityKey === 'string' && typeof entity.displayName === 'string' &&
+    Array.isArray(entity.aliases) && entity.aliases.every(alias => Array.isArray(alias.evidenceRefs) && alias.evidenceRefs.length) &&
+    entity.id === makeStableEntityId(entity.type, entity.identityKey));
+}
+
+function validEvent(event) {
+  return Boolean(event && typeof event.id === 'string' && typeof event.eventKey === 'string' &&
+    typeof event.title === 'string' && typeof event.eventType === 'string' && EVENT_STATUS_SET.has(event.status) &&
+    event.id === makeStableEventId(event.eventKey));
 }
 
 function addAlias(index, value, entityId) {
@@ -227,66 +182,10 @@ function addAlias(index, value, entityId) {
   if (!index.has(normalized)) index.set(normalized, new Set());
   index.get(normalized).add(entityId);
 }
-
-function duplicates(values) {
-  const seen = new Set();
-  const repeated = new Set();
-  for (const value of values) {
-    if (seen.has(value)) repeated.add(value);
-    seen.add(value);
-  }
-  return [...repeated].sort();
-}
-
-function isStructurallyValidEntity(entity) {
-  return Boolean(
-    entity &&
-      typeof entity.id === 'string' &&
-      ENTITY_TYPE_SET.has(entity.type) &&
-      typeof entity.identityKey === 'string' &&
-      typeof entity.displayName === 'string' &&
-      entity.id === makeStableEntityId(entity.type, entity.identityKey)
-  );
-}
-
-function isStructurallyValidEvent(event) {
-  return Boolean(
-    event &&
-      typeof event.id === 'string' &&
-      typeof event.eventKey === 'string' &&
-      typeof event.title === 'string' &&
-      typeof event.eventType === 'string' &&
-      EVENT_STATUS_SET.has(event.status) &&
-      event.id === makeStableEventId(event.eventKey)
-  );
-}
-
-function fnv1a(value) {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < value.length; i++) {
-    hash ^= value.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  return hash.toString(16).padStart(8, '0');
-}
-
-function requireObject(value, field) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new TypeError(`${field} must be an object`);
-  }
-}
-
-function requireNonEmptyString(value, field) {
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw new TypeError(`${field} must be a non-empty string`);
-  }
-}
-
-function requireOneOf(value, allowed, field) {
-  if (!allowed.has(value)) throw new TypeError(`${field} is not supported`);
-}
-
-function clonePlainValue(value) {
-  if (value == null || typeof value !== 'object') return value;
-  return JSON.parse(JSON.stringify(value));
-}
+function duplicates(values) { const seen = new Set(); const repeated = new Set(); for (const value of values) { if (seen.has(value)) repeated.add(value); seen.add(value); } return [...repeated].sort(); }
+function unique(values) { return [...new Set(values)].sort(); }
+function fnv1a(value) { let hash = 0x811c9dc5; for (let i = 0; i < value.length; i++) { hash ^= value.charCodeAt(i); hash = Math.imul(hash, 0x01000193) >>> 0; } return hash.toString(16).padStart(8, '0'); }
+function object(value, field) { if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError(`${field} must be an object`); }
+function text(value, field) { if (typeof value !== 'string' || !value.trim()) throw new TypeError(`${field} must be a non-empty string`); }
+function oneOf(value, allowed, field) { if (!allowed.has(value)) throw new TypeError(`${field} is not supported`); }
+function clone(value) { if (value == null || typeof value !== 'object') return value; return JSON.parse(JSON.stringify(value)); }

--- a/functions/lib/intelligence-model.js
+++ b/functions/lib/intelligence-model.js
@@ -1,5 +1,5 @@
 // Deterministic intelligence primitives. Identity is explicit; fuzzy similarity never merges records.
-export const INTELLIGENCE_MODEL_VERSION = '2026-09-03.1';
+export const INTELLIGENCE_MODEL_VERSION = '2026-09-03.2';
 export const ENTITY_TYPES = Object.freeze([
   'person', 'organization', 'government-public-body', 'company', 'place', 'multilateral-body',
 ]);
@@ -12,7 +12,7 @@ export function createEntity(definition) {
   text(definition.identityKey, 'entity.identityKey');
   text(definition.displayName, 'entity.displayName');
   oneOf(definition.type, ENTITY_TYPE_SET, 'entity.type');
-  const normalizedStandardIds = standardIds(definition.standardIds || null);
+  const normalizedStandardIds = standardIds(definition.standardIds ?? null);
   if (definition.type === 'place' && definition.identityKey.startsWith('m49:')) {
     const keyM49 = m49Code(definition.identityKey.slice(4));
     if (definition.identityKey !== `m49:${keyM49}` || normalizedStandardIds?.m49 !== keyM49) {
@@ -24,13 +24,13 @@ export function createEntity(definition) {
     identityKey: definition.identityKey,
     type: definition.type,
     displayName: definition.displayName,
-    aliases: aliasRecords(definition.aliases || []),
-    evidenceRefs: stringList(definition.evidenceRefs || []),
-    countryEntityId: definition.countryEntityId || null,
+    aliases: aliasRecords(definition.aliases ?? []),
+    evidenceRefs: stringList(definition.evidenceRefs ?? []),
+    countryEntityId: optionalText(definition.countryEntityId, 'entity.countryEntityId'),
     standardIds: normalizedStandardIds,
     attributes: clone(definition.attributes ?? {}),
-    createdAt: definition.createdAt || null,
-    reviewedAt: definition.reviewedAt || null,
+    createdAt: definition.createdAt ?? null,
+    reviewedAt: definition.reviewedAt ?? null,
   });
 }
 
@@ -43,7 +43,7 @@ export function createM49PlaceEntity(definition) {
     ...definition,
     identityKey: `m49:${m49}`,
     type: 'place',
-    standardIds: { ...(definition.standardIds || {}), m49, isoAlpha2, isoAlpha3 },
+    standardIds: { ...(definition.standardIds ?? {}), m49, isoAlpha2, isoAlpha3 },
   });
 }
 
@@ -59,16 +59,16 @@ export function createEvent(definition) {
     title: definition.title,
     eventType: definition.eventType,
     status: definition.status,
-    observedAt: definition.observedAt || null,
-    startedAt: definition.startedAt || null,
-    endedAt: definition.endedAt || null,
-    entityIds: stringList(definition.entityIds || []),
-    placeEntityIds: stringList(definition.placeEntityIds || []),
-    articleIds: stringList(definition.articleIds || []),
-    unknowns: stringList(definition.unknowns || []),
-    evidenceRefs: stringList(definition.evidenceRefs || []),
-    createdAt: definition.createdAt || null,
-    reviewedAt: definition.reviewedAt || null,
+    observedAt: definition.observedAt ?? null,
+    startedAt: definition.startedAt ?? null,
+    endedAt: definition.endedAt ?? null,
+    entityIds: stringList(definition.entityIds ?? []),
+    placeEntityIds: stringList(definition.placeEntityIds ?? []),
+    articleIds: stringList(definition.articleIds ?? []),
+    unknowns: stringList(definition.unknowns ?? []),
+    evidenceRefs: stringList(definition.evidenceRefs ?? []),
+    createdAt: definition.createdAt ?? null,
+    reviewedAt: definition.reviewedAt ?? null,
   });
 }
 
@@ -80,12 +80,12 @@ export function makeStableEntityId(type, identityKey) {
     if (identityKey !== `m49:${code}`) throw new TypeError('M49 place identityKey must use a canonical three-digit code');
     return `place:m49:${code}`;
   }
-  return `entity:${type}:${fnv1a(`${type}\u001f${identityKey}`)}`;
+  return `entity:${type}:${encodeURIComponent(identityKey)}`;
 }
 
 export function makeStableEventId(eventKey) {
   text(eventKey, 'event.eventKey');
-  return `event:${fnv1a(eventKey)}`;
+  return `event:${encodeURIComponent(eventKey)}`;
 }
 
 export function normalizeAlias(value) {
@@ -115,6 +115,14 @@ export function validateIntelligenceGraph({ entities = [], events = [] } = {}) {
   const orphanEntityRefs = [];
   const orphanPlaceRefs = [];
   const nonPlaceRefs = [];
+  const orphanCountryRefs = [];
+  const nonPlaceCountryRefs = [];
+  for (const entity of entities) {
+    if (!entity.countryEntityId) continue;
+    const country = entityById.get(entity.countryEntityId);
+    if (!country) orphanCountryRefs.push(`${entity.id}:${entity.countryEntityId}`);
+    else if (country.type !== 'place') nonPlaceCountryRefs.push(`${entity.id}:${entity.countryEntityId}`);
+  }
   for (const event of events) {
     for (const id of event.entityIds || []) if (!entityById.has(id)) orphanEntityRefs.push(`${event.id}:${id}`);
     for (const id of event.placeEntityIds || []) {
@@ -129,6 +137,8 @@ export function validateIntelligenceGraph({ entities = [], events = [] } = {}) {
     orphanEntityRefs: unique(orphanEntityRefs),
     orphanPlaceRefs: unique(orphanPlaceRefs),
     nonPlaceRefs: unique(nonPlaceRefs),
+    orphanCountryRefs: unique(orphanCountryRefs),
+    nonPlaceCountryRefs: unique(nonPlaceCountryRefs),
     invalidEntityIds: unique(entities.filter(entity => !validEntity(entity)).map(entity => entity.id || '(missing-id)')),
     invalidEventIds: unique(events.filter(event => !validEvent(event)).map(event => event.id || '(missing-id)')),
   };
@@ -140,7 +150,7 @@ function aliasRecords(aliases) {
   return aliases.map(alias => {
     object(alias, 'entity alias');
     text(alias.value, 'entity alias.value');
-    const evidenceRefs = stringList(alias.evidenceRefs || []);
+    const evidenceRefs = stringList(alias.evidenceRefs ?? []);
     if (!evidenceRefs.length) throw new TypeError('entity alias.evidenceRefs must not be empty');
     return Object.freeze({ value: alias.value, normalized: normalizeAlias(alias.value), evidenceRefs, sourceNative: alias.sourceNative === true });
   });
@@ -178,6 +188,7 @@ function isoCode(value, length, field) {
 function validEntity(entity) {
   return Boolean(entity && typeof entity.id === 'string' && ENTITY_TYPE_SET.has(entity.type) &&
     typeof entity.identityKey === 'string' && typeof entity.displayName === 'string' &&
+    (entity.countryEntityId == null || (typeof entity.countryEntityId === 'string' && entity.countryEntityId.trim())) &&
     Array.isArray(entity.aliases) && entity.aliases.every(alias => Array.isArray(alias.evidenceRefs) && alias.evidenceRefs.length) &&
     entity.id === makeStableEntityId(entity.type, entity.identityKey));
 }
@@ -195,7 +206,7 @@ function addAlias(index, value, entityId) {
 }
 function duplicates(values) { const seen = new Set(); const repeated = new Set(); for (const value of values) { if (seen.has(value)) repeated.add(value); seen.add(value); } return [...repeated].sort(); }
 function unique(values) { return [...new Set(values)].sort(); }
-function fnv1a(value) { let hash = 0x811c9dc5; for (let i = 0; i < value.length; i++) { hash ^= value.charCodeAt(i); hash = Math.imul(hash, 0x01000193) >>> 0; } return hash.toString(16).padStart(8, '0'); }
+function optionalText(value, field) { if (value == null) return null; text(value, field); return value.trim(); }
 function object(value, field) { if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError(`${field} must be an object`); }
 function text(value, field) { if (typeof value !== 'string' || !value.trim()) throw new TypeError(`${field} must be a non-empty string`); }
 function oneOf(value, allowed, field) { if (!allowed.has(value)) throw new TypeError(`${field} is not supported`); }

--- a/functions/lib/intelligence-model.js
+++ b/functions/lib/intelligence-model.js
@@ -12,6 +12,13 @@ export function createEntity(definition) {
   text(definition.identityKey, 'entity.identityKey');
   text(definition.displayName, 'entity.displayName');
   oneOf(definition.type, ENTITY_TYPE_SET, 'entity.type');
+  const normalizedStandardIds = standardIds(definition.standardIds || null);
+  if (definition.type === 'place' && definition.identityKey.startsWith('m49:')) {
+    const keyM49 = m49Code(definition.identityKey.slice(4));
+    if (definition.identityKey !== `m49:${keyM49}` || normalizedStandardIds?.m49 !== keyM49) {
+      throw new TypeError('M49 place identity requires canonical identityKey and matching standardIds.m49');
+    }
+  }
   return Object.freeze({
     id: makeStableEntityId(definition.type, definition.identityKey),
     identityKey: definition.identityKey,
@@ -20,7 +27,7 @@ export function createEntity(definition) {
     aliases: aliasRecords(definition.aliases || []),
     evidenceRefs: stringList(definition.evidenceRefs || []),
     countryEntityId: definition.countryEntityId || null,
-    standardIds: standardIds(definition.standardIds || null),
+    standardIds: normalizedStandardIds,
     attributes: clone(definition.attributes ?? {}),
     createdAt: definition.createdAt || null,
     reviewedAt: definition.reviewedAt || null,
@@ -68,7 +75,11 @@ export function createEvent(definition) {
 export function makeStableEntityId(type, identityKey) {
   oneOf(type, ENTITY_TYPE_SET, 'entity.type');
   text(identityKey, 'entity.identityKey');
-  if (type === 'place' && /^m49:\d{3}$/.test(identityKey)) return `place:${identityKey}`;
+  if (type === 'place' && identityKey.startsWith('m49:')) {
+    const code = m49Code(identityKey.slice(4));
+    if (identityKey !== `m49:${code}`) throw new TypeError('M49 place identityKey must use a canonical three-digit code');
+    return `place:m49:${code}`;
+  }
   return `entity:${type}:${fnv1a(`${type}\u001f${identityKey}`)}`;
 }
 

--- a/functions/lib/intelligence-model.js
+++ b/functions/lib/intelligence-model.js
@@ -1,0 +1,292 @@
+// Deterministic intelligence primitives for GlobalDeets.
+// Identity is explicit. Similar names, headlines, or aliases never create an automatic merge.
+
+export const INTELLIGENCE_MODEL_VERSION = '2026-09-03.1';
+
+export const ENTITY_TYPES = Object.freeze([
+  'person',
+  'organization',
+  'government-public-body',
+  'company',
+  'place',
+  'multilateral-body',
+]);
+
+export const EVENT_STATUSES = Object.freeze([
+  'developing',
+  'confirmed',
+  'closed',
+  'disputed',
+]);
+
+const ENTITY_TYPE_SET = new Set(ENTITY_TYPES);
+const EVENT_STATUS_SET = new Set(EVENT_STATUSES);
+
+export function createEntity(definition) {
+  requireObject(definition, 'entity definition');
+  requireNonEmptyString(definition.identityKey, 'entity.identityKey');
+  requireNonEmptyString(definition.displayName, 'entity.displayName');
+  requireOneOf(definition.type, ENTITY_TYPE_SET, 'entity.type');
+
+  const aliases = normalizeAliasRecords(definition.aliases || []);
+  const evidenceRefs = normalizeStringList(definition.evidenceRefs || []);
+  const attributes = clonePlainValue(definition.attributes ?? {});
+
+  return Object.freeze({
+    id: makeStableEntityId(definition.type, definition.identityKey),
+    identityKey: definition.identityKey,
+    type: definition.type,
+    displayName: definition.displayName,
+    aliases,
+    evidenceRefs,
+    countryEntityId: definition.countryEntityId || null,
+    standardIds: normalizeStandardIds(definition.standardIds || null),
+    attributes,
+    createdAt: definition.createdAt || null,
+    reviewedAt: definition.reviewedAt || null,
+  });
+}
+
+export function createM49PlaceEntity(definition) {
+  requireObject(definition, 'M49 place definition');
+  const m49 = normalizeM49(definition.m49);
+  const isoAlpha2 = normalizeIso(definition.isoAlpha2, 2, 'place.isoAlpha2');
+  const isoAlpha3 = normalizeIso(definition.isoAlpha3, 3, 'place.isoAlpha3');
+
+  return createEntity({
+    ...definition,
+    identityKey: `m49:${m49}`,
+    type: 'place',
+    standardIds: {
+      ...(definition.standardIds || {}),
+      m49,
+      isoAlpha2,
+      isoAlpha3,
+    },
+  });
+}
+
+export function createEvent(definition) {
+  requireObject(definition, 'event definition');
+  requireNonEmptyString(definition.eventKey, 'event.eventKey');
+  requireNonEmptyString(definition.title, 'event.title');
+  requireNonEmptyString(definition.eventType, 'event.eventType');
+  requireOneOf(definition.status, EVENT_STATUS_SET, 'event.status');
+
+  return Object.freeze({
+    id: makeStableEventId(definition.eventKey),
+    eventKey: definition.eventKey,
+    title: definition.title,
+    eventType: definition.eventType,
+    status: definition.status,
+    observedAt: definition.observedAt || null,
+    startedAt: definition.startedAt || null,
+    endedAt: definition.endedAt || null,
+    entityIds: normalizeStringList(definition.entityIds || []),
+    placeEntityIds: normalizeStringList(definition.placeEntityIds || []),
+    articleIds: normalizeStringList(definition.articleIds || []),
+    unknowns: normalizeStringList(definition.unknowns || []),
+    evidenceRefs: normalizeStringList(definition.evidenceRefs || []),
+    createdAt: definition.createdAt || null,
+    reviewedAt: definition.reviewedAt || null,
+  });
+}
+
+export function makeStableEntityId(type, identityKey) {
+  requireOneOf(type, ENTITY_TYPE_SET, 'entity.type');
+  requireNonEmptyString(identityKey, 'entity.identityKey');
+  if (type === 'place' && /^m49:\d{3}$/.test(identityKey)) {
+    return `place:${identityKey}`;
+  }
+  return `entity:${type}:${fnv1a(`${type}\u001f${identityKey}`)}`;
+}
+
+export function makeStableEventId(eventKey) {
+  requireNonEmptyString(eventKey, 'event.eventKey');
+  return `event:${fnv1a(eventKey)}`;
+}
+
+export function normalizeAlias(value) {
+  requireNonEmptyString(value, 'alias');
+  return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase('und');
+}
+
+export function buildAliasIndex(entities) {
+  const index = new Map();
+  for (const entity of entities || []) {
+    addAlias(index, entity.displayName, entity.id);
+    for (const alias of entity.aliases || []) addAlias(index, alias.value, entity.id);
+  }
+  return index;
+}
+
+export function resolveEntityAlias(value, entities) {
+  const normalized = normalizeAlias(value);
+  const index = buildAliasIndex(entities);
+  const matches = [...(index.get(normalized) || [])].sort();
+
+  if (matches.length === 0) return { status: 'no-match', normalized, entityIds: [] };
+  if (matches.length === 1) {
+    return { status: 'matched', normalized, entityId: matches[0], entityIds: matches };
+  }
+  return { status: 'ambiguous', normalized, entityIds: matches };
+}
+
+export function validateIntelligenceGraph({ entities = [], events = [] } = {}) {
+  const entityIds = entities.map(entity => entity.id);
+  const eventIds = events.map(event => event.id);
+  const duplicateEntityIds = duplicates(entityIds);
+  const duplicateEventIds = duplicates(eventIds);
+  const entityById = new Map(entities.map(entity => [entity.id, entity]));
+  const orphanEntityRefs = [];
+  const orphanPlaceRefs = [];
+  const nonPlaceRefs = [];
+
+  for (const event of events) {
+    for (const entityId of event.entityIds || []) {
+      if (!entityById.has(entityId)) orphanEntityRefs.push(`${event.id}:${entityId}`);
+    }
+    for (const placeId of event.placeEntityIds || []) {
+      const entity = entityById.get(placeId);
+      if (!entity) orphanPlaceRefs.push(`${event.id}:${placeId}`);
+      else if (entity.type !== 'place') nonPlaceRefs.push(`${event.id}:${placeId}`);
+    }
+  }
+
+  const invalidEntityIds = entities
+    .filter(entity => !isStructurallyValidEntity(entity))
+    .map(entity => entity.id || '(missing-id)');
+  const invalidEventIds = events
+    .filter(event => !isStructurallyValidEvent(event))
+    .map(event => event.id || '(missing-id)');
+
+  const result = {
+    duplicateEntityIds,
+    duplicateEventIds,
+    orphanEntityRefs: [...new Set(orphanEntityRefs)].sort(),
+    orphanPlaceRefs: [...new Set(orphanPlaceRefs)].sort(),
+    nonPlaceRefs: [...new Set(nonPlaceRefs)].sort(),
+    invalidEntityIds: [...new Set(invalidEntityIds)].sort(),
+    invalidEventIds: [...new Set(invalidEventIds)].sort(),
+  };
+
+  return {
+    valid: Object.values(result).every(values => values.length === 0),
+    ...result,
+  };
+}
+
+function normalizeAliasRecords(aliases) {
+  if (!Array.isArray(aliases)) throw new TypeError('entity.aliases must be an array');
+  return aliases.map(alias => {
+    if (typeof alias === 'string') {
+      return Object.freeze({ value: alias, normalized: normalizeAlias(alias), evidenceRefs: [] });
+    }
+    requireObject(alias, 'entity alias');
+    requireNonEmptyString(alias.value, 'entity alias.value');
+    return Object.freeze({
+      value: alias.value,
+      normalized: normalizeAlias(alias.value),
+      evidenceRefs: normalizeStringList(alias.evidenceRefs || []),
+      sourceNative: alias.sourceNative === true,
+    });
+  });
+}
+
+function normalizeStringList(values) {
+  if (!Array.isArray(values)) throw new TypeError('expected an array');
+  return [...new Set(values.filter(value => typeof value === 'string' && value.trim()).map(value => value.trim()))].sort();
+}
+
+function normalizeStandardIds(value) {
+  if (value == null) return null;
+  requireObject(value, 'entity.standardIds');
+  const normalized = { ...value };
+  if (normalized.m49 != null) normalized.m49 = normalizeM49(normalized.m49);
+  if (normalized.isoAlpha2 != null) normalized.isoAlpha2 = normalizeIso(normalized.isoAlpha2, 2, 'standardIds.isoAlpha2');
+  if (normalized.isoAlpha3 != null) normalized.isoAlpha3 = normalizeIso(normalized.isoAlpha3, 3, 'standardIds.isoAlpha3');
+  return Object.freeze(normalized);
+}
+
+function normalizeM49(value) {
+  const m49 = String(value || '').padStart(3, '0');
+  if (!/^\d{3}$/.test(m49)) throw new TypeError('place.m49 must be a three-digit code');
+  return m49;
+}
+
+function normalizeIso(value, length, field) {
+  const normalized = String(value || '').trim().toUpperCase();
+  if (!new RegExp(`^[A-Z]{${length}}$`).test(normalized)) {
+    throw new TypeError(`${field} must be ${length} ASCII letters`);
+  }
+  return normalized;
+}
+
+function addAlias(index, value, entityId) {
+  const normalized = normalizeAlias(value);
+  if (!index.has(normalized)) index.set(normalized, new Set());
+  index.get(normalized).add(entityId);
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  const repeated = new Set();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated].sort();
+}
+
+function isStructurallyValidEntity(entity) {
+  return Boolean(
+    entity &&
+      typeof entity.id === 'string' &&
+      ENTITY_TYPE_SET.has(entity.type) &&
+      typeof entity.identityKey === 'string' &&
+      typeof entity.displayName === 'string' &&
+      entity.id === makeStableEntityId(entity.type, entity.identityKey)
+  );
+}
+
+function isStructurallyValidEvent(event) {
+  return Boolean(
+    event &&
+      typeof event.id === 'string' &&
+      typeof event.eventKey === 'string' &&
+      typeof event.title === 'string' &&
+      typeof event.eventType === 'string' &&
+      EVENT_STATUS_SET.has(event.status) &&
+      event.id === makeStableEventId(event.eventKey)
+  );
+}
+
+function fnv1a(value) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+function requireObject(value, field) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${field} must be an object`);
+  }
+}
+
+function requireNonEmptyString(value, field) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new TypeError(`${field} must be a non-empty string`);
+  }
+}
+
+function requireOneOf(value, allowed, field) {
+  if (!allowed.has(value)) throw new TypeError(`${field} is not supported`);
+}
+
+function clonePlainValue(value) {
+  if (value == null || typeof value !== 'object') return value;
+  return JSON.parse(JSON.stringify(value));
+}

--- a/functions/lib/m49-place-seed.js
+++ b/functions/lib/m49-place-seed.js
@@ -1,0 +1,126 @@
+// Initial UN M49-backed place seed for countries represented by the current news-source origins.
+// This is intentionally incomplete; it establishes the identity/import contract before a full M49 snapshot.
+
+import { createM49PlaceEntity } from './intelligence-model.js';
+
+export const M49_SOURCE_URL = 'https://unstats.un.org/unsd/methodology/m49/overview/';
+export const M49_SEED_REVIEWED_AT = '2026-09-03';
+
+export const M49_SEED_METADATA = Object.freeze({
+  standard: 'United Nations Statistics Division M49',
+  sourceUrl: M49_SOURCE_URL,
+  reviewedAt: M49_SEED_REVIEWED_AT,
+  complete: false,
+  scope: 'countries represented by current news-source provenance origins',
+  runtimeFetchRequired: false,
+});
+
+export const M49_PLACE_SEED = Object.freeze([
+  seed('Australia', '036', 'AU', 'AUS', '009', 'Oceania', '053', 'Australia and New Zealand'),
+  seed('France', '250', 'FR', 'FRA', '150', 'Europe', '155', 'Western Europe'),
+  seed('Germany', '276', 'DE', 'DEU', '150', 'Europe', '155', 'Western Europe'),
+  seed('India', '356', 'IN', 'IND', '142', 'Asia', '034', 'Southern Asia'),
+  seed('Japan', '392', 'JP', 'JPN', '142', 'Asia', '030', 'Eastern Asia'),
+  seed(
+    'Kenya',
+    '404',
+    'KE',
+    'KEN',
+    '002',
+    'Africa',
+    '202',
+    'Sub-Saharan Africa',
+    '014',
+    'Eastern Africa'
+  ),
+  seed(
+    'Nigeria',
+    '566',
+    'NG',
+    'NGA',
+    '002',
+    'Africa',
+    '202',
+    'Sub-Saharan Africa',
+    '011',
+    'Western Africa'
+  ),
+  seed('Pakistan', '586', 'PK', 'PAK', '142', 'Asia', '034', 'Southern Asia'),
+  seed('Qatar', '634', 'QA', 'QAT', '142', 'Asia', '145', 'Western Asia'),
+  seed('Republic of Korea', '410', 'KR', 'KOR', '142', 'Asia', '030', 'Eastern Asia'),
+  seed('Singapore', '702', 'SG', 'SGP', '142', 'Asia', '035', 'South-eastern Asia'),
+  seed('Türkiye', '792', 'TR', 'TUR', '142', 'Asia', '145', 'Western Asia'),
+  seed('Ukraine', '804', 'UA', 'UKR', '150', 'Europe', '151', 'Eastern Europe'),
+  seed(
+    'United Kingdom of Great Britain and Northern Ireland',
+    '826',
+    'GB',
+    'GBR',
+    '150',
+    'Europe',
+    '154',
+    'Northern Europe'
+  ),
+  seed(
+    'United States of America',
+    '840',
+    'US',
+    'USA',
+    '019',
+    'Americas',
+    '021',
+    'Northern America'
+  ),
+  seed(
+    'Uruguay',
+    '858',
+    'UY',
+    'URY',
+    '019',
+    'Americas',
+    '419',
+    'Latin America and the Caribbean',
+    '005',
+    'South America'
+  ),
+].sort((a, b) => a.standardIds.m49.localeCompare(b.standardIds.m49)));
+
+export function getSeedPlaceByIsoAlpha2(code) {
+  const normalized = String(code || '').trim().toUpperCase();
+  return M49_PLACE_SEED.find(place => place.standardIds.isoAlpha2 === normalized) || null;
+}
+
+export function getSeedPlaceByM49(code) {
+  const normalized = String(code || '').trim().padStart(3, '0');
+  return M49_PLACE_SEED.find(place => place.standardIds.m49 === normalized) || null;
+}
+
+function seed(
+  displayName,
+  m49,
+  isoAlpha2,
+  isoAlpha3,
+  regionCode,
+  regionName,
+  subregionCode,
+  subregionName,
+  intermediateRegionCode = null,
+  intermediateRegionName = null
+) {
+  return createM49PlaceEntity({
+    displayName,
+    m49,
+    isoAlpha2,
+    isoAlpha3,
+    evidenceRefs: [M49_SOURCE_URL],
+    reviewedAt: M49_SEED_REVIEWED_AT,
+    attributes: {
+      m49Region: { code: regionCode, name: regionName },
+      m49Subregion: { code: subregionCode, name: subregionName },
+      m49IntermediateRegion:
+        intermediateRegionCode && intermediateRegionName
+          ? { code: intermediateRegionCode, name: intermediateRegionName }
+          : null,
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/intelligence-model.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/tests/intelligence-model.test.mjs
+++ b/tests/intelligence-model.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const root = mkdtempSync(join(tmpdir(), 'globaldeets-intelligence-'));
+const functions = join(root, 'functions');
+const modelPath = join(functions, 'lib', 'intelligence-model.js');
+const seedPath = join(functions, 'lib', 'm49-place-seed.js');
+const apiPath = join(functions, 'api', 'intelligence', 'schema.js');
+mkdirSync(dirname(modelPath), { recursive: true });
+mkdirSync(dirname(apiPath), { recursive: true });
+writeFileSync(join(functions, 'package.json'), '{"type":"module"}\n');
+for (const [source, target] of [
+  ['../functions/lib/intelligence-model.js', modelPath],
+  ['../functions/lib/m49-place-seed.js', seedPath],
+  ['../functions/api/intelligence/schema.js', apiPath],
+]) copyFileSync(fileURLToPath(new URL(source, import.meta.url)), target);
+
+const model = await import(pathToFileURL(modelPath).href);
+const seed = await import(pathToFileURL(seedPath).href);
+const api = await import(pathToFileURL(apiPath).href);
+const EVIDENCE = 'https://example.com/evidence';
+
+function alias(value) { return { value, evidenceRefs: [EVIDENCE] }; }
+function entity(identityKey, displayName = 'Alex Kim') {
+  return model.createEntity({ identityKey, displayName, type: 'person', aliases: [alias('A. Kim')] });
+}
+
+test('entity identity is explicit and not derived from display-name similarity', () => {
+  const first = entity('person:source-a:123');
+  const reordered = model.createEntity({ aliases: [alias('A. Kim')], type: 'person', displayName: 'Alex Kim', identityKey: 'person:source-a:123' });
+  const second = entity('person:source-b:456');
+  assert.equal(first.id, reordered.id);
+  assert.notEqual(first.id, second.id);
+  assert.equal(first.displayName, second.displayName);
+});
+
+test('aliases require evidence and ambiguous aliases never choose a silent winner', () => {
+  assert.throws(() => model.createEntity({ identityKey: 'x', displayName: 'X', type: 'person', aliases: [{ value: 'Shared' }] }), /evidenceRefs/);
+  const a = model.createEntity({ identityKey: 'a', displayName: 'Alpha', type: 'organization', aliases: [alias('Shared Name')] });
+  const b = model.createEntity({ identityKey: 'b', displayName: 'Beta', type: 'organization', aliases: [alias('shared   name')] });
+  assert.deepEqual(model.resolveEntityAlias(' SHARED NAME ', [a, b]), { status: 'ambiguous', normalized: 'shared name', entityIds: [a.id, b.id].sort() });
+  assert.equal(model.resolveEntityAlias('missing', [a, b]).status, 'no-match');
+});
+
+test('M49 place identity is stable and rejects missing, zero, or malformed codes', () => {
+  const us = model.createM49PlaceEntity({ displayName: 'United States of America', m49: '840', isoAlpha2: 'US', isoAlpha3: 'USA', evidenceRefs: [EVIDENCE] });
+  assert.equal(us.id, 'place:m49:840');
+  assert.deepEqual(us.standardIds, { m49: '840', isoAlpha2: 'US', isoAlpha3: 'USA' });
+  assert.throws(() => model.createM49PlaceEntity({ displayName: 'Bad', isoAlpha2: 'XX', isoAlpha3: 'XXX' }), /m49/);
+  assert.throws(() => model.createM49PlaceEntity({ displayName: 'Bad', m49: '000', isoAlpha2: 'XX', isoAlpha3: 'XXX' }), /000/);
+  assert.throws(() => model.createM49PlaceEntity({ displayName: 'Bad', m49: '12x', isoAlpha2: 'XX', isoAlpha3: 'XXX' }), /m49/);
+});
+
+test('reviewed M49 seed is explicitly partial and has unique standard identifiers', () => {
+  assert.equal(seed.M49_SEED_METADATA.complete, false);
+  assert.equal(seed.M49_SEED_METADATA.runtimeFetchRequired, false);
+  assert.equal(seed.M49_PLACE_SEED.length, 16);
+  assert.equal(new Set(seed.M49_PLACE_SEED.map(place => place.standardIds.m49)).size, 16);
+  assert.equal(new Set(seed.M49_PLACE_SEED.map(place => place.standardIds.isoAlpha2)).size, 16);
+  assert.equal(seed.getSeedPlaceByIsoAlpha2('us').id, 'place:m49:840');
+  assert.equal(seed.getSeedPlaceByM49('36').standardIds.isoAlpha2, 'AU');
+});
+
+test('event identity depends on explicit event key rather than mutable title', () => {
+  const first = model.createEvent({ eventKey: 'incident:example:2026-09-03:001', title: 'Initial title', eventType: 'incident', status: 'developing', articleIds: ['article-b', 'article-a', 'article-a'], unknowns: ['cause', 'cause'] });
+  const revised = model.createEvent({ eventKey: 'incident:example:2026-09-03:001', title: 'Revised title', eventType: 'incident', status: 'confirmed' });
+  const distinct = model.createEvent({ eventKey: 'incident:example:2026-09-03:002', title: 'Initial title', eventType: 'incident', status: 'developing' });
+  assert.equal(first.id, revised.id);
+  assert.notEqual(first.id, distinct.id);
+  assert.deepEqual(first.articleIds, ['article-a', 'article-b']);
+  assert.deepEqual(first.unknowns, ['cause']);
+});
+
+test('graph permits many-to-many article relations but rejects orphan and wrong-type place references', () => {
+  const place = seed.getSeedPlaceByIsoAlpha2('UA');
+  const person = entity('person:test:1');
+  const one = model.createEvent({ eventKey: 'event:one', title: 'One', eventType: 'incident', status: 'developing', entityIds: [person.id], placeEntityIds: [place.id], articleIds: ['article-shared', 'article-one'] });
+  const two = model.createEvent({ eventKey: 'event:two', title: 'Two', eventType: 'incident', status: 'developing', articleIds: ['article-shared'] });
+  assert.equal(model.validateIntelligenceGraph({ entities: [place, person], events: [one, two] }).valid, true);
+
+  const broken = model.createEvent({ eventKey: 'event:broken', title: 'Broken', eventType: 'incident', status: 'disputed', entityIds: ['entity:missing'], placeEntityIds: ['place:missing', person.id] });
+  const result = model.validateIntelligenceGraph({ entities: [place, person], events: [broken] });
+  assert.equal(result.valid, false);
+  assert.equal(result.orphanEntityRefs.length, 1);
+  assert.equal(result.orphanPlaceRefs.length, 1);
+  assert.equal(result.nonPlaceRefs.length, 1);
+});
+
+test('/api/intelligence/schema exposes identity rules without claiming a complete country set', async () => {
+  const response = await api.onRequestGet({ request: new Request('https://globaldeets.com/api/intelligence/schema', { headers: { Origin: 'https://globaldeets.com' } }) });
+  const json = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(json.modelVersion, model.INTELLIGENCE_MODEL_VERSION);
+  assert.equal(json.identityRules.automaticNameMerge, false);
+  assert.equal(json.identityRules.aliasesRequireEvidence, true);
+  assert.equal(json.identityRules.placeIdentityStandard, 'UN M49');
+  assert.equal(json.placeSeed.complete, false);
+  assert.equal(json.placeSeed.count, 16);
+});

--- a/tests/intelligence-model.test.mjs
+++ b/tests/intelligence-model.test.mjs
@@ -29,13 +29,15 @@ function entity(identityKey, displayName = 'Alex Kim') {
   return model.createEntity({ identityKey, displayName, type: 'person', aliases: [alias('A. Kim')] });
 }
 
-test('entity identity is explicit and not derived from display-name similarity', () => {
+test('entity identity is explicit, deterministic, and collision-free by construction', () => {
   const first = entity('person:source-a:123');
   const reordered = model.createEntity({ aliases: [alias('A. Kim')], type: 'person', displayName: 'Alex Kim', identityKey: 'person:source-a:123' });
   const second = entity('person:source-b:456');
   assert.equal(first.id, reordered.id);
   assert.notEqual(first.id, second.id);
   assert.equal(first.displayName, second.displayName);
+  assert.equal(first.id, 'entity:person:person%3Asource-a%3A123');
+  assert.notEqual(model.makeStableEntityId('person', 'ke1mzdtk6'), model.makeStableEntityId('person', 'kgus2fumc'));
 });
 
 test('aliases require evidence and ambiguous aliases never choose a silent winner', () => {
@@ -46,13 +48,18 @@ test('aliases require evidence and ambiguous aliases never choose a silent winne
   assert.equal(model.resolveEntityAlias('missing', [a, b]).status, 'no-match');
 });
 
-test('M49 place identity is stable and rejects missing, zero, or malformed codes', () => {
+test('M49 place identity is stable and rejects missing, zero, malformed, or generic-constructor bypasses', () => {
   const us = model.createM49PlaceEntity({ displayName: 'United States of America', m49: '840', isoAlpha2: 'US', isoAlpha3: 'USA', evidenceRefs: [EVIDENCE] });
   assert.equal(us.id, 'place:m49:840');
   assert.deepEqual(us.standardIds, { m49: '840', isoAlpha2: 'US', isoAlpha3: 'USA' });
   assert.throws(() => model.createM49PlaceEntity({ displayName: 'Bad', isoAlpha2: 'XX', isoAlpha3: 'XXX' }), /m49/);
   assert.throws(() => model.createM49PlaceEntity({ displayName: 'Bad', m49: '000', isoAlpha2: 'XX', isoAlpha3: 'XXX' }), /000/);
   assert.throws(() => model.createM49PlaceEntity({ displayName: 'Bad', m49: '12x', isoAlpha2: 'XX', isoAlpha3: 'XXX' }), /m49/);
+  assert.throws(() => model.createEntity({ identityKey: 'm49:840', displayName: 'Bad', type: 'place' }), /matching standardIds\.m49/);
+  assert.throws(() => model.createEntity({ identityKey: 'm49:840', displayName: 'Bad', type: 'place', standardIds: { m49: '124' } }), /matching standardIds\.m49/);
+  assert.throws(() => model.createEntity({ identityKey: 'm49:84', displayName: 'Bad', type: 'place', standardIds: { m49: '084' } }), /canonical identityKey/);
+  const generic = model.createEntity({ identityKey: 'm49:840', displayName: 'United States of America', type: 'place', standardIds: { m49: '840', isoAlpha2: 'US', isoAlpha3: 'USA' } });
+  assert.equal(generic.id, us.id);
 });
 
 test('reviewed M49 seed is explicitly partial and has unique standard identifiers', () => {
@@ -65,7 +72,7 @@ test('reviewed M49 seed is explicitly partial and has unique standard identifier
   assert.equal(seed.getSeedPlaceByM49('36').standardIds.isoAlpha2, 'AU');
 });
 
-test('event identity depends on explicit event key rather than mutable title', () => {
+test('event identity depends on explicit event key rather than mutable title and avoids hash collisions', () => {
   const first = model.createEvent({ eventKey: 'incident:example:2026-09-03:001', title: 'Initial title', eventType: 'incident', status: 'developing', articleIds: ['article-b', 'article-a', 'article-a'], unknowns: ['cause', 'cause'] });
   const revised = model.createEvent({ eventKey: 'incident:example:2026-09-03:001', title: 'Revised title', eventType: 'incident', status: 'confirmed' });
   const distinct = model.createEvent({ eventKey: 'incident:example:2026-09-03:002', title: 'Initial title', eventType: 'incident', status: 'developing' });
@@ -73,6 +80,7 @@ test('event identity depends on explicit event key rather than mutable title', (
   assert.notEqual(first.id, distinct.id);
   assert.deepEqual(first.articleIds, ['article-a', 'article-b']);
   assert.deepEqual(first.unknowns, ['cause']);
+  assert.notEqual(model.makeStableEventId('krrteh2tr'), model.makeStableEventId('k8x9t7fdm'));
 });
 
 test('graph permits many-to-many article relations but rejects orphan and wrong-type place references', () => {
@@ -88,6 +96,20 @@ test('graph permits many-to-many article relations but rejects orphan and wrong-
   assert.equal(result.orphanEntityRefs.length, 1);
   assert.equal(result.orphanPlaceRefs.length, 1);
   assert.equal(result.nonPlaceRefs.length, 1);
+});
+
+test('graph validates entity country links instead of accepting dangling or non-place references', () => {
+  const place = seed.getSeedPlaceByIsoAlpha2('US');
+  const person = entity('person:test:country');
+  const validCompany = model.createEntity({ identityKey: 'company:test:valid', displayName: 'Valid Co', type: 'company', countryEntityId: place.id });
+  assert.equal(model.validateIntelligenceGraph({ entities: [place, validCompany] }).valid, true);
+
+  const missing = model.createEntity({ identityKey: 'company:test:missing', displayName: 'Missing Co', type: 'company', countryEntityId: 'place:missing' });
+  const wrongType = model.createEntity({ identityKey: 'company:test:wrong', displayName: 'Wrong Co', type: 'company', countryEntityId: person.id });
+  const result = model.validateIntelligenceGraph({ entities: [place, person, missing, wrongType] });
+  assert.equal(result.valid, false);
+  assert.equal(result.orphanCountryRefs.length, 1);
+  assert.equal(result.nonPlaceCountryRefs.length, 1);
 });
 
 test('/api/intelligence/schema exposes identity rules without claiming a complete country set', async () => {

--- a/tools/verify-intelligence-prod.js
+++ b/tools/verify-intelligence-prod.js
@@ -17,16 +17,11 @@ async function fetchJson(path) {
     },
     signal: AbortSignal.timeout(TIMEOUT_MS),
   });
-
-  if (response.status !== 200) {
-    throw new Error(`${path} returned HTTP ${response.status}`);
-  }
-
+  if (response.status !== 200) throw new Error(`${path} returned HTTP ${response.status}`);
   const contentType = response.headers.get('content-type') || '';
   if (!contentType.includes('application/json')) {
     throw new Error(`${path} returned unexpected content-type ${contentType}`);
   }
-
   return response.json();
 }
 
@@ -35,37 +30,36 @@ function requireCondition(condition, message) {
 }
 
 (async () => {
-  const [coverage, sources] = await Promise.all([
+  const [coverage, sources, schema] = await Promise.all([
     fetchJson('/api/news/coverage'),
     fetchJson('/api/news/sources'),
+    fetchJson('/api/intelligence/schema'),
   ]);
 
   requireCondition(typeof coverage.sourceFingerprint === 'string', 'coverage fingerprint missing');
   requireCondition(typeof sources.sourceFingerprint === 'string', 'sources fingerprint missing');
-  requireCondition(
-    coverage.sourceFingerprint === sources.sourceFingerprint,
-    'coverage and source provenance fingerprints disagree'
-  );
+  requireCondition(coverage.sourceFingerprint === sources.sourceFingerprint, 'coverage and source provenance fingerprints disagree');
   requireCondition(coverage.provenance?.valid === true, 'coverage provenance validation failed');
   requireCondition(sources.validation?.valid === true, 'source registry validation failed');
   requireCondition(Number.isInteger(coverage.totalSources), 'coverage totalSources missing');
   requireCondition(Number.isInteger(sources.totalSources), 'sources totalSources missing');
   requireCondition(Array.isArray(sources.sources), 'sources array missing');
   requireCondition(Array.isArray(coverage.gaps), 'coverage gaps array missing');
-  requireCondition(
-    coverage.totalSources === sources.totalSources && sources.totalSources === sources.sources.length,
-    'source counts disagree across intelligence APIs'
-  );
-  requireCondition(
-    sources.sources.every(source =>
-      Array.isArray(source.evidenceUrls) && source.evidenceUrls.length > 0
-    ),
-    'one or more source provenance records lack evidence URLs'
-  );
+  requireCondition(coverage.totalSources === sources.totalSources && sources.totalSources === sources.sources.length, 'source counts disagree across intelligence APIs');
+  requireCondition(sources.sources.every(source => Array.isArray(source.evidenceUrls) && source.evidenceUrls.length > 0), 'one or more source provenance records lack evidence URLs');
 
-  console.log(
-    `Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} active coverage gaps, fingerprint ${coverage.sourceFingerprint}`
-  );
+  requireCondition(typeof schema.modelVersion === 'string', 'intelligence model version missing');
+  requireCondition(Array.isArray(schema.entityTypes) && schema.entityTypes.includes('place'), 'place entity type missing');
+  requireCondition(Array.isArray(schema.eventStatuses) && schema.eventStatuses.includes('disputed'), 'event status contract missing');
+  requireCondition(schema.identityRules?.automaticNameMerge === false, 'automatic name merge must remain disabled');
+  requireCondition(schema.identityRules?.ambiguousAliasResolution === 'ambiguous', 'ambiguous alias contract changed');
+  requireCondition(schema.identityRules?.aliasesRequireEvidence === true, 'alias evidence contract changed');
+  requireCondition(schema.identityRules?.placeIdentityStandard === 'UN M49', 'place identity standard changed');
+  requireCondition(schema.placeSeed?.complete === false, 'partial place seed must not claim completeness');
+  requireCondition(Number.isInteger(schema.placeSeed?.count) && schema.placeSeed.count > 0, 'place seed count missing');
+  requireCondition(schema.placeSeed?.runtimeFetchRequired === false, 'production must not depend on live M49 fetching');
+
+  console.log(`Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} reviewed place identities, model ${schema.modelVersion}`);
 })().catch(error => {
   console.error(`Intelligence API verification failed: ${error.message}`);
   process.exit(1);


### PR DESCRIPTION
## Phase II — Canonical entity/event identity

Builds the durable identity layer needed for place-aware intelligence and the later claims/evidence graph.

### What changes
- Adds explicit stable entity identities for people, organizations, public bodies, companies, places, and multilateral bodies.
- Adds explicit stable event identities derived from a durable event key rather than mutable headline/title prose.
- Adds evidence-backed alias records and ambiguity-safe alias resolution (`matched`, `ambiguous`, `no-match`).
- Rejects aliases without evidence instead of accepting unreviewed alternate names.
- Adds graph integrity checks for duplicate identities, orphan entity/place links, and non-place references used as geography.
- Adds an initial reviewed UN M49-backed place seed for the 16 countries represented by current live-source provenance origins. The seed is deliberately marked partial and is not presented as a complete country directory.
- Keeps capitals, languages, coordinates, culture, and political/legal context outside the place identity key so those facts can carry their own provenance.
- Adds `GET /api/intelligence/schema` exposing model enums, identity rules, and partial-place-seed metadata.
- Adds adversarial/deterministic contracts for same-name false merges, alias ambiguity, M49 validation, mutable event titles, many-to-many article links, unknown preservation, and graph integrity.
- Extends the existing production intelligence verifier so the schema must preserve no-auto-merge, alias-evidence, UN M49, partial-seed, and no-live-M49-fetch guarantees after deployment.

### Geography boundary
UN M49 is source material for committed/reviewed identity data, not a runtime dependency. The initial seed covers current source-origin countries only (`complete: false`). A full reviewed import can expand this without changing the identity contract.

### Legacy globe boundary
This tranche establishes the canonical place IDs that the existing webcam/worldmap data can later reference. It does not silently reinterpret free-text webcam locations or mutate webcam identities.

### Explicit non-goals
No LLM entity extraction, fuzzy automatic merges, AI-written story prose, truth/reliability scores, claim resolution, or automatic headline clustering.

Closes #15 after merge.