### PR TITLE
GD-015: Add claim and primary-evidence model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,17 @@ jobs:
           node --check functions/api/news/coverage.js
           node --check functions/api/news/sources.js
           node --check functions/api/intelligence/schema.js
+          node --check functions/api/intelligence/evidence-schema.js
           node --check functions/lib/news-coverage.js
           node --check functions/lib/news-source-provenance.js
           node --check functions/lib/intelligence-model.js
           node --check functions/lib/m49-place-seed.js
+          node --check functions/lib/claim-evidence-model.js
+          node --check functions/lib/institutional-evidence-sources.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
           node --check tests/intelligence-model.test.mjs
+          node --check tests/claim-evidence-model.test.mjs
 
       - name: Lint JavaScript
         run: npm run lint

--- a/docs/phase2-claim-evidence-model.md
+++ b/docs/phase2-claim-evidence-model.md
@@ -1,0 +1,136 @@
+# Phase II — Claim and Primary-Evidence Model
+
+GD-015 adds the evidence-state layer between GlobalDeets' canonical entity/event identity and future evidence dossiers.
+
+## Purpose
+
+The model records what a source actually asserts, what primary evidence is available, and how claims/evidence relate without reducing disagreement to a synthetic truth or reliability score.
+
+The governing boundary is:
+
+- reporting is a claim origin;
+- an issuing institution can produce primary evidence;
+- corroboration requires a genuinely distinct originating source;
+- contradiction is preserved rather than resolved by hidden weighting;
+- supersession appends history rather than deleting earlier records;
+- unknown/unreviewed evidence state remains explicit.
+
+## Claim identity
+
+Claims require an explicit `claimKey` plus `originSourceId`. The proposition text is not the identity boundary, so wording can be corrected without changing the durable claim ID. Two publishers making textually similar assertions do not collapse into one claim.
+
+Supported claim types:
+
+- `fact-assertion`
+- `estimate`
+- `forecast`
+- `allegation`
+- `denial`
+- `official-position`
+
+Supported evidence states:
+
+- `unreviewed`
+- `single-source`
+- `corroborated`
+- `contradicted`
+- `superseded`
+- `withdrawn`
+
+These states describe the evidence record. They are not declarations of truth.
+
+## Evidence identity
+
+Evidence records require:
+
+- explicit `evidenceKey`
+- issuing canonical entity
+- canonical document/reference URL
+- document type
+- provenance reference(s)
+- optional immutable reference
+- publication/effective/retrieval/review timestamps
+- links to relevant events, entities, places, and claims
+
+Primary-document types include court filings, judgments, government/regulator releases, election records, sanctions notices, central-bank/statistical releases, multilateral publications, corporate filings, datasets, official records, and other reviewed primary material.
+
+## Relationship model
+
+Claim-to-claim relationships support:
+
+- `corroborates`
+- `contradicts`
+- `supersedes`
+
+Evidence-to-claim relationships support:
+
+- `supports`
+- `contradicts`
+- `supersedes`
+
+The graph validator rejects an attempted `corroborates` relationship when both claims originate from the same source. A source cannot manufacture independent corroboration by repeating itself.
+
+## Existing Knowledge catalog reuse
+
+GlobalDeets already has `data/knowledge-sources.json`. GD-015 does not replace it or clone it into a second public directory.
+
+Instead, `functions/lib/institutional-evidence-sources.js` adds a reviewed classification overlay keyed back to exact existing Knowledge entries. The initial overlay is intentionally partial and contains ten high-value institutional candidates spanning multilateral organizations, public data portals, statistical offices, regulators, and health authorities.
+
+The overlay records:
+
+- exact Knowledge catalog reference
+- canonical organization/entity ID
+- source class
+- evidence role
+- jurisdiction/scope
+- document types
+- canonical base URL
+- machine-readable endpoint list
+- authentication/licensing review state
+- classification evidence URL(s)
+- review date/status
+
+## Directory identity is not collection authority
+
+Every initial GD-015 institutional source is `directory-only` and `collectionEligible: false`.
+
+The machine-readable endpoint arrays are deliberately empty. A website/data-directory URL does not become a feed/API ingestion endpoint by implication. Future endpoint admission must separately establish endpoint identity, authority, authentication, usage/licensing requirements, and technical health before collection can be enabled.
+
+This also means the Knowledge catalog itself is **not** an ingestion authority.
+
+## Integrity contracts
+
+CI covers:
+
+- deterministic claim/evidence IDs
+- mutable proposition wording without identity drift
+- same proposition from different sources remaining distinct
+- contradictory claims coexisting
+- same-source fake corroboration rejection
+- evidence provenance requirement
+- orphan claim/evidence/entity/place/event detection
+- non-place geography references
+- supersession preserving historical records
+- exact reuse of existing Knowledge catalog entries
+- zero collection-eligible institutional endpoints in this gate
+- public schema boundary and no-truth-score/no-bulk-collection invariants
+
+## Public schema
+
+`GET /api/intelligence/evidence-schema` publishes the deterministic enums and safety boundaries required by future dossier/collection work. Production verification requires the endpoint to preserve the no-truth-score, independent-corroboration, history-preservation, Knowledge-boundary, endpoint-review, and no-bulk-collection rules.
+
+## Explicit non-goals
+
+GD-015 does not enable:
+
+- bulk evidence collection
+- LLM factual conclusions treated as evidence
+- automatic legal interpretation
+- automatic truth determination
+- publisher reliability or political-bias scores
+- silent conflict resolution
+- automatic promotion of Knowledge entries into ingestion sources
+
+## Downstream
+
+GD-016 should consume these records to build the first source-first evidence dossier: timeline, geography, entities, claims, primary evidence, independent corroboration, contradiction, superseded information, and unresolved unknowns.

--- a/docs/phase2-claim-evidence-model.md
+++ b/docs/phase2-claim-evidence-model.md
@@ -11,8 +11,8 @@ The governing boundary is:
 - reporting is a claim origin;
 - an issuing institution can produce primary evidence;
 - corroboration requires a genuinely distinct originating source;
-- contradiction is preserved rather than resolved by hidden weighting;
-- supersession appends history rather than deleting earlier records;
+- contradiction/dispute is preserved rather than resolved by hidden weighting;
+- claim and evidence supersession append history rather than deleting earlier records;
 - unknown/unreviewed evidence state remains explicit.
 
 ## Claim identity
@@ -34,6 +34,7 @@ Supported evidence states:
 - `single-source`
 - `corroborated`
 - `contradicted`
+- `disputed`
 - `superseded`
 - `withdrawn`
 
@@ -51,6 +52,9 @@ Evidence records require:
 - optional immutable reference
 - publication/effective/retrieval/review timestamps
 - links to relevant events, entities, places, and claims
+- optional `supersedesEvidenceIds` links to earlier evidence records
+
+The explicit evidence key and issuer—not the mutable URL—form the identity boundary. An evidence document can move to a new canonical URL without becoming a different record. A later document can supersede an earlier one while both remain addressable.
 
 Primary-document types include court filings, judgments, government/regulator releases, election records, sanctions notices, central-bank/statistical releases, multilateral publications, corporate filings, datasets, official records, and other reviewed primary material.
 
@@ -90,6 +94,8 @@ The overlay records:
 - classification evidence URL(s)
 - review date/status
 
+A catalog item has no evidence-source authority until that exact category/name/URL tuple appears in the reviewed overlay. Entries that remain only in Knowledge are still useful discovery resources, but are not admitted evidence sources.
+
 ## Directory identity is not collection authority
 
 Every initial GD-015 institutional source is `directory-only` and `collectionEligible: false`.
@@ -103,15 +109,17 @@ This also means the Knowledge catalog itself is **not** an ingestion authority.
 CI covers:
 
 - deterministic claim/evidence IDs
-- mutable proposition wording without identity drift
+- mutable proposition and evidence URL wording without identity drift
 - same proposition from different sources remaining distinct
-- contradictory claims coexisting
+- disputed/contradictory claims coexisting
 - same-source fake corroboration rejection
 - evidence provenance requirement
 - orphan claim/evidence/entity/place/event detection
+- orphan evidence-supersession detection
 - non-place geography references
-- supersession preserving historical records
+- claim and evidence supersession preserving historical records
 - exact reuse of existing Knowledge catalog entries
+- unreviewed Knowledge candidates remaining ineligible
 - zero collection-eligible institutional endpoints in this gate
 - public schema boundary and no-truth-score/no-bulk-collection invariants
 

--- a/functions/api/intelligence/evidence-schema.js
+++ b/functions/api/intelligence/evidence-schema.js
@@ -1,0 +1,65 @@
+// Cloudflare Pages Function - GET /api/intelligence/evidence-schema
+import {
+  CLAIM_EVIDENCE_MODEL_VERSION,
+  CLAIM_RELATION_TYPES,
+  CLAIM_STATES,
+  CLAIM_TYPES,
+  EVIDENCE_DOCUMENT_TYPES,
+  EVIDENCE_RELATION_TYPES,
+} from '../../lib/claim-evidence-model.js';
+import {
+  COLLECTION_STATES,
+  INSTITUTIONAL_EVIDENCE_ROLES,
+  institutionalRegistrySummary,
+} from '../../lib/institutional-evidence-sources.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+function headers(request) {
+  const origin = request?.headers?.get('Origin');
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=3600',
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: headers(request) });
+}
+
+export async function onRequestGet({ request }) {
+  return new Response(
+    JSON.stringify({
+      modelVersion: CLAIM_EVIDENCE_MODEL_VERSION,
+      claimTypes: CLAIM_TYPES,
+      claimStates: CLAIM_STATES,
+      evidenceDocumentTypes: EVIDENCE_DOCUMENT_TYPES,
+      claimRelationTypes: CLAIM_RELATION_TYPES,
+      evidenceRelationTypes: EVIDENCE_RELATION_TYPES,
+      institutionalEvidenceRoles: INSTITUTIONAL_EVIDENCE_ROLES,
+      collectionStates: COLLECTION_STATES,
+      rules: {
+        truthScore: false,
+        explicitClaimIdentity: true,
+        explicitEvidenceIdentity: true,
+        contradictoryClaimsMayCoexist: true,
+        independentCorroborationRequiresDistinctOriginSource: true,
+        supersessionDeletesHistory: false,
+        knowledgeCatalogIsIngestionAuthority: false,
+        machineReadableEndpointRequiresSeparateReview: true,
+        bulkCollectionEnabled: false,
+      },
+      institutionalSources: institutionalRegistrySummary(),
+    }),
+    { headers: headers(request) }
+  );
+}

--- a/functions/lib/claim-evidence-model.js
+++ b/functions/lib/claim-evidence-model.js
@@ -1,5 +1,5 @@
 // Deterministic claim/evidence primitives. Evidence state is explicit; this module never computes a truth score.
-export const CLAIM_EVIDENCE_MODEL_VERSION = '2026-09-03.1';
+export const CLAIM_EVIDENCE_MODEL_VERSION = '2026-09-03.2';
 
 export const CLAIM_TYPES = Object.freeze([
   'fact-assertion',
@@ -15,6 +15,7 @@ export const CLAIM_STATES = Object.freeze([
   'single-source',
   'corroborated',
   'contradicted',
+  'disputed',
   'superseded',
   'withdrawn',
 ]);
@@ -79,9 +80,12 @@ export function createEvidence(definition) {
   oneOf(definition.documentType, EVIDENCE_DOCUMENT_TYPE_SET, 'evidence.documentType');
   const provenanceRefs = stringList(definition.provenanceRefs ?? []);
   if (!provenanceRefs.length) throw new TypeError('evidence.provenanceRefs must not be empty');
+  const id = makeStableEvidenceId(definition.issuerEntityId, definition.evidenceKey);
+  const supersedesEvidenceIds = stringList(definition.supersedesEvidenceIds ?? []);
+  if (supersedesEvidenceIds.includes(id)) throw new TypeError('evidence cannot supersede itself');
 
   return Object.freeze({
-    id: makeStableEvidenceId(definition.issuerEntityId, definition.evidenceKey),
+    id,
     evidenceKey: definition.evidenceKey,
     issuerEntityId: definition.issuerEntityId,
     canonicalRef: definition.canonicalRef,
@@ -93,6 +97,7 @@ export function createEvidence(definition) {
     entityIds: stringList(definition.entityIds ?? []),
     placeEntityIds: stringList(definition.placeEntityIds ?? []),
     claimIds: stringList(definition.claimIds ?? []),
+    supersedesEvidenceIds,
     provenanceRefs,
     retrievedAt: optionalText(definition.retrievedAt, 'evidence.retrievedAt'),
     reviewedAt: optionalText(definition.reviewedAt, 'evidence.reviewedAt'),
@@ -171,6 +176,7 @@ export function validateClaimEvidenceGraph({
     orphanEvidencePlaceRefs: [],
     nonPlaceEvidenceRefs: [],
     orphanEvidenceClaimRefs: [],
+    orphanSupersededEvidenceRefs: [],
     orphanClaimRelationRefs: [],
     orphanClaimRelationEvidenceRefs: [],
     nonIndependentCorroborationRefs: [],
@@ -198,6 +204,9 @@ export function validateClaimEvidenceGraph({
       else if (entity.type !== 'place') result.nonPlaceEvidenceRefs.push(`${item.id}:${id}`);
     }
     for (const id of item.claimIds || []) if (!claimById.has(id)) result.orphanEvidenceClaimRefs.push(`${item.id}:${id}`);
+    for (const id of item.supersedesEvidenceIds || []) {
+      if (!evidenceById.has(id)) result.orphanSupersededEvidenceRefs.push(`${item.id}:${id}`);
+    }
   }
 
   for (const relation of claimRelations) {
@@ -244,6 +253,7 @@ function validEvidence(item) {
       typeof item.issuerEntityId === 'string' &&
       typeof item.canonicalRef === 'string' &&
       EVIDENCE_DOCUMENT_TYPE_SET.has(item.documentType) &&
+      Array.isArray(item.supersedesEvidenceIds) &&
       Array.isArray(item.provenanceRefs) &&
       item.provenanceRefs.length > 0 &&
       item.id === makeStableEvidenceId(item.issuerEntityId, item.evidenceKey)

--- a/functions/lib/claim-evidence-model.js
+++ b/functions/lib/claim-evidence-model.js
@@ -1,0 +1,285 @@
+// Deterministic claim/evidence primitives. Evidence state is explicit; this module never computes a truth score.
+export const CLAIM_EVIDENCE_MODEL_VERSION = '2026-09-03.1';
+
+export const CLAIM_TYPES = Object.freeze([
+  'fact-assertion',
+  'estimate',
+  'forecast',
+  'allegation',
+  'denial',
+  'official-position',
+]);
+
+export const CLAIM_STATES = Object.freeze([
+  'unreviewed',
+  'single-source',
+  'corroborated',
+  'contradicted',
+  'superseded',
+  'withdrawn',
+]);
+
+export const EVIDENCE_DOCUMENT_TYPES = Object.freeze([
+  'court-filing',
+  'judgment',
+  'government-release',
+  'regulator-release',
+  'election-record',
+  'sanctions-notice',
+  'central-bank-release',
+  'statistical-release',
+  'multilateral-publication',
+  'corporate-filing',
+  'dataset',
+  'official-record',
+  'other-primary',
+]);
+
+export const CLAIM_RELATION_TYPES = Object.freeze(['corroborates', 'contradicts', 'supersedes']);
+export const EVIDENCE_RELATION_TYPES = Object.freeze(['supports', 'contradicts', 'supersedes']);
+
+const CLAIM_TYPE_SET = new Set(CLAIM_TYPES);
+const CLAIM_STATE_SET = new Set(CLAIM_STATES);
+const EVIDENCE_DOCUMENT_TYPE_SET = new Set(EVIDENCE_DOCUMENT_TYPES);
+const CLAIM_RELATION_TYPE_SET = new Set(CLAIM_RELATION_TYPES);
+const EVIDENCE_RELATION_TYPE_SET = new Set(EVIDENCE_RELATION_TYPES);
+
+export function createClaim(definition) {
+  object(definition, 'claim definition');
+  text(definition.claimKey, 'claim.claimKey');
+  text(definition.proposition, 'claim.proposition');
+  text(definition.originSourceId, 'claim.originSourceId');
+  text(definition.originRef, 'claim.originRef');
+  oneOf(definition.type, CLAIM_TYPE_SET, 'claim.type');
+  oneOf(definition.state, CLAIM_STATE_SET, 'claim.state');
+
+  return Object.freeze({
+    id: makeStableClaimId(definition.originSourceId, definition.claimKey),
+    claimKey: definition.claimKey,
+    proposition: definition.proposition,
+    type: definition.type,
+    state: definition.state,
+    originSourceId: definition.originSourceId,
+    originRef: definition.originRef,
+    sourceWording: optionalText(definition.sourceWording, 'claim.sourceWording'),
+    eventIds: stringList(definition.eventIds ?? []),
+    entityIds: stringList(definition.entityIds ?? []),
+    placeEntityIds: stringList(definition.placeEntityIds ?? []),
+    assertedAt: optionalText(definition.assertedAt, 'claim.assertedAt'),
+    createdAt: optionalText(definition.createdAt, 'claim.createdAt'),
+    reviewedAt: optionalText(definition.reviewedAt, 'claim.reviewedAt'),
+  });
+}
+
+export function createEvidence(definition) {
+  object(definition, 'evidence definition');
+  text(definition.evidenceKey, 'evidence.evidenceKey');
+  text(definition.issuerEntityId, 'evidence.issuerEntityId');
+  text(definition.canonicalRef, 'evidence.canonicalRef');
+  oneOf(definition.documentType, EVIDENCE_DOCUMENT_TYPE_SET, 'evidence.documentType');
+  const provenanceRefs = stringList(definition.provenanceRefs ?? []);
+  if (!provenanceRefs.length) throw new TypeError('evidence.provenanceRefs must not be empty');
+
+  return Object.freeze({
+    id: makeStableEvidenceId(definition.issuerEntityId, definition.evidenceKey),
+    evidenceKey: definition.evidenceKey,
+    issuerEntityId: definition.issuerEntityId,
+    canonicalRef: definition.canonicalRef,
+    immutableRef: optionalText(definition.immutableRef, 'evidence.immutableRef'),
+    documentType: definition.documentType,
+    publishedAt: optionalText(definition.publishedAt, 'evidence.publishedAt'),
+    effectiveAt: optionalText(definition.effectiveAt, 'evidence.effectiveAt'),
+    eventIds: stringList(definition.eventIds ?? []),
+    entityIds: stringList(definition.entityIds ?? []),
+    placeEntityIds: stringList(definition.placeEntityIds ?? []),
+    claimIds: stringList(definition.claimIds ?? []),
+    provenanceRefs,
+    retrievedAt: optionalText(definition.retrievedAt, 'evidence.retrievedAt'),
+    reviewedAt: optionalText(definition.reviewedAt, 'evidence.reviewedAt'),
+  });
+}
+
+export function createClaimRelation(definition) {
+  object(definition, 'claim relation definition');
+  text(definition.claimId, 'claimRelation.claimId');
+  text(definition.relatedClaimId, 'claimRelation.relatedClaimId');
+  if (definition.claimId === definition.relatedClaimId) {
+    throw new TypeError('claim relation cannot reference the same claim twice');
+  }
+  oneOf(definition.relation, CLAIM_RELATION_TYPE_SET, 'claimRelation.relation');
+  return Object.freeze({
+    id: `claim-relation:${encode(definition.relation)}:${encode(definition.claimId)}:${encode(definition.relatedClaimId)}`,
+    claimId: definition.claimId,
+    relatedClaimId: definition.relatedClaimId,
+    relation: definition.relation,
+    evidenceIds: stringList(definition.evidenceIds ?? []),
+    reviewedAt: optionalText(definition.reviewedAt, 'claimRelation.reviewedAt'),
+  });
+}
+
+export function createEvidenceRelation(definition) {
+  object(definition, 'evidence relation definition');
+  text(definition.claimId, 'evidenceRelation.claimId');
+  text(definition.evidenceId, 'evidenceRelation.evidenceId');
+  oneOf(definition.relation, EVIDENCE_RELATION_TYPE_SET, 'evidenceRelation.relation');
+  return Object.freeze({
+    id: `evidence-relation:${encode(definition.relation)}:${encode(definition.claimId)}:${encode(definition.evidenceId)}`,
+    claimId: definition.claimId,
+    evidenceId: definition.evidenceId,
+    relation: definition.relation,
+    reviewedAt: optionalText(definition.reviewedAt, 'evidenceRelation.reviewedAt'),
+  });
+}
+
+export function makeStableClaimId(originSourceId, claimKey) {
+  text(originSourceId, 'claim.originSourceId');
+  text(claimKey, 'claim.claimKey');
+  return `claim:${encode(originSourceId)}:${encode(claimKey)}`;
+}
+
+export function makeStableEvidenceId(issuerEntityId, evidenceKey) {
+  text(issuerEntityId, 'evidence.issuerEntityId');
+  text(evidenceKey, 'evidence.evidenceKey');
+  return `evidence:${encode(issuerEntityId)}:${encode(evidenceKey)}`;
+}
+
+export function validateClaimEvidenceGraph({
+  entities = [],
+  events = [],
+  claims = [],
+  evidence = [],
+  claimRelations = [],
+  evidenceRelations = [],
+} = {}) {
+  const entityById = new Map(entities.map(entity => [entity.id, entity]));
+  const eventById = new Map(events.map(event => [event.id, event]));
+  const claimById = new Map(claims.map(claim => [claim.id, claim]));
+  const evidenceById = new Map(evidence.map(item => [item.id, item]));
+
+  const result = {
+    duplicateClaimIds: duplicates(claims.map(claim => claim.id)),
+    duplicateEvidenceIds: duplicates(evidence.map(item => item.id)),
+    invalidClaimIds: unique(claims.filter(claim => !validClaim(claim)).map(claim => claim.id || '(missing-id)')),
+    invalidEvidenceIds: unique(evidence.filter(item => !validEvidence(item)).map(item => item.id || '(missing-id)')),
+    orphanClaimEventRefs: [],
+    orphanClaimEntityRefs: [],
+    orphanClaimPlaceRefs: [],
+    nonPlaceClaimRefs: [],
+    orphanEvidenceIssuerRefs: [],
+    orphanEvidenceEventRefs: [],
+    orphanEvidenceEntityRefs: [],
+    orphanEvidencePlaceRefs: [],
+    nonPlaceEvidenceRefs: [],
+    orphanEvidenceClaimRefs: [],
+    orphanClaimRelationRefs: [],
+    orphanClaimRelationEvidenceRefs: [],
+    nonIndependentCorroborationRefs: [],
+    orphanEvidenceRelationClaimRefs: [],
+    orphanEvidenceRelationEvidenceRefs: [],
+  };
+
+  for (const claim of claims) {
+    for (const id of claim.eventIds || []) if (!eventById.has(id)) result.orphanClaimEventRefs.push(`${claim.id}:${id}`);
+    for (const id of claim.entityIds || []) if (!entityById.has(id)) result.orphanClaimEntityRefs.push(`${claim.id}:${id}`);
+    for (const id of claim.placeEntityIds || []) {
+      const entity = entityById.get(id);
+      if (!entity) result.orphanClaimPlaceRefs.push(`${claim.id}:${id}`);
+      else if (entity.type !== 'place') result.nonPlaceClaimRefs.push(`${claim.id}:${id}`);
+    }
+  }
+
+  for (const item of evidence) {
+    if (!entityById.has(item.issuerEntityId)) result.orphanEvidenceIssuerRefs.push(`${item.id}:${item.issuerEntityId}`);
+    for (const id of item.eventIds || []) if (!eventById.has(id)) result.orphanEvidenceEventRefs.push(`${item.id}:${id}`);
+    for (const id of item.entityIds || []) if (!entityById.has(id)) result.orphanEvidenceEntityRefs.push(`${item.id}:${id}`);
+    for (const id of item.placeEntityIds || []) {
+      const entity = entityById.get(id);
+      if (!entity) result.orphanEvidencePlaceRefs.push(`${item.id}:${id}`);
+      else if (entity.type !== 'place') result.nonPlaceEvidenceRefs.push(`${item.id}:${id}`);
+    }
+    for (const id of item.claimIds || []) if (!claimById.has(id)) result.orphanEvidenceClaimRefs.push(`${item.id}:${id}`);
+  }
+
+  for (const relation of claimRelations) {
+    const claim = claimById.get(relation.claimId);
+    const related = claimById.get(relation.relatedClaimId);
+    if (!claim) result.orphanClaimRelationRefs.push(`${relation.id}:${relation.claimId}`);
+    if (!related) result.orphanClaimRelationRefs.push(`${relation.id}:${relation.relatedClaimId}`);
+    for (const id of relation.evidenceIds || []) {
+      if (!evidenceById.has(id)) result.orphanClaimRelationEvidenceRefs.push(`${relation.id}:${id}`);
+    }
+    if (relation.relation === 'corroborates' && claim && related && claim.originSourceId === related.originSourceId) {
+      result.nonIndependentCorroborationRefs.push(relation.id);
+    }
+  }
+
+  for (const relation of evidenceRelations) {
+    if (!claimById.has(relation.claimId)) result.orphanEvidenceRelationClaimRefs.push(`${relation.id}:${relation.claimId}`);
+    if (!evidenceById.has(relation.evidenceId)) result.orphanEvidenceRelationEvidenceRefs.push(`${relation.id}:${relation.evidenceId}`);
+  }
+
+  for (const key of Object.keys(result)) result[key] = unique(result[key]);
+  return { valid: Object.values(result).every(values => values.length === 0), ...result };
+}
+
+function validClaim(claim) {
+  return Boolean(
+    claim &&
+      typeof claim.id === 'string' &&
+      typeof claim.claimKey === 'string' &&
+      typeof claim.proposition === 'string' &&
+      typeof claim.originSourceId === 'string' &&
+      typeof claim.originRef === 'string' &&
+      CLAIM_TYPE_SET.has(claim.type) &&
+      CLAIM_STATE_SET.has(claim.state) &&
+      claim.id === makeStableClaimId(claim.originSourceId, claim.claimKey)
+  );
+}
+
+function validEvidence(item) {
+  return Boolean(
+    item &&
+      typeof item.id === 'string' &&
+      typeof item.evidenceKey === 'string' &&
+      typeof item.issuerEntityId === 'string' &&
+      typeof item.canonicalRef === 'string' &&
+      EVIDENCE_DOCUMENT_TYPE_SET.has(item.documentType) &&
+      Array.isArray(item.provenanceRefs) &&
+      item.provenanceRefs.length > 0 &&
+      item.id === makeStableEvidenceId(item.issuerEntityId, item.evidenceKey)
+  );
+}
+
+function encode(value) {
+  return encodeURIComponent(value);
+}
+function duplicates(values) {
+  const seen = new Set();
+  const repeated = new Set();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated].sort();
+}
+function unique(values) {
+  return [...new Set(values)].sort();
+}
+function stringList(values) {
+  if (!Array.isArray(values)) throw new TypeError('expected an array');
+  return unique(values.filter(value => typeof value === 'string' && value.trim()).map(value => value.trim()));
+}
+function optionalText(value, field) {
+  if (value == null) return null;
+  text(value, field);
+  return value.trim();
+}
+function object(value, field) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError(`${field} must be an object`);
+}
+function text(value, field) {
+  if (typeof value !== 'string' || !value.trim()) throw new TypeError(`${field} must be a non-empty string`);
+}
+function oneOf(value, allowed, field) {
+  if (!allowed.has(value)) throw new TypeError(`${field} is not supported`);
+}

--- a/functions/lib/institutional-evidence-sources.js
+++ b/functions/lib/institutional-evidence-sources.js
@@ -1,0 +1,265 @@
+// Reviewed evidence-role overlay for selected entries in the existing Knowledge catalog.
+// A directory/source identity is not an ingestion endpoint; collection remains disabled until separately reviewed.
+import { createEntity } from './intelligence-model.js';
+
+export const INSTITUTIONAL_REVIEW_DATE = '2026-09-03';
+export const INSTITUTIONAL_EVIDENCE_ROLES = Object.freeze([
+  'issuing-primary',
+  'official-repository',
+  'research-repository',
+  'watchdog',
+  'secondary-reference',
+]);
+export const COLLECTION_STATES = Object.freeze(['directory-only', 'endpoint-reviewed']);
+
+const ROLE_SET = new Set(INSTITUTIONAL_EVIDENCE_ROLES);
+const COLLECTION_STATE_SET = new Set(COLLECTION_STATES);
+
+export const INSTITUTIONAL_ENTITIES = Object.freeze([
+  institution('United Nations', 'multilateral-body', 'institution:un', 'https://www.un.org'),
+  institution('World Bank', 'multilateral-body', 'institution:world-bank', 'https://data.worldbank.org'),
+  institution('European Union Open Data', 'government-public-body', 'institution:eu-open-data', 'https://data.europa.eu'),
+  institution('U.S. General Services Administration', 'government-public-body', 'institution:us-gsa-data-gov', 'https://data.gov'),
+  institution('National Aeronautics and Space Administration', 'government-public-body', 'institution:nasa', 'https://data.nasa.gov'),
+  institution('World Health Organization', 'multilateral-body', 'institution:who', 'https://www.who.int/data/gho'),
+  institution('United States Environmental Protection Agency', 'government-public-body', 'institution:us-epa', 'https://www.epa.gov/environmental-topics'),
+  institution('International Monetary Fund', 'multilateral-body', 'institution:imf', 'https://www.imf.org/en/Data'),
+  institution('Eurostat', 'government-public-body', 'institution:eurostat', 'https://ec.europa.eu/eurostat'),
+  institution('Centers for Disease Control and Prevention', 'government-public-body', 'institution:us-cdc', 'https://www.cdc.gov/datastatistics/index.html'),
+]);
+
+export const REVIEWED_INSTITUTIONAL_SOURCES = Object.freeze([
+  source({
+    sourceId: 'knowledge:governance:united-nations',
+    knowledgeCategoryId: 'governance',
+    knowledgeName: 'United Nations',
+    knowledgeUrl: 'https://www.un.org',
+    organizationEntityId: entityId('institution:un', 'multilateral-body'),
+    sourceClass: 'multilateral-institution',
+    evidenceRole: 'issuing-primary',
+    jurisdiction: 'global',
+    documentTypes: ['government-release', 'multilateral-publication', 'official-record'],
+  }),
+  source({
+    sourceId: 'knowledge:governance:world-bank-open-data',
+    knowledgeCategoryId: 'governance',
+    knowledgeName: 'World Bank Open Data',
+    knowledgeUrl: 'https://data.worldbank.org',
+    organizationEntityId: entityId('institution:world-bank', 'multilateral-body'),
+    sourceClass: 'multilateral-data-portal',
+    evidenceRole: 'official-repository',
+    jurisdiction: 'global',
+    documentTypes: ['dataset', 'statistical-release'],
+  }),
+  source({
+    sourceId: 'knowledge:governance:eu-open-data',
+    knowledgeCategoryId: 'governance',
+    knowledgeName: 'EU Open Data Portal',
+    knowledgeUrl: 'https://data.europa.eu',
+    organizationEntityId: entityId('institution:eu-open-data', 'government-public-body'),
+    sourceClass: 'public-data-portal',
+    evidenceRole: 'official-repository',
+    jurisdiction: 'European Union',
+    documentTypes: ['dataset', 'official-record'],
+  }),
+  source({
+    sourceId: 'knowledge:governance:data-gov',
+    knowledgeCategoryId: 'governance',
+    knowledgeName: 'U.S. Data.gov',
+    knowledgeUrl: 'https://data.gov',
+    organizationEntityId: entityId('institution:us-gsa-data-gov', 'government-public-body'),
+    sourceClass: 'government-data-portal',
+    evidenceRole: 'official-repository',
+    jurisdiction: 'US',
+    documentTypes: ['dataset', 'official-record'],
+  }),
+  source({
+    sourceId: 'knowledge:science:nasa-open-data',
+    knowledgeCategoryId: 'science',
+    knowledgeName: 'NASA Open Data',
+    knowledgeUrl: 'https://data.nasa.gov',
+    organizationEntityId: entityId('institution:nasa', 'government-public-body'),
+    sourceClass: 'government-data-portal',
+    evidenceRole: 'official-repository',
+    jurisdiction: 'US',
+    documentTypes: ['dataset', 'official-record'],
+  }),
+  source({
+    sourceId: 'knowledge:science:who-gho',
+    knowledgeCategoryId: 'science',
+    knowledgeName: 'WHO Global Health Observatory',
+    knowledgeUrl: 'https://www.who.int/data/gho',
+    organizationEntityId: entityId('institution:who', 'multilateral-body'),
+    sourceClass: 'multilateral-health-authority',
+    evidenceRole: 'issuing-primary',
+    jurisdiction: 'global',
+    documentTypes: ['dataset', 'statistical-release', 'multilateral-publication'],
+  }),
+  source({
+    sourceId: 'knowledge:environment:epa-data',
+    knowledgeCategoryId: 'environment',
+    knowledgeName: 'EPA Environmental Data',
+    knowledgeUrl: 'https://www.epa.gov/environmental-topics',
+    organizationEntityId: entityId('institution:us-epa', 'government-public-body'),
+    sourceClass: 'government-regulator',
+    evidenceRole: 'issuing-primary',
+    jurisdiction: 'US',
+    documentTypes: ['dataset', 'regulator-release', 'official-record'],
+  }),
+  source({
+    sourceId: 'knowledge:economy:imf-data',
+    knowledgeCategoryId: 'economy',
+    knowledgeName: 'IMF Data',
+    knowledgeUrl: 'https://www.imf.org/en/Data',
+    organizationEntityId: entityId('institution:imf', 'multilateral-body'),
+    sourceClass: 'multilateral-financial-institution',
+    evidenceRole: 'issuing-primary',
+    jurisdiction: 'global',
+    documentTypes: ['dataset', 'statistical-release', 'multilateral-publication'],
+  }),
+  source({
+    sourceId: 'knowledge:economy:eurostat',
+    knowledgeCategoryId: 'economy',
+    knowledgeName: 'Eurostat',
+    knowledgeUrl: 'https://ec.europa.eu/eurostat',
+    organizationEntityId: entityId('institution:eurostat', 'government-public-body'),
+    sourceClass: 'statistical-office',
+    evidenceRole: 'issuing-primary',
+    jurisdiction: 'European Union',
+    documentTypes: ['dataset', 'statistical-release'],
+  }),
+  source({
+    sourceId: 'knowledge:health:cdc-data',
+    knowledgeCategoryId: 'health',
+    knowledgeName: 'CDC Data & Statistics',
+    knowledgeUrl: 'https://www.cdc.gov/datastatistics/index.html',
+    organizationEntityId: entityId('institution:us-cdc', 'government-public-body'),
+    sourceClass: 'government-health-authority',
+    evidenceRole: 'issuing-primary',
+    jurisdiction: 'US',
+    documentTypes: ['dataset', 'government-release', 'official-record'],
+  }),
+]);
+
+export function validateInstitutionalSourceRegistry(
+  knowledgeCatalog,
+  entities = INSTITUTIONAL_ENTITIES,
+  registry = REVIEWED_INSTITUTIONAL_SOURCES
+) {
+  const catalogRefs = new Set(flattenKnowledgeCatalog(knowledgeCatalog).map(item => knowledgeKey(item.categoryId, item.name, item.url)));
+  const entityIds = new Set(entities.map(entity => entity.id));
+  const sourceIds = registry.map(item => item.sourceId);
+  const knowledgeRefs = registry.map(item => knowledgeKey(item.knowledgeCategoryId, item.knowledgeName, item.knowledgeUrl));
+
+  const duplicateSourceIds = duplicates(sourceIds);
+  const duplicateKnowledgeRefs = duplicates(knowledgeRefs);
+  const missingKnowledgeRefs = registry
+    .filter(item => !catalogRefs.has(knowledgeKey(item.knowledgeCategoryId, item.knowledgeName, item.knowledgeUrl)))
+    .map(item => item.sourceId);
+  const orphanOrganizationRefs = registry
+    .filter(item => !entityIds.has(item.organizationEntityId))
+    .map(item => item.sourceId);
+  const invalidEntries = registry.filter(item => !validSource(item)).map(item => item.sourceId);
+  const unsafeCollectionRefs = registry
+    .filter(item => item.collectionEligible && !item.machineReadableEndpoints.some(endpoint => endpoint.reviewStatus === 'verified'))
+    .map(item => item.sourceId);
+
+  return {
+    valid:
+      duplicateSourceIds.length === 0 &&
+      duplicateKnowledgeRefs.length === 0 &&
+      missingKnowledgeRefs.length === 0 &&
+      orphanOrganizationRefs.length === 0 &&
+      invalidEntries.length === 0 &&
+      unsafeCollectionRefs.length === 0,
+    duplicateSourceIds,
+    duplicateKnowledgeRefs,
+    missingKnowledgeRefs: unique(missingKnowledgeRefs),
+    orphanOrganizationRefs: unique(orphanOrganizationRefs),
+    invalidEntries: unique(invalidEntries),
+    unsafeCollectionRefs: unique(unsafeCollectionRefs),
+  };
+}
+
+export function institutionalRegistrySummary() {
+  return {
+    reviewedSources: REVIEWED_INSTITUTIONAL_SOURCES.length,
+    issuingPrimarySources: REVIEWED_INSTITUTIONAL_SOURCES.filter(item => item.evidenceRole === 'issuing-primary').length,
+    collectionEligibleSources: REVIEWED_INSTITUTIONAL_SOURCES.filter(item => item.collectionEligible).length,
+    knowledgeCatalogIsIngestionAuthority: false,
+    endpointReviewRequired: true,
+  };
+}
+
+function institution(displayName, type, identityKey, evidenceUrl) {
+  return createEntity({
+    displayName,
+    type,
+    identityKey,
+    evidenceRefs: [evidenceUrl],
+    reviewedAt: INSTITUTIONAL_REVIEW_DATE,
+  });
+}
+
+function source(definition) {
+  if (!ROLE_SET.has(definition.evidenceRole)) throw new TypeError('institutional evidence role is not supported');
+  return Object.freeze({
+    ...definition,
+    canonicalBaseUrl: definition.knowledgeUrl,
+    machineReadableEndpoints: Object.freeze([]),
+    collectionState: 'directory-only',
+    collectionEligible: false,
+    authenticationRequirement: 'unknown',
+    licensingRequirement: 'unknown',
+    evidenceUrls: Object.freeze([definition.knowledgeUrl]),
+    reviewStatus: 'reviewed-classification',
+    reviewedAt: INSTITUTIONAL_REVIEW_DATE,
+  });
+}
+
+function validSource(item) {
+  return Boolean(
+    item &&
+      typeof item.sourceId === 'string' &&
+      typeof item.knowledgeCategoryId === 'string' &&
+      typeof item.knowledgeName === 'string' &&
+      typeof item.knowledgeUrl === 'string' &&
+      typeof item.organizationEntityId === 'string' &&
+      ROLE_SET.has(item.evidenceRole) &&
+      COLLECTION_STATE_SET.has(item.collectionState) &&
+      Array.isArray(item.documentTypes) &&
+      item.documentTypes.length > 0 &&
+      Array.isArray(item.evidenceUrls) &&
+      item.evidenceUrls.length > 0 &&
+      Array.isArray(item.machineReadableEndpoints) &&
+      item.reviewStatus === 'reviewed-classification' &&
+      item.collectionEligible === false
+  );
+}
+
+function flattenKnowledgeCatalog(catalog) {
+  if (!Array.isArray(catalog)) throw new TypeError('knowledge catalog must be an array');
+  return catalog.flatMap(category =>
+    (category.sources || []).map(item => ({ categoryId: category.id, name: item.name, url: item.url }))
+  );
+}
+function knowledgeKey(categoryId, name, url) {
+  return `${categoryId}\u001f${name}\u001f${url}`;
+}
+function entityId(identityKey, type) {
+  const match = INSTITUTIONAL_ENTITIES.find(entity => entity.type === type && entity.identityKey === identityKey);
+  if (!match) throw new TypeError(`missing institutional entity ${identityKey}`);
+  return match.id;
+}
+function duplicates(values) {
+  const seen = new Set();
+  const repeated = new Set();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated].sort();
+}
+function unique(values) {
+  return [...new Set(values)].sort();
+}

--- a/functions/lib/institutional-evidence-sources.js
+++ b/functions/lib/institutional-evidence-sources.js
@@ -18,13 +18,13 @@ const COLLECTION_STATE_SET = new Set(COLLECTION_STATES);
 export const INSTITUTIONAL_ENTITIES = Object.freeze([
   institution('United Nations', 'multilateral-body', 'institution:un', 'https://www.un.org'),
   institution('World Bank', 'multilateral-body', 'institution:world-bank', 'https://data.worldbank.org'),
-  institution('European Union Open Data', 'government-public-body', 'institution:eu-open-data', 'https://data.europa.eu'),
-  institution('U.S. General Services Administration', 'government-public-body', 'institution:us-gsa-data-gov', 'https://data.gov'),
+  institution('Publications Office of the European Union', 'government-public-body', 'institution:eu-publications-office', 'https://data.europa.eu/en/legal-notice'),
+  institution('U.S. General Services Administration', 'government-public-body', 'institution:us-gsa-data-gov', 'https://data.gov/about/'),
   institution('National Aeronautics and Space Administration', 'government-public-body', 'institution:nasa', 'https://data.nasa.gov'),
-  institution('World Health Organization', 'multilateral-body', 'institution:who', 'https://www.who.int/data/gho'),
+  institution('World Health Organization', 'multilateral-body', 'institution:who', 'https://www.who.int/data/gho/info/about-the-observatory'),
   institution('United States Environmental Protection Agency', 'government-public-body', 'institution:us-epa', 'https://www.epa.gov/environmental-topics'),
   institution('International Monetary Fund', 'multilateral-body', 'institution:imf', 'https://www.imf.org/en/Data'),
-  institution('Eurostat', 'government-public-body', 'institution:eurostat', 'https://ec.europa.eu/eurostat'),
+  institution('Eurostat', 'government-public-body', 'institution:eurostat', 'https://ec.europa.eu/eurostat/about-us'),
   institution('Centers for Disease Control and Prevention', 'government-public-body', 'institution:us-cdc', 'https://www.cdc.gov/datastatistics/index.html'),
 ]);
 
@@ -56,11 +56,12 @@ export const REVIEWED_INSTITUTIONAL_SOURCES = Object.freeze([
     knowledgeCategoryId: 'governance',
     knowledgeName: 'EU Open Data Portal',
     knowledgeUrl: 'https://data.europa.eu',
-    organizationEntityId: entityId('institution:eu-open-data', 'government-public-body'),
+    organizationEntityId: entityId('institution:eu-publications-office', 'government-public-body'),
     sourceClass: 'public-data-portal',
     evidenceRole: 'official-repository',
     jurisdiction: 'European Union',
     documentTypes: ['dataset', 'official-record'],
+    evidenceUrls: ['https://data.europa.eu/en/legal-notice'],
   }),
   source({
     sourceId: 'knowledge:governance:data-gov',
@@ -72,6 +73,7 @@ export const REVIEWED_INSTITUTIONAL_SOURCES = Object.freeze([
     evidenceRole: 'official-repository',
     jurisdiction: 'US',
     documentTypes: ['dataset', 'official-record'],
+    evidenceUrls: ['https://data.gov/about/'],
   }),
   source({
     sourceId: 'knowledge:science:nasa-open-data',
@@ -94,6 +96,7 @@ export const REVIEWED_INSTITUTIONAL_SOURCES = Object.freeze([
     evidenceRole: 'issuing-primary',
     jurisdiction: 'global',
     documentTypes: ['dataset', 'statistical-release', 'multilateral-publication'],
+    evidenceUrls: ['https://www.who.int/data/gho/info/about-the-observatory'],
   }),
   source({
     sourceId: 'knowledge:environment:epa-data',
@@ -127,6 +130,7 @@ export const REVIEWED_INSTITUTIONAL_SOURCES = Object.freeze([
     evidenceRole: 'issuing-primary',
     jurisdiction: 'European Union',
     documentTypes: ['dataset', 'statistical-release'],
+    evidenceUrls: ['https://ec.europa.eu/eurostat/about-us'],
   }),
   source({
     sourceId: 'knowledge:health:cdc-data',
@@ -140,6 +144,13 @@ export const REVIEWED_INSTITUTIONAL_SOURCES = Object.freeze([
     documentTypes: ['dataset', 'government-release', 'official-record'],
   }),
 ]);
+
+export function findReviewedInstitutionalSource(categoryId, name, url) {
+  const key = knowledgeKey(categoryId, name, url);
+  return REVIEWED_INSTITUTIONAL_SOURCES.find(item =>
+    knowledgeKey(item.knowledgeCategoryId, item.knowledgeName, item.knowledgeUrl) === key
+  ) || null;
+}
 
 export function validateInstitutionalSourceRegistry(
   knowledgeCatalog,
@@ -161,7 +172,10 @@ export function validateInstitutionalSourceRegistry(
     .map(item => item.sourceId);
   const invalidEntries = registry.filter(item => !validSource(item)).map(item => item.sourceId);
   const unsafeCollectionRefs = registry
-    .filter(item => item.collectionEligible && !item.machineReadableEndpoints.some(endpoint => endpoint.reviewStatus === 'verified'))
+    .filter(item => item.collectionEligible && (
+      item.collectionState !== 'endpoint-reviewed' ||
+      !item.machineReadableEndpoints.some(endpoint => endpoint.reviewStatus === 'verified')
+    ))
     .map(item => item.sourceId);
 
   return {
@@ -211,13 +225,17 @@ function source(definition) {
     collectionEligible: false,
     authenticationRequirement: 'unknown',
     licensingRequirement: 'unknown',
-    evidenceUrls: Object.freeze([definition.knowledgeUrl]),
+    evidenceUrls: Object.freeze([...(definition.evidenceUrls ?? [definition.knowledgeUrl])]),
     reviewStatus: 'reviewed-classification',
     reviewedAt: INSTITUTIONAL_REVIEW_DATE,
   });
 }
 
 function validSource(item) {
+  const collectionContractValid = !item.collectionEligible || (
+    item.collectionState === 'endpoint-reviewed' &&
+    item.machineReadableEndpoints.some(endpoint => endpoint.reviewStatus === 'verified')
+  );
   return Boolean(
     item &&
       typeof item.sourceId === 'string' &&
@@ -233,7 +251,7 @@ function validSource(item) {
       item.evidenceUrls.length > 0 &&
       Array.isArray(item.machineReadableEndpoints) &&
       item.reviewStatus === 'reviewed-classification' &&
-      item.collectionEligible === false
+      collectionContractValid
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/intelligence-model.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/tests/claim-evidence-model.test.mjs
+++ b/tests/claim-evidence-model.test.mjs
@@ -209,13 +209,15 @@ test('supersession preserves both historical claims and evidence records instead
   assert.deepEqual(newEvidence.supersedesEvidenceIds, [oldEvidence.id]);
 });
 
-test('reviewed institutional overlay reuses exact Knowledge catalog entries but authorizes no collection endpoints', () => {
+test('reviewed institutional overlay reuses exact Knowledge catalog entries but unreviewed candidates stay ineligible', () => {
   const validation = institutions.validateInstitutionalSourceRegistry(knowledgeCatalog);
   assert.equal(validation.valid, true);
   assert.equal(institutions.REVIEWED_INSTITUTIONAL_SOURCES.length, 10);
   assert.equal(institutions.REVIEWED_INSTITUTIONAL_SOURCES.every(item => item.collectionEligible === false), true);
   assert.equal(institutions.REVIEWED_INSTITUTIONAL_SOURCES.every(item => item.machineReadableEndpoints.length === 0), true);
   assert.ok(institutions.REVIEWED_INSTITUTIONAL_SOURCES.some(item => item.evidenceRole === 'issuing-primary'));
+  assert.ok(institutions.findReviewedInstitutionalSource('governance', 'United Nations', 'https://www.un.org'));
+  assert.equal(institutions.findReviewedInstitutionalSource('education', 'Wikipedia', 'https://www.wikipedia.org'), null);
   assert.equal(institutions.institutionalRegistrySummary().knowledgeCatalogIsIngestionAuthority, false);
 });
 

--- a/tests/claim-evidence-model.test.mjs
+++ b/tests/claim-evidence-model.test.mjs
@@ -66,13 +66,14 @@ test('claim identity is explicit and survives proposition edits without collapsi
   assert.notEqual(first.proposition, revised.proposition);
 });
 
-test('contradictory claims coexist and no relation chooses a silent winner', () => {
-  const yes = claim('source-a', 'claim-yes', 'The event occurred.', 'contradicted');
-  const no = claim('source-b', 'claim-no', 'The event did not occur.', 'corroborated');
+test('disputed and contradictory claims coexist and no relation chooses a silent winner', () => {
+  const yes = claim('source-a', 'claim-yes', 'The event occurred.', 'disputed');
+  const no = claim('source-b', 'claim-no', 'The event did not occur.', 'contradicted');
   const relation = model.createClaimRelation({ claimId: yes.id, relatedClaimId: no.id, relation: 'contradicts' });
   const result = model.validateClaimEvidenceGraph({ claims: [yes, no], claimRelations: [relation] });
   assert.equal(result.valid, true);
   assert.equal(new Set([yes.id, no.id]).size, 2);
+  assert.ok(model.CLAIM_STATES.includes('disputed'));
 });
 
 test('corroboration must come from a distinct origin source', () => {
@@ -99,7 +100,16 @@ test('primary evidence requires issuer, canonical reference, provenance, and ins
     claimIds: [assertion.id],
     provenanceRefs: ['https://www.un.org'],
   });
+  const movedReference = model.createEvidence({
+    evidenceKey: 'resolution:example:1',
+    issuerEntityId: issuer.id,
+    canonicalRef: 'https://www.un.org/example-resolution-new-location',
+    documentType: 'multilateral-publication',
+    claimIds: [assertion.id],
+    provenanceRefs: ['https://www.un.org'],
+  });
   const link = model.createEvidenceRelation({ claimId: assertion.id, evidenceId: document.id, relation: 'supports' });
+  assert.equal(document.id, movedReference.id);
   assert.equal(model.validateClaimEvidenceGraph({ entities: [issuer], claims: [assertion], evidence: [document], evidenceRelations: [link] }).valid, true);
   assert.throws(
     () => model.createEvidence({ evidenceKey: 'bad', issuerEntityId: issuer.id, canonicalRef: 'https://example.com/bad', documentType: 'official-record' }),
@@ -107,7 +117,7 @@ test('primary evidence requires issuer, canonical reference, provenance, and ins
   );
 });
 
-test('claim/evidence graph rejects orphan entities, places, events, issuers, claims, and evidence links', () => {
+test('claim/evidence graph rejects orphan entities, places, events, issuers, claims, superseded evidence, and evidence links', () => {
   const { place, person, issuer, event } = basicGraph();
   const good = model.createClaim({
     originSourceId: 'source-a',
@@ -140,6 +150,7 @@ test('claim/evidence graph rejects orphan entities, places, events, issuers, cla
     entityIds: ['entity:missing'],
     placeEntityIds: ['place:missing', person.id],
     claimIds: ['claim:missing'],
+    supersedesEvidenceIds: ['evidence:missing'],
     provenanceRefs: [EVIDENCE_URL],
   });
   const missingEvidenceLink = model.createEvidenceRelation({ claimId: good.id, evidenceId: 'evidence:missing', relation: 'supports' });
@@ -157,18 +168,45 @@ test('claim/evidence graph rejects orphan entities, places, events, issuers, cla
   assert.equal(result.nonPlaceClaimRefs.length, 1);
   assert.equal(result.orphanEvidenceIssuerRefs.length, 1);
   assert.equal(result.orphanEvidenceClaimRefs.length, 1);
+  assert.equal(result.orphanSupersededEvidenceRefs.length, 1);
   assert.equal(result.orphanEvidenceRelationEvidenceRefs.length, 1);
 });
 
-test('supersession preserves both historical claims instead of deleting the old record', () => {
+test('supersession preserves both historical claims and evidence records instead of deleting old state', () => {
+  const { issuer } = basicGraph();
   const oldClaim = claim('source-a', 'revision-1', 'Initial estimate', 'superseded');
   const newClaim = claim('source-a', 'revision-2', 'Updated estimate', 'single-source');
-  const relation = model.createClaimRelation({ claimId: newClaim.id, relatedClaimId: oldClaim.id, relation: 'supersedes' });
-  const result = model.validateClaimEvidenceGraph({ claims: [oldClaim, newClaim], claimRelations: [relation] });
+  const claimRelation = model.createClaimRelation({ claimId: newClaim.id, relatedClaimId: oldClaim.id, relation: 'supersedes' });
+  const oldEvidence = model.createEvidence({
+    evidenceKey: 'release:1',
+    issuerEntityId: issuer.id,
+    canonicalRef: 'https://example.com/release-1',
+    documentType: 'official-record',
+    claimIds: [oldClaim.id],
+    provenanceRefs: [EVIDENCE_URL],
+  });
+  const newEvidence = model.createEvidence({
+    evidenceKey: 'release:2',
+    issuerEntityId: issuer.id,
+    canonicalRef: 'https://example.com/release-2',
+    documentType: 'official-record',
+    claimIds: [newClaim.id],
+    supersedesEvidenceIds: [oldEvidence.id],
+    provenanceRefs: [EVIDENCE_URL],
+  });
+  const result = model.validateClaimEvidenceGraph({
+    entities: [issuer],
+    claims: [oldClaim, newClaim],
+    evidence: [oldEvidence, newEvidence],
+    claimRelations: [claimRelation],
+  });
   assert.equal(result.valid, true);
   assert.equal(result.duplicateClaimIds.length, 0);
+  assert.equal(result.duplicateEvidenceIds.length, 0);
   assert.equal(oldClaim.state, 'superseded');
   assert.notEqual(oldClaim.id, newClaim.id);
+  assert.notEqual(oldEvidence.id, newEvidence.id);
+  assert.deepEqual(newEvidence.supersedesEvidenceIds, [oldEvidence.id]);
 });
 
 test('reviewed institutional overlay reuses exact Knowledge catalog entries but authorizes no collection endpoints', () => {
@@ -186,6 +224,7 @@ test('/api/intelligence/evidence-schema exposes evidence-state rules without ena
   const json = await response.json();
   assert.equal(response.status, 200);
   assert.equal(json.modelVersion, model.CLAIM_EVIDENCE_MODEL_VERSION);
+  assert.ok(json.claimStates.includes('disputed'));
   assert.equal(json.rules.truthScore, false);
   assert.equal(json.rules.contradictoryClaimsMayCoexist, true);
   assert.equal(json.rules.independentCorroborationRequiresDistinctOriginSource, true);

--- a/tests/claim-evidence-model.test.mjs
+++ b/tests/claim-evidence-model.test.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const root = mkdtempSync(join(tmpdir(), 'globaldeets-evidence-'));
+const functions = join(root, 'functions');
+const files = [
+  ['../functions/lib/intelligence-model.js', join(functions, 'lib', 'intelligence-model.js')],
+  ['../functions/lib/claim-evidence-model.js', join(functions, 'lib', 'claim-evidence-model.js')],
+  ['../functions/lib/institutional-evidence-sources.js', join(functions, 'lib', 'institutional-evidence-sources.js')],
+  ['../functions/api/intelligence/evidence-schema.js', join(functions, 'api', 'intelligence', 'evidence-schema.js')],
+];
+for (const [, target] of files) mkdirSync(dirname(target), { recursive: true });
+writeFileSync(join(functions, 'package.json'), '{"type":"module"}\n');
+for (const [source, target] of files) copyFileSync(fileURLToPath(new URL(source, import.meta.url)), target);
+
+const identity = await import(pathToFileURL(join(functions, 'lib', 'intelligence-model.js')).href);
+const model = await import(pathToFileURL(join(functions, 'lib', 'claim-evidence-model.js')).href);
+const institutions = await import(pathToFileURL(join(functions, 'lib', 'institutional-evidence-sources.js')).href);
+const api = await import(pathToFileURL(join(functions, 'api', 'intelligence', 'evidence-schema.js')).href);
+const knowledgeCatalog = JSON.parse(readFileSync(fileURLToPath(new URL('../data/knowledge-sources.json', import.meta.url)), 'utf8'));
+const EVIDENCE_URL = 'https://example.com/source';
+
+function claim(originSourceId, claimKey, proposition = 'A reviewed proposition', state = 'single-source') {
+  return model.createClaim({
+    originSourceId,
+    claimKey,
+    proposition,
+    type: 'fact-assertion',
+    state,
+    originRef: `https://example.com/${originSourceId}/${claimKey}`,
+    sourceWording: proposition,
+  });
+}
+
+function basicGraph() {
+  const place = identity.createM49PlaceEntity({
+    displayName: 'United States of America',
+    m49: '840',
+    isoAlpha2: 'US',
+    isoAlpha3: 'USA',
+    evidenceRefs: [EVIDENCE_URL],
+  });
+  const person = identity.createEntity({ identityKey: 'person:test:1', displayName: 'Alex Kim', type: 'person' });
+  const issuer = institutions.INSTITUTIONAL_ENTITIES.find(entity => entity.identityKey === 'institution:un');
+  const event = identity.createEvent({
+    eventKey: 'event:test:1',
+    title: 'Test event',
+    eventType: 'incident',
+    status: 'developing',
+    entityIds: [person.id],
+    placeEntityIds: [place.id],
+  });
+  return { place, person, issuer, event };
+}
+
+test('claim identity is explicit and survives proposition edits without collapsing distinct sources', () => {
+  const first = claim('source-a', 'claim-001', 'Initial wording');
+  const revised = claim('source-a', 'claim-001', 'Corrected wording');
+  const secondSource = claim('source-b', 'claim-001', 'Initial wording');
+  assert.equal(first.id, revised.id);
+  assert.notEqual(first.id, secondSource.id);
+  assert.notEqual(first.proposition, revised.proposition);
+});
+
+test('contradictory claims coexist and no relation chooses a silent winner', () => {
+  const yes = claim('source-a', 'claim-yes', 'The event occurred.', 'contradicted');
+  const no = claim('source-b', 'claim-no', 'The event did not occur.', 'corroborated');
+  const relation = model.createClaimRelation({ claimId: yes.id, relatedClaimId: no.id, relation: 'contradicts' });
+  const result = model.validateClaimEvidenceGraph({ claims: [yes, no], claimRelations: [relation] });
+  assert.equal(result.valid, true);
+  assert.equal(new Set([yes.id, no.id]).size, 2);
+});
+
+test('corroboration must come from a distinct origin source', () => {
+  const first = claim('source-a', 'claim-1');
+  const sameSource = claim('source-a', 'claim-2');
+  const independent = claim('source-b', 'claim-3');
+  const invalidRelation = model.createClaimRelation({ claimId: first.id, relatedClaimId: sameSource.id, relation: 'corroborates' });
+  const validRelation = model.createClaimRelation({ claimId: first.id, relatedClaimId: independent.id, relation: 'corroborates' });
+
+  const invalid = model.validateClaimEvidenceGraph({ claims: [first, sameSource], claimRelations: [invalidRelation] });
+  assert.equal(invalid.valid, false);
+  assert.deepEqual(invalid.nonIndependentCorroborationRefs, [invalidRelation.id]);
+  assert.equal(model.validateClaimEvidenceGraph({ claims: [first, independent], claimRelations: [validRelation] }).valid, true);
+});
+
+test('primary evidence requires issuer, canonical reference, provenance, and inspectable claim relation', () => {
+  const { issuer } = basicGraph();
+  const assertion = claim('source-a', 'claim-1');
+  const document = model.createEvidence({
+    evidenceKey: 'resolution:example:1',
+    issuerEntityId: issuer.id,
+    canonicalRef: 'https://www.un.org/example-resolution',
+    documentType: 'multilateral-publication',
+    claimIds: [assertion.id],
+    provenanceRefs: ['https://www.un.org'],
+  });
+  const link = model.createEvidenceRelation({ claimId: assertion.id, evidenceId: document.id, relation: 'supports' });
+  assert.equal(model.validateClaimEvidenceGraph({ entities: [issuer], claims: [assertion], evidence: [document], evidenceRelations: [link] }).valid, true);
+  assert.throws(
+    () => model.createEvidence({ evidenceKey: 'bad', issuerEntityId: issuer.id, canonicalRef: 'https://example.com/bad', documentType: 'official-record' }),
+    /provenanceRefs/
+  );
+});
+
+test('claim/evidence graph rejects orphan entities, places, events, issuers, claims, and evidence links', () => {
+  const { place, person, issuer, event } = basicGraph();
+  const good = model.createClaim({
+    originSourceId: 'source-a',
+    claimKey: 'good',
+    proposition: 'Good',
+    type: 'fact-assertion',
+    state: 'single-source',
+    originRef: 'https://example.com/good',
+    eventIds: [event.id],
+    entityIds: [person.id],
+    placeEntityIds: [place.id],
+  });
+  const broken = model.createClaim({
+    originSourceId: 'source-b',
+    claimKey: 'broken',
+    proposition: 'Broken',
+    type: 'allegation',
+    state: 'unreviewed',
+    originRef: 'https://example.com/broken',
+    eventIds: ['event:missing'],
+    entityIds: ['entity:missing'],
+    placeEntityIds: ['place:missing', person.id],
+  });
+  const badEvidence = model.createEvidence({
+    evidenceKey: 'bad-evidence',
+    issuerEntityId: 'entity:missing-issuer',
+    canonicalRef: 'https://example.com/evidence',
+    documentType: 'official-record',
+    eventIds: ['event:missing'],
+    entityIds: ['entity:missing'],
+    placeEntityIds: ['place:missing', person.id],
+    claimIds: ['claim:missing'],
+    provenanceRefs: [EVIDENCE_URL],
+  });
+  const missingEvidenceLink = model.createEvidenceRelation({ claimId: good.id, evidenceId: 'evidence:missing', relation: 'supports' });
+  const result = model.validateClaimEvidenceGraph({
+    entities: [place, person, issuer],
+    events: [event],
+    claims: [good, broken],
+    evidence: [badEvidence],
+    evidenceRelations: [missingEvidenceLink],
+  });
+  assert.equal(result.valid, false);
+  assert.equal(result.orphanClaimEventRefs.length, 1);
+  assert.equal(result.orphanClaimEntityRefs.length, 1);
+  assert.equal(result.orphanClaimPlaceRefs.length, 1);
+  assert.equal(result.nonPlaceClaimRefs.length, 1);
+  assert.equal(result.orphanEvidenceIssuerRefs.length, 1);
+  assert.equal(result.orphanEvidenceClaimRefs.length, 1);
+  assert.equal(result.orphanEvidenceRelationEvidenceRefs.length, 1);
+});
+
+test('supersession preserves both historical claims instead of deleting the old record', () => {
+  const oldClaim = claim('source-a', 'revision-1', 'Initial estimate', 'superseded');
+  const newClaim = claim('source-a', 'revision-2', 'Updated estimate', 'single-source');
+  const relation = model.createClaimRelation({ claimId: newClaim.id, relatedClaimId: oldClaim.id, relation: 'supersedes' });
+  const result = model.validateClaimEvidenceGraph({ claims: [oldClaim, newClaim], claimRelations: [relation] });
+  assert.equal(result.valid, true);
+  assert.equal(result.duplicateClaimIds.length, 0);
+  assert.equal(oldClaim.state, 'superseded');
+  assert.notEqual(oldClaim.id, newClaim.id);
+});
+
+test('reviewed institutional overlay reuses exact Knowledge catalog entries but authorizes no collection endpoints', () => {
+  const validation = institutions.validateInstitutionalSourceRegistry(knowledgeCatalog);
+  assert.equal(validation.valid, true);
+  assert.equal(institutions.REVIEWED_INSTITUTIONAL_SOURCES.length, 10);
+  assert.equal(institutions.REVIEWED_INSTITUTIONAL_SOURCES.every(item => item.collectionEligible === false), true);
+  assert.equal(institutions.REVIEWED_INSTITUTIONAL_SOURCES.every(item => item.machineReadableEndpoints.length === 0), true);
+  assert.ok(institutions.REVIEWED_INSTITUTIONAL_SOURCES.some(item => item.evidenceRole === 'issuing-primary'));
+  assert.equal(institutions.institutionalRegistrySummary().knowledgeCatalogIsIngestionAuthority, false);
+});
+
+test('/api/intelligence/evidence-schema exposes evidence-state rules without enabling bulk collection', async () => {
+  const response = await api.onRequestGet({ request: new Request('https://globaldeets.com/api/intelligence/evidence-schema', { headers: { Origin: 'https://globaldeets.com' } }) });
+  const json = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(json.modelVersion, model.CLAIM_EVIDENCE_MODEL_VERSION);
+  assert.equal(json.rules.truthScore, false);
+  assert.equal(json.rules.contradictoryClaimsMayCoexist, true);
+  assert.equal(json.rules.independentCorroborationRequiresDistinctOriginSource, true);
+  assert.equal(json.rules.supersessionDeletesHistory, false);
+  assert.equal(json.rules.knowledgeCatalogIsIngestionAuthority, false);
+  assert.equal(json.rules.machineReadableEndpointRequiresSeparateReview, true);
+  assert.equal(json.rules.bulkCollectionEnabled, false);
+  assert.equal(json.institutionalSources.collectionEligibleSources, 0);
+});

--- a/tools/verify-intelligence-prod.js
+++ b/tools/verify-intelligence-prod.js
@@ -30,10 +30,11 @@ function requireCondition(condition, message) {
 }
 
 (async () => {
-  const [coverage, sources, schema] = await Promise.all([
+  const [coverage, sources, schema, evidenceSchema] = await Promise.all([
     fetchJson('/api/news/coverage'),
     fetchJson('/api/news/sources'),
     fetchJson('/api/intelligence/schema'),
+    fetchJson('/api/intelligence/evidence-schema'),
   ]);
 
   requireCondition(typeof coverage.sourceFingerprint === 'string', 'coverage fingerprint missing');
@@ -59,7 +60,21 @@ function requireCondition(condition, message) {
   requireCondition(Number.isInteger(schema.placeSeed?.count) && schema.placeSeed.count > 0, 'place seed count missing');
   requireCondition(schema.placeSeed?.runtimeFetchRequired === false, 'production must not depend on live M49 fetching');
 
-  console.log(`Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} reviewed place identities, model ${schema.modelVersion}`);
+  requireCondition(typeof evidenceSchema.modelVersion === 'string', 'claim/evidence model version missing');
+  requireCondition(Array.isArray(evidenceSchema.claimTypes) && evidenceSchema.claimTypes.includes('allegation'), 'claim type contract missing');
+  requireCondition(Array.isArray(evidenceSchema.claimStates) && evidenceSchema.claimStates.includes('contradicted'), 'claim state contract missing');
+  requireCondition(Array.isArray(evidenceSchema.evidenceDocumentTypes) && evidenceSchema.evidenceDocumentTypes.includes('court-filing'), 'evidence document contract missing');
+  requireCondition(evidenceSchema.rules?.truthScore === false, 'truth score must remain disabled');
+  requireCondition(evidenceSchema.rules?.contradictoryClaimsMayCoexist === true, 'contradictory claim coexistence contract changed');
+  requireCondition(evidenceSchema.rules?.independentCorroborationRequiresDistinctOriginSource === true, 'independent corroboration contract changed');
+  requireCondition(evidenceSchema.rules?.supersessionDeletesHistory === false, 'supersession must preserve history');
+  requireCondition(evidenceSchema.rules?.knowledgeCatalogIsIngestionAuthority === false, 'Knowledge catalog must not become ingestion authority');
+  requireCondition(evidenceSchema.rules?.machineReadableEndpointRequiresSeparateReview === true, 'endpoint review boundary changed');
+  requireCondition(evidenceSchema.rules?.bulkCollectionEnabled === false, 'bulk evidence collection must remain disabled in GD-015');
+  requireCondition(Number.isInteger(evidenceSchema.institutionalSources?.reviewedSources) && evidenceSchema.institutionalSources.reviewedSources > 0, 'reviewed institutional source count missing');
+  requireCondition(evidenceSchema.institutionalSources?.collectionEligibleSources === 0, 'GD-015 must not silently enable institutional collection');
+
+  console.log(`Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} reviewed institutional candidates, models ${schema.modelVersion}/${evidenceSchema.modelVersion}`);
 })().catch(error => {
   console.error(`Intelligence API verification failed: ${error.message}`);
   process.exit(1);


### PR DESCRIPTION
## Phase II — Claim + primary evidence

Builds the deterministic evidence-state layer on top of GD-014 canonical entities/events.

### What changes
- Adds explicit stable claim identity keyed by origin source + claim key, independent of mutable proposition wording.
- Adds primary-evidence records with issuing canonical entity, canonical/immutable references, document type, provenance, dates, and claim/event/entity/place links.
- Adds inspectable claim-to-claim relationships (`corroborates`, `contradicts`, `supersedes`) and evidence-to-claim relationships (`supports`, `contradicts`, `supersedes`).
- Rejects same-source "corroboration" as non-independent.
- Preserves contradictory and superseded claims rather than choosing a hidden winner or deleting history.
- Reuses `data/knowledge-sources.json` through a reviewed institutional-source overlay instead of creating a duplicate directory.
- Seeds ten reviewed institutional classifications while keeping every source `directory-only` and `collectionEligible: false`.
- Keeps machine-readable endpoint identity, licensing/authentication review, and technical collection admission separate from institutional/directory identity.
- Adds `GET /api/intelligence/evidence-schema` and extends the production intelligence verifier.
- Adds adversarial contracts for identity drift, conflicting claims, fake corroboration, orphan graph links, evidence provenance, supersession history, Knowledge-catalog reuse, and accidental collection enablement.

### Safety / epistemic boundary
- no truth score
- no publisher reliability/bias score
- no LLM conclusion treated as evidence
- no automatic legal interpretation
- no bulk evidence collection
- no Knowledge-directory URL promoted to ingestion authority

### Downstream
GD-016 can consume these deterministic records to build the first source-first evidence dossier.

Closes #16 after merge.