### PR TITLE
GD-013.1: Add source admission and usage-rights contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,20 @@ jobs:
           node --check functions/api/news/health.js
           node --check functions/api/news/coverage.js
           node --check functions/api/news/sources.js
+          node --check functions/api/news/admission.js
           node --check functions/api/intelligence/schema.js
           node --check functions/api/intelligence/evidence-schema.js
           node --check functions/lib/news-coverage.js
           node --check functions/lib/news-source-provenance.js
+          node --check functions/lib/news-source-admission.js
           node --check functions/lib/intelligence-model.js
           node --check functions/lib/m49-place-seed.js
           node --check functions/lib/claim-evidence-model.js
           node --check functions/lib/institutional-evidence-sources.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
+          node --check tests/news-source-admission.test.mjs
+          node --check tests/news-admission-api.test.mjs
           node --check tests/intelligence-model.test.mjs
           node --check tests/claim-evidence-model.test.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           node --check playwright.config.js
           node --check tests/smoke.spec.js
           node --check tests/news-source-admission.test.mjs
+          node --check tests/news-source-admission-hardening.test.mjs
           node --check tests/news-admission-api.test.mjs
           node --check tests/intelligence-model.test.mjs
           node --check tests/claim-evidence-model.test.mjs

--- a/docs/source-admission-rights.md
+++ b/docs/source-admission-rights.md
@@ -1,0 +1,120 @@
+# Source Admission and Usage-Rights Contract
+
+GlobalDeets separates four questions that were previously easy to conflate:
+
+1. **Publisher provenance** — who publishes/operates the source?
+2. **Endpoint authority** — is this feed/API first-party or otherwise authorized?
+3. **Technical health** — does the endpoint currently fetch and parse successfully?
+4. **Usage/admission state** — is the intended GlobalDeets use reviewed for this endpoint/content?
+
+A positive answer to one does not imply a positive answer to the others. This is an engineering governance ledger, not a legal conclusion.
+
+## Current GlobalDeets use profile
+
+The live RSS pipeline currently normalizes:
+
+- headline/title
+- original article link
+- RSS description/summary, truncated to 280 characters
+- publication timestamp
+- source/region/language metadata
+- machine-translated headline and summary for non-English feeds when Workers AI succeeds
+
+The admission ledger records that actual use rather than describing GlobalDeets generically as an "RSS reader."
+
+## New-source fail-closed rule
+
+The 19 sources that existed when this gate was introduced are frozen as the legacy set. They may remain visible while their individual reviews migrate from `legacy-unreviewed` to `reviewed`.
+
+Any source outside that frozen set is **new** and fails validation unless its admission record is production-admissible. Production admission requires:
+
+- explicit `reviewed` state
+- `verified-public-use` for the intended use
+- first-party or reviewed authorized-third-party endpoint authority
+- verified technical health
+- no unresolved item-level review requirement
+- every current use type included in the reviewed permitted-use set
+
+A new source cannot self-label as legacy to bypass the gate.
+
+## Existing 19-source migration
+
+Every live source has an explicit admission record. Most begin as `legacy-unreviewed` with `allowedUseStatus: unknown`; that means "not yet reviewed," not "unauthorized" and not "approved."
+
+Two existing sources have already produced concrete remediation signals:
+
+### AP
+
+The current GlobalDeets AP endpoint is an RSSHub route, not first-party AP access. AP documents its Media API as licensed, account-entitled content ingestion tied to contract terms. The current record therefore remains visible as a legacy source but is classified `contract-required` with `unverified-third-party` endpoint authority. GlobalDeets should not replace RSSHub with another unofficial scraper.
+
+### Guardian
+
+The Guardian's RSS endpoint is first-party, but its published RSS/terms material does not justify marking the present GlobalDeets public use as `verified-public-use` without further permission/licensing review. The record remains visible and is classified `permission-required` pending remediation.
+
+Neither finding silently removes the source or turns an engineering signal into a legal conclusion.
+
+## Research candidates
+
+Rejected/deferred research must remain queryable so dead ends are not repeatedly rediscovered.
+
+### RNZ Pacific
+
+RNZ Pacific remains a `research` candidate with `permission-required` status under the currently reviewed RSS-use signal. The candidate record does not add RNZ to production.
+
+### Agencia Brasil
+
+Agencia Brasil remains a `research` candidate. Its published reproduction policy is promising for journalistic reuse, but partner/syndicated material can carry different restrictions. The candidate is therefore blocked by `itemLevelReviewRequired` until GlobalDeets has a reliable item-origin/restriction strategy.
+
+## Item-level override
+
+Source-level permission never overrides an explicit stricter item signal.
+
+`evaluateItemUse()` applies the more restrictive of the source and item statuses:
+
+- `verified-public-use` → current reviewed display mode
+- `unknown`, `permission-required`, `contract-required` → headline/link fallback
+- `prohibited` → exclude
+
+This gives future collectors a deterministic conservative behavior when a feed mixes publisher-native and partner content.
+
+## Observability
+
+`GET /api/news/admission` exposes:
+
+- source fingerprint
+- independent admission fingerprint
+- validation result
+- live admission records
+- research candidates
+- reviewed/backlog/remediation summary
+- fail-closed rules
+
+`GET /api/news/coverage` includes admission integrity and raises explicit gaps for:
+
+- invalid admission registry
+- remaining legacy review backlog
+- reviewed sources requiring remediation
+
+The future GD-017 command center can therefore consume the same deterministic state rather than maintaining a separate spreadsheet.
+
+## Cache identity boundary
+
+Admission metadata has its own fingerprint for observability but does **not** change the news feed cache key. The canonical feed/source definition already participates in the news source fingerprint. If an admitted endpoint actually becomes canonical, changing `SOURCES` changes the feed/cache identity through the existing contract.
+
+This prevents a reviewer-note or policy-link edit from needlessly invalidating production news caches while still making governance changes measurable.
+
+## Non-goals
+
+This gate does not:
+
+- make legal determinations
+- infer permission from robots.txt
+- infer permission from first-party hosting
+- infer permission from successful HTTP health
+- add RNZ Pacific or Agencia Brasil to production
+- replace AP with an unofficial source
+- silently remove Guardian or AP
+- bulk-review the remaining 17 legacy sources without evidence
+- automatically alter displayed fields based on the ledger yet
+
+The next source-by-source review tranche should convert legacy records to reviewed states using publisher/endpoint-specific evidence and open remediation issues wherever a concrete restriction conflicts with current behavior.

--- a/functions/api/news/admission.js
+++ b/functions/api/news/admission.js
@@ -1,0 +1,61 @@
+// Cloudflare Pages Function - GET /api/news/admission
+import { SOURCE_FINGERPRINT } from '../news.js';
+import {
+  ADMISSION_FINGERPRINT,
+  ADMISSION_REVIEW_DATE,
+  SOURCE_ADMISSIONS,
+  SOURCE_RESEARCH_CANDIDATES,
+  admissionSummary,
+  validateSourceAdmissions,
+} from '../../lib/news-source-admission.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+const BASE_HEADERS = {
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Content-Type': 'application/json',
+  'Cache-Control': 'public, max-age=3600',
+};
+
+function getCorsHeaders(request) {
+  const origin = request?.headers?.get('Origin');
+  return {
+    ...BASE_HEADERS,
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com',
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: getCorsHeaders(request) });
+}
+
+export async function onRequestGet({ request }) {
+  const validation = validateSourceAdmissions();
+  return new Response(
+    JSON.stringify({
+      sourceFingerprint: SOURCE_FINGERPRINT,
+      admissionFingerprint: ADMISSION_FINGERPRINT,
+      reviewedAt: ADMISSION_REVIEW_DATE,
+      validation,
+      summary: admissionSummary(),
+      liveAdmissions: SOURCE_ADMISSIONS,
+      researchCandidates: SOURCE_RESEARCH_CANDIDATES,
+      rules: {
+        newSourcesRequireReviewedAdmission: true,
+        legacyUnreviewedMayRemainTemporarily: true,
+        endpointAuthorityIsUsagePermission: false,
+        feedHealthIsUsagePermission: false,
+        itemRestrictionsOverrideSourcePermission: true,
+        admissionMetadataChangesNewsCacheIdentity: false,
+      },
+    }),
+    { headers: getCorsHeaders(request) }
+  );
+}

--- a/functions/lib/news-coverage.js
+++ b/functions/lib/news-coverage.js
@@ -1,7 +1,8 @@
 // Deterministic coverage inventory derived from the canonical news source contract.
-// Provenance enriches observability but intentionally does not alter feed fetching or cache identity.
+// Provenance and admission enrich observability but intentionally do not alter feed fetching/cache identity.
 
 import { SOURCES, slugifySourceName } from '../api/news.js';
+import { SOURCE_ADMISSIONS, validateSourceAdmissions } from './news-source-admission.js';
 import { SOURCE_PROVENANCE, validateSourceProvenance } from './news-source-provenance.js';
 
 export const COVERAGE_POLICY = Object.freeze({
@@ -10,13 +11,20 @@ export const COVERAGE_POLICY = Object.freeze({
   minimumPrimarySourceInputs: 1,
 });
 
-export function buildCoverageInventory(sources = SOURCES, provenance = SOURCE_PROVENANCE) {
+export function buildCoverageInventory(
+  sources = SOURCES,
+  provenance = SOURCE_PROVENANCE,
+  admissions = SOURCE_ADMISSIONS
+) {
   const provenanceValidation = validateSourceProvenance(sources, provenance);
+  const admissionValidation = validateSourceAdmissions(sources, admissions);
   const provenanceById = new Map(provenance.map(entry => [entry.sourceId, entry]));
+  const admissionById = new Map(admissions.map(entry => [entry.sourceId, entry]));
   const normalizedSources = sources
     .map(source => {
       const sourceId = slugifySourceName(source.name);
       const metadata = provenanceById.get(sourceId) || {};
+      const admission = admissionById.get(sourceId) || {};
       return {
         sourceId,
         name: source.name,
@@ -28,6 +36,9 @@ export function buildCoverageInventory(sources = SOURCES, provenance = SOURCE_PR
         primaryCountry: metadata.primaryCountry || null,
         locality: metadata.locality || 'unknown',
         ownershipOperatorKnown: Boolean(metadata.ownershipOperator),
+        admissionReviewState: admission.reviewState || 'missing',
+        allowedUseStatus: admission.allowedUseStatus || 'missing',
+        endpointAuthority: admission.endpointAuthority || 'missing',
       };
     })
     .sort((a, b) => a.sourceId.localeCompare(b.sourceId));
@@ -52,7 +63,14 @@ export function buildCoverageInventory(sources = SOURCES, provenance = SOURCE_PR
   const geographicScopes = summarizeGroups(geographicScopeGroups, 'geographicScope');
   const sourceOriginCountries = summarizeGroups(countryGroups, 'country');
 
-  const gaps = buildGapSignals(normalizedSources, regions, provenanceValidation);
+  const admission = buildAdmissionInventory(admissions, admissionValidation);
+  const gaps = buildGapSignals(
+    normalizedSources,
+    regions,
+    provenanceValidation,
+    admissionValidation,
+    admission
+  );
   const englishSources = normalizedSources.filter(source => source.lang === 'en').length;
   const primarySourceInputs = normalizedSources.filter(
     source => source.evidenceRole === 'primary-source'
@@ -79,6 +97,7 @@ export function buildCoverageInventory(sources = SOURCES, provenance = SOURCE_PR
         .filter(source => !source.ownershipOperatorKnown)
         .map(source => source.sourceId),
     },
+    admission,
     regions,
     languages,
     sourceClasses,
@@ -89,7 +108,33 @@ export function buildCoverageInventory(sources = SOURCES, provenance = SOURCE_PR
   };
 }
 
-function buildGapSignals(sources, regions, provenanceValidation) {
+function buildAdmissionInventory(admissions, validation) {
+  return {
+    valid: validation.valid,
+    reviewedSources: admissions.filter(entry => entry.reviewState === 'reviewed').length,
+    legacyUnreviewedSources: admissions.filter(entry => entry.reviewState === 'legacy-unreviewed').length,
+    remediationSourceIds: admissions
+      .filter(entry => ['permission-required', 'contract-required', 'prohibited'].includes(entry.allowedUseStatus))
+      .map(entry => entry.sourceId)
+      .sort(),
+    unknownRightsSourceIds: admissions
+      .filter(entry => entry.allowedUseStatus === 'unknown')
+      .map(entry => entry.sourceId)
+      .sort(),
+    missingSourceIds: validation.missingSourceIds,
+    orphanSourceIds: validation.orphanSourceIds,
+    endpointDriftSourceIds: validation.endpointDriftSourceIds,
+    unadmittedNewSourceIds: validation.unadmittedNewSourceIds,
+  };
+}
+
+function buildGapSignals(
+  sources,
+  regions,
+  provenanceValidation,
+  admissionValidation,
+  admission
+) {
   const gaps = [];
 
   for (const region of regions) {
@@ -171,6 +216,42 @@ function buildGapSignals(sources, regions, provenanceValidation) {
       observed: provenanceValidation,
       target: 'exactly one valid provenance record per live source',
       detail: 'The provenance registry does not exactly match the canonical live source contract.',
+    });
+  }
+
+  if (!admissionValidation.valid) {
+    gaps.push({
+      id: 'source-admission:invalid',
+      type: 'source-admission-integrity',
+      severity: 'critical',
+      region: null,
+      observed: admissionValidation,
+      target: 'exactly one structurally valid admission record per live source and fully reviewed admission for every new source',
+      detail: 'The source-admission registry does not satisfy the canonical live-source contract.',
+    });
+  }
+
+  if (admission.legacyUnreviewedSources > 0) {
+    gaps.push({
+      id: 'source-admission:legacy-review-backlog',
+      type: 'source-admission-review',
+      severity: 'high',
+      region: null,
+      observed: admission.legacyUnreviewedSources,
+      target: 0,
+      detail: 'Legacy live sources remain explicitly unreviewed for usage rights and require source-by-source admission review.',
+    });
+  }
+
+  if (admission.remediationSourceIds.length > 0) {
+    gaps.push({
+      id: 'source-admission:remediation-required',
+      type: 'source-admission-remediation',
+      severity: 'high',
+      region: null,
+      observed: admission.remediationSourceIds,
+      target: 'authorized use path or reviewed restrictive fallback for each source',
+      detail: 'One or more reviewed legacy sources have permission/contract restrictions that require explicit remediation rather than silent removal or assumption.',
     });
   }
 

--- a/functions/lib/news-source-admission.js
+++ b/functions/lib/news-source-admission.js
@@ -150,11 +150,15 @@ export function getAdmissionFingerprint(admissions = SOURCE_ADMISSIONS, candidat
 }
 
 export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_ADMISSIONS) {
+  const canonicalSourceIds = sources.map(source => slugifySourceName(source.name));
+  const canonicalEndpointUrls = sources.map(source => source.url);
   const sourceById = new Map(sources.map(source => [slugifySourceName(source.name), source]));
   const admissionById = new Map(admissions.map(entry => [entry.sourceId, entry]));
   const sourceIds = [...sourceById.keys()];
   const admissionIds = admissions.map(entry => entry.sourceId);
 
+  const duplicateCanonicalSourceIds = duplicates(canonicalSourceIds);
+  const duplicateCanonicalEndpointUrls = duplicates(canonicalEndpointUrls);
   const missingSourceIds = sourceIds.filter(id => !admissionById.has(id));
   const orphanSourceIds = admissionIds.filter(id => !sourceById.has(id));
   const duplicateIds = duplicates(admissionIds);
@@ -180,6 +184,8 @@ export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_
   });
 
   const result = {
+    duplicateCanonicalSourceIds,
+    duplicateCanonicalEndpointUrls,
     missingSourceIds: unique(missingSourceIds),
     orphanSourceIds: unique(orphanSourceIds),
     duplicateIds,
@@ -199,8 +205,12 @@ export function isProductionAdmissible(entry) {
     entry &&
       entry.legacy === false &&
       entry.reviewState === 'reviewed' &&
+      typeof entry.reviewedAt === 'string' &&
+      entry.reviewedAt.trim() &&
       entry.allowedUseStatus === 'verified-public-use' &&
       ['first-party', 'authorized-third-party'].includes(entry.endpointAuthority) &&
+      entry.endpointEvidenceUrls.length > 0 &&
+      entry.usagePolicyUrls.length > 0 &&
       entry.healthVerificationStatus === 'verified' &&
       entry.itemLevelReviewRequired !== true &&
       entry.currentUse.every(use => entry.permittedUse.includes(use))
@@ -322,17 +332,24 @@ function candidate(definition) {
 }
 
 function validAdmission(entry) {
+  const reviewedAtValid =
+    entry?.reviewState === 'legacy-unreviewed'
+      ? entry.reviewedAt == null || (typeof entry.reviewedAt === 'string' && entry.reviewedAt.trim())
+      : typeof entry?.reviewedAt === 'string' && entry.reviewedAt.trim();
   return Boolean(
     entry &&
       typeof entry.sourceId === 'string' &&
+      entry.sourceId === slugifySourceName(entry.name) &&
       typeof entry.name === 'string' &&
-      typeof entry.endpointUrl === 'string' &&
+      /^https:\/\//.test(entry.endpointUrl) &&
       typeof entry.endpointType === 'string' &&
       AUTHORITY_SET.has(entry.endpointAuthority) &&
       Array.isArray(entry.endpointEvidenceUrls) &&
       entry.endpointEvidenceUrls.length > 0 &&
+      entry.endpointEvidenceUrls.every(url => /^https:\/\//.test(url)) &&
       typeof entry.authenticationRequirement === 'string' &&
       Array.isArray(entry.usagePolicyUrls) &&
+      entry.usagePolicyUrls.every(url => /^https:\/\//.test(url)) &&
       USE_STATUS_SET.has(entry.allowedUseStatus) &&
       Array.isArray(entry.currentUse) &&
       entry.currentUse.every(use => CURRENT_USE_SET.has(use)) &&
@@ -344,7 +361,9 @@ function validAdmission(entry) {
       typeof entry.itemLevelReviewRequired === 'boolean' &&
       typeof entry.itemLevelStrategy === 'string' &&
       REVIEW_STATE_SET.has(entry.reviewState) &&
+      reviewedAtValid &&
       typeof entry.reviewerNotes === 'string' &&
+      entry.reviewerNotes.trim() &&
       typeof entry.healthVerificationStatus === 'string' &&
       typeof entry.legacy === 'boolean'
   );

--- a/functions/lib/news-source-admission.js
+++ b/functions/lib/news-source-admission.js
@@ -1,0 +1,368 @@
+// Source-admission governance for the live news contract.
+// This is an engineering review ledger, not a legal conclusion. Feed health, publisher provenance,
+// endpoint authority, and usage rights remain separate dimensions.
+import { SOURCES, slugifySourceName } from '../api/news.js';
+
+export const ADMISSION_REVIEW_DATE = '2026-09-03';
+export const ALLOWED_USE_STATUSES = Object.freeze([
+  'verified-public-use',
+  'permission-required',
+  'contract-required',
+  'unknown',
+  'prohibited',
+]);
+export const ENDPOINT_AUTHORITY_STATUSES = Object.freeze([
+  'first-party',
+  'authorized-third-party',
+  'unverified-third-party',
+]);
+export const REVIEW_STATES = Object.freeze(['legacy-unreviewed', 'reviewed']);
+export const CURRENT_USE_TYPES = Object.freeze([
+  'headline-link',
+  'metadata',
+  'excerpt',
+  'translated-headline-summary',
+]);
+
+const USE_STATUS_SET = new Set(ALLOWED_USE_STATUSES);
+const AUTHORITY_SET = new Set(ENDPOINT_AUTHORITY_STATUSES);
+const REVIEW_STATE_SET = new Set(REVIEW_STATES);
+const CURRENT_USE_SET = new Set(CURRENT_USE_TYPES);
+
+// Frozen at the moment the admission gate was introduced. These IDs may remain live while their
+// usage review migrates from legacy-unreviewed to reviewed. Any source outside this set is new and
+// must be fully production-admissible before CI will accept it in SOURCES.
+export const LEGACY_SOURCE_IDS = Object.freeze([
+  'abc-australia',
+  'al-jazeera',
+  'anadolu-agency',
+  'ap',
+  'bbc-world',
+  'cna',
+  'dawn',
+  'dw',
+  'france-24',
+  'guardian',
+  'kyiv-independent',
+  'mercopress',
+  'nhk',
+  'npr',
+  'premium-times',
+  'the-east-african',
+  'the-hindu',
+  'ukrinform',
+  'yonhap',
+].sort());
+
+export const SOURCE_ADMISSIONS = Object.freeze([
+  legacy('BBC World', 'https://feeds.bbci.co.uk/news/world/rss.xml'),
+  reviewedLegacy('AP', 'https://rsshub.app/apnews/topics/world-news', {
+    endpointAuthority: 'unverified-third-party',
+    endpointEvidenceUrls: ['https://api.ap.org/media/v/docs/Getting_Started_API.htm'],
+    usagePolicyUrls: ['https://api.ap.org/media/v/docs/Getting_Started_API.htm'],
+    allowedUseStatus: 'contract-required',
+    syndicatedContentBehavior: 'wire-service-content',
+    reviewerNotes:
+      'Current RSSHub endpoint is not first-party AP access. AP documents licensed Media API ingestion tied to account entitlements and contract terms; keep this legacy source visible/research-status until an authorized path is established.',
+  }),
+  reviewedLegacy('Guardian', 'https://www.theguardian.com/world/rss', {
+    endpointEvidenceUrls: ['https://www.theguardian.com/help/feeds'],
+    usagePolicyUrls: [
+      'https://www.theguardian.com/help/feeds',
+      'https://www.theguardian.com/help/terms-of-service',
+      'https://www.theguardian.com/info/content-licensing-syndication',
+    ],
+    allowedUseStatus: 'permission-required',
+    reviewerNotes:
+      'First-party RSS is technically valid, but published feed/terms signals do not support marking the current public GlobalDeets use as verified-public-use without further permission/licensing review.',
+  }),
+  legacy('Al Jazeera', 'https://www.aljazeera.com/xml/rss/all.xml'),
+  legacy('Anadolu Agency', 'https://aa.com.tr/en/rss/default?cat=world'),
+  legacy('DW', 'https://rss.dw.com/xml/rss-en-world'),
+  legacy('France 24', 'https://www.france24.com/en/rss'),
+  legacy('Kyiv Independent', 'https://kyivindependent.com/news-archive/rss/'),
+  legacy('Ukrinform', 'https://www.ukrinform.net/rss/block-lastnews'),
+  legacy('NHK', 'https://www3.nhk.or.jp/rss/news/cat0.xml', { translated: true }),
+  legacy('Yonhap', 'https://en.yna.co.kr/RSS/news.xml'),
+  legacy('The Hindu', 'https://www.thehindu.com/news/international/feeder/default.rss'),
+  legacy('CNA', 'https://www.channelnewsasia.com/api/v1/rss-outbound-feed?_format=xml&category=6311'),
+  legacy('Dawn', 'https://www.dawn.com/feeds/home/'),
+  legacy('NPR', 'https://feeds.npr.org/1004/rss.xml'),
+  legacy('Mercopress', 'https://en.mercopress.com/rss/'),
+  legacy('ABC Australia', 'https://www.abc.net.au/news/feed/51120/rss.xml'),
+  legacy('Premium Times', 'https://www.premiumtimesng.com/feed/'),
+  legacy('The East African', 'https://www.theeastafrican.co.ke/rss.xml'),
+]);
+
+export const SOURCE_RESEARCH_CANDIDATES = Object.freeze([
+  candidate({
+    candidateId: 'rnz-pacific',
+    name: 'RNZ Pacific',
+    endpointUrl: 'https://www.rnz.co.nz/rss',
+    endpointType: 'rss-directory',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: ['https://www.rnz.co.nz/rss', 'https://www.rnz.co.nz/international/about'],
+    usagePolicyUrls: ['https://www.rnz.co.nz/rss'],
+    allowedUseStatus: 'permission-required',
+    disposition: 'research',
+    reviewerNotes:
+      'RNZ publishes first-party RSS, but the published RSS conditions require a permission review for GlobalDeets public reuse. No production source is created by this candidate record.',
+  }),
+  candidate({
+    candidateId: 'agencia-brasil',
+    name: 'Agencia Brasil',
+    endpointUrl: 'https://agenciabrasil.ebc.com.br/feed/',
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [
+      'https://agenciabrasil.ebc.com.br/feed/',
+      'https://agenciabrasil.ebc.com.br/sobre',
+    ],
+    usagePolicyUrls: ['https://agenciabrasil.ebc.com.br/sobre'],
+    allowedUseStatus: 'verified-public-use',
+    disposition: 'research',
+    syndicatedContentBehavior: 'mixed-rights-partner-content',
+    itemLevelReviewRequired: true,
+    reviewerNotes:
+      'Agencia Brasil publishes a journalistic reproduction policy, but partner-agency material can carry separate restrictions. Production admission requires a verified item-origin/restriction signal strategy first.',
+  }),
+]);
+
+export const ADMISSION_FINGERPRINT = getAdmissionFingerprint();
+
+export function getAdmissionFingerprint(admissions = SOURCE_ADMISSIONS, candidates = SOURCE_RESEARCH_CANDIDATES) {
+  const canonical = [...admissions, ...candidates]
+    .map(entry => JSON.stringify(entry))
+    .sort()
+    .join('\u001e');
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < canonical.length; i++) {
+    hash ^= canonical.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_ADMISSIONS) {
+  const sourceById = new Map(sources.map(source => [slugifySourceName(source.name), source]));
+  const admissionById = new Map(admissions.map(entry => [entry.sourceId, entry]));
+  const sourceIds = [...sourceById.keys()];
+  const admissionIds = admissions.map(entry => entry.sourceId);
+
+  const missingSourceIds = sourceIds.filter(id => !admissionById.has(id));
+  const orphanSourceIds = admissionIds.filter(id => !sourceById.has(id));
+  const duplicateIds = duplicates(admissionIds);
+  const invalidEntries = admissions.filter(entry => !validAdmission(entry)).map(entry => entry?.sourceId || '(missing-id)');
+  const endpointDriftSourceIds = admissions
+    .filter(entry => sourceById.has(entry.sourceId) && sourceById.get(entry.sourceId).url !== entry.endpointUrl)
+    .map(entry => entry.sourceId);
+  const nameDriftSourceIds = admissions
+    .filter(entry => sourceById.has(entry.sourceId) && sourceById.get(entry.sourceId).name !== entry.name)
+    .map(entry => entry.sourceId);
+  const unadmittedNewSourceIds = sourceIds.filter(id => {
+    if (LEGACY_SOURCE_IDS.includes(id)) return false;
+    return !isProductionAdmissible(admissionById.get(id));
+  });
+  const legacyStateErrors = sourceIds.filter(id => {
+    if (!LEGACY_SOURCE_IDS.includes(id)) return false;
+    const entry = admissionById.get(id);
+    return !entry || !REVIEW_STATE_SET.has(entry.reviewState) || entry.legacy !== true;
+  });
+
+  const result = {
+    missingSourceIds: unique(missingSourceIds),
+    orphanSourceIds: unique(orphanSourceIds),
+    duplicateIds,
+    invalidEntries: unique(invalidEntries),
+    endpointDriftSourceIds: unique(endpointDriftSourceIds),
+    nameDriftSourceIds: unique(nameDriftSourceIds),
+    unadmittedNewSourceIds: unique(unadmittedNewSourceIds),
+    legacyStateErrors: unique(legacyStateErrors),
+  };
+
+  return { valid: Object.values(result).every(values => values.length === 0), ...result };
+}
+
+export function isProductionAdmissible(entry) {
+  return Boolean(
+    entry &&
+      entry.reviewState === 'reviewed' &&
+      entry.allowedUseStatus === 'verified-public-use' &&
+      ['first-party', 'authorized-third-party'].includes(entry.endpointAuthority) &&
+      entry.healthVerificationStatus === 'verified' &&
+      entry.itemLevelReviewRequired !== true &&
+      entry.currentUse.every(use => entry.permittedUse.includes(use))
+  );
+}
+
+export function evaluateItemUse(entry, itemAllowedUseStatus = null) {
+  if (!entry) return { allowedUseStatus: 'unknown', displayMode: 'headline-link' };
+  const statuses = [entry.allowedUseStatus];
+  if (itemAllowedUseStatus != null) {
+    if (!USE_STATUS_SET.has(itemAllowedUseStatus)) throw new TypeError('item allowed-use status is not supported');
+    statuses.push(itemAllowedUseStatus);
+  }
+  const allowedUseStatus = statuses.sort((a, b) => useRestrictionRank(b) - useRestrictionRank(a))[0];
+  return {
+    allowedUseStatus,
+    displayMode:
+      allowedUseStatus === 'verified-public-use'
+        ? 'current-use'
+        : allowedUseStatus === 'prohibited'
+          ? 'exclude'
+          : 'headline-link',
+  };
+}
+
+export function admissionSummary(admissions = SOURCE_ADMISSIONS) {
+  const validation = validateSourceAdmissions(SOURCES, admissions);
+  return {
+    valid: validation.valid,
+    totalLiveSources: admissions.length,
+    reviewedSources: admissions.filter(entry => entry.reviewState === 'reviewed').length,
+    legacyUnreviewedSources: admissions.filter(entry => entry.reviewState === 'legacy-unreviewed').length,
+    productionAdmissibleForNewSource: admissions.filter(isProductionAdmissible).length,
+    remediationSourceIds: admissions
+      .filter(entry => ['permission-required', 'contract-required', 'prohibited'].includes(entry.allowedUseStatus))
+      .map(entry => entry.sourceId)
+      .sort(),
+    unknownRightsSourceIds: admissions
+      .filter(entry => entry.allowedUseStatus === 'unknown')
+      .map(entry => entry.sourceId)
+      .sort(),
+  };
+}
+
+function legacy(name, endpointUrl, options = {}) {
+  return admission({
+    sourceId: slugifySourceName(name),
+    name,
+    endpointUrl,
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [endpointUrl],
+    authenticationRequirement: 'none-observed',
+    usagePolicyUrls: [],
+    allowedUseStatus: 'unknown',
+    currentUse: currentUse(Boolean(options.translated)),
+    permittedUse: [],
+    excerptMaxChars: 280,
+    syndicatedContentBehavior: 'unknown',
+    itemLevelReviewRequired: true,
+    itemLevelStrategy: 'restrict-on-explicit-item-signal',
+    reviewState: 'legacy-unreviewed',
+    reviewedAt: null,
+    reviewerNotes: 'Legacy source predates the admission contract; usage rights remain explicitly unreviewed.',
+    healthVerificationStatus: 'telemetry-managed',
+    legacy: true,
+    ...options,
+  });
+}
+
+function reviewedLegacy(name, endpointUrl, options) {
+  return admission({
+    sourceId: slugifySourceName(name),
+    name,
+    endpointUrl,
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [endpointUrl],
+    authenticationRequirement: 'none-observed',
+    usagePolicyUrls: [],
+    allowedUseStatus: 'unknown',
+    currentUse: currentUse(false),
+    permittedUse: [],
+    excerptMaxChars: 280,
+    syndicatedContentBehavior: 'unknown',
+    itemLevelReviewRequired: true,
+    itemLevelStrategy: 'restrict-on-explicit-item-signal',
+    reviewState: 'reviewed',
+    reviewedAt: ADMISSION_REVIEW_DATE,
+    reviewerNotes: '',
+    healthVerificationStatus: 'telemetry-managed',
+    legacy: true,
+    ...options,
+  });
+}
+
+function admission(definition) {
+  return Object.freeze({
+    ...definition,
+    endpointEvidenceUrls: Object.freeze([...(definition.endpointEvidenceUrls || [])]),
+    usagePolicyUrls: Object.freeze([...(definition.usagePolicyUrls || [])]),
+    currentUse: Object.freeze([...(definition.currentUse || [])]),
+    permittedUse: Object.freeze([...(definition.permittedUse || [])]),
+  });
+}
+
+function candidate(definition) {
+  return Object.freeze({
+    ...definition,
+    endpointEvidenceUrls: Object.freeze([...(definition.endpointEvidenceUrls || [])]),
+    usagePolicyUrls: Object.freeze([...(definition.usagePolicyUrls || [])]),
+    currentUse: Object.freeze(currentUse(false)),
+    permittedUse: Object.freeze([]),
+    authenticationRequirement: definition.authenticationRequirement || 'unknown',
+    healthVerificationStatus: 'research-only',
+    reviewedAt: ADMISSION_REVIEW_DATE,
+    itemLevelReviewRequired: definition.itemLevelReviewRequired === true,
+    syndicatedContentBehavior: definition.syndicatedContentBehavior || 'unknown',
+  });
+}
+
+function validAdmission(entry) {
+  return Boolean(
+    entry &&
+      typeof entry.sourceId === 'string' &&
+      typeof entry.name === 'string' &&
+      typeof entry.endpointUrl === 'string' &&
+      typeof entry.endpointType === 'string' &&
+      AUTHORITY_SET.has(entry.endpointAuthority) &&
+      Array.isArray(entry.endpointEvidenceUrls) &&
+      entry.endpointEvidenceUrls.length > 0 &&
+      typeof entry.authenticationRequirement === 'string' &&
+      Array.isArray(entry.usagePolicyUrls) &&
+      USE_STATUS_SET.has(entry.allowedUseStatus) &&
+      Array.isArray(entry.currentUse) &&
+      entry.currentUse.every(use => CURRENT_USE_SET.has(use)) &&
+      Array.isArray(entry.permittedUse) &&
+      Number.isInteger(entry.excerptMaxChars) &&
+      entry.excerptMaxChars >= 0 &&
+      typeof entry.syndicatedContentBehavior === 'string' &&
+      typeof entry.itemLevelReviewRequired === 'boolean' &&
+      typeof entry.itemLevelStrategy === 'string' &&
+      REVIEW_STATE_SET.has(entry.reviewState) &&
+      typeof entry.reviewerNotes === 'string' &&
+      typeof entry.healthVerificationStatus === 'string' &&
+      entry.legacy === true
+  );
+}
+
+function currentUse(translated) {
+  return translated
+    ? ['headline-link', 'metadata', 'excerpt', 'translated-headline-summary']
+    : ['headline-link', 'metadata', 'excerpt'];
+}
+
+function useRestrictionRank(status) {
+  return {
+    'verified-public-use': 0,
+    unknown: 1,
+    'permission-required': 2,
+    'contract-required': 3,
+    prohibited: 4,
+  }[status];
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  const repeated = new Set();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated].sort();
+}
+function unique(values) {
+  return [...new Set(values)].sort();
+}

--- a/functions/lib/news-source-admission.js
+++ b/functions/lib/news-source-admission.js
@@ -130,6 +130,12 @@ export const SOURCE_RESEARCH_CANDIDATES = Object.freeze([
 
 export const ADMISSION_FINGERPRINT = getAdmissionFingerprint();
 
+export function createSourceAdmission(definition) {
+  const entry = admission({ ...definition, legacy: definition?.legacy === true });
+  if (!validAdmission(entry)) throw new TypeError('source admission definition is invalid');
+  return entry;
+}
+
 export function getAdmissionFingerprint(admissions = SOURCE_ADMISSIONS, candidates = SOURCE_RESEARCH_CANDIDATES) {
   const canonical = [...admissions, ...candidates]
     .map(entry => JSON.stringify(entry))
@@ -168,6 +174,10 @@ export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_
     const entry = admissionById.get(id);
     return !entry || !REVIEW_STATE_SET.has(entry.reviewState) || entry.legacy !== true;
   });
+  const newSourceMarkedLegacyIds = sourceIds.filter(id => {
+    if (LEGACY_SOURCE_IDS.includes(id)) return false;
+    return admissionById.get(id)?.legacy === true;
+  });
 
   const result = {
     missingSourceIds: unique(missingSourceIds),
@@ -178,6 +188,7 @@ export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_
     nameDriftSourceIds: unique(nameDriftSourceIds),
     unadmittedNewSourceIds: unique(unadmittedNewSourceIds),
     legacyStateErrors: unique(legacyStateErrors),
+    newSourceMarkedLegacyIds: unique(newSourceMarkedLegacyIds),
   };
 
   return { valid: Object.values(result).every(values => values.length === 0), ...result };
@@ -186,6 +197,7 @@ export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_
 export function isProductionAdmissible(entry) {
   return Boolean(
     entry &&
+      entry.legacy === false &&
       entry.reviewState === 'reviewed' &&
       entry.allowedUseStatus === 'verified-public-use' &&
       ['first-party', 'authorized-third-party'].includes(entry.endpointAuthority) &&
@@ -221,7 +233,6 @@ export function admissionSummary(admissions = SOURCE_ADMISSIONS) {
     totalLiveSources: admissions.length,
     reviewedSources: admissions.filter(entry => entry.reviewState === 'reviewed').length,
     legacyUnreviewedSources: admissions.filter(entry => entry.reviewState === 'legacy-unreviewed').length,
-    productionAdmissibleForNewSource: admissions.filter(isProductionAdmissible).length,
     remediationSourceIds: admissions
       .filter(entry => ['permission-required', 'contract-required', 'prohibited'].includes(entry.allowedUseStatus))
       .map(entry => entry.sourceId)
@@ -326,6 +337,7 @@ function validAdmission(entry) {
       Array.isArray(entry.currentUse) &&
       entry.currentUse.every(use => CURRENT_USE_SET.has(use)) &&
       Array.isArray(entry.permittedUse) &&
+      entry.permittedUse.every(use => CURRENT_USE_SET.has(use)) &&
       Number.isInteger(entry.excerptMaxChars) &&
       entry.excerptMaxChars >= 0 &&
       typeof entry.syndicatedContentBehavior === 'string' &&
@@ -334,7 +346,7 @@ function validAdmission(entry) {
       REVIEW_STATE_SET.has(entry.reviewState) &&
       typeof entry.reviewerNotes === 'string' &&
       typeof entry.healthVerificationStatus === 'string' &&
-      entry.legacy === true
+      typeof entry.legacy === 'boolean'
   );
 }
 

--- a/functions/lib/news-source-admission.js
+++ b/functions/lib/news-source-admission.js
@@ -29,9 +29,8 @@ const AUTHORITY_SET = new Set(ENDPOINT_AUTHORITY_STATUSES);
 const REVIEW_STATE_SET = new Set(REVIEW_STATES);
 const CURRENT_USE_SET = new Set(CURRENT_USE_TYPES);
 
-// Frozen at the moment the admission gate was introduced. These IDs may remain live while their
-// usage review migrates from legacy-unreviewed to reviewed. Any source outside this set is new and
-// must be fully production-admissible before CI will accept it in SOURCES.
+// Frozen when the admission gate was introduced. Existing IDs may remain live while review debt
+// is migrated. Any ID outside this set is a new source and must satisfy production admission.
 export const LEGACY_SOURCE_IDS = Object.freeze([
   'abc-australia',
   'al-jazeera',
@@ -136,7 +135,10 @@ export function createSourceAdmission(definition) {
   return entry;
 }
 
-export function getAdmissionFingerprint(admissions = SOURCE_ADMISSIONS, candidates = SOURCE_RESEARCH_CANDIDATES) {
+export function getAdmissionFingerprint(
+  admissions = SOURCE_ADMISSIONS,
+  candidates = SOURCE_RESEARCH_CANDIDATES
+) {
   const canonical = [...admissions, ...candidates]
     .map(entry => JSON.stringify(entry))
     .sort()
@@ -150,24 +152,49 @@ export function getAdmissionFingerprint(admissions = SOURCE_ADMISSIONS, candidat
 }
 
 export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_ADMISSIONS) {
-  const canonicalSourceIds = sources.map(source => slugifySourceName(source.name));
-  const canonicalEndpointUrls = sources.map(source => source.url);
-  const sourceById = new Map(sources.map(source => [slugifySourceName(source.name), source]));
-  const admissionById = new Map(admissions.map(entry => [entry.sourceId, entry]));
+  const canonicalSourceIds = sources.map(source => safeSourceId(source));
+  const canonicalEndpointUrls = sources.map(source => source?.url).filter(Boolean);
+  const validSources = sources.filter(
+    source => typeof source?.name === 'string' && typeof source?.url === 'string'
+  );
+  const sourceById = new Map(validSources.map(source => [slugifySourceName(source.name), source]));
+  const admissionById = new Map(
+    admissions
+      .filter(entry => typeof entry?.sourceId === 'string')
+      .map(entry => [entry.sourceId, entry])
+  );
   const sourceIds = [...sourceById.keys()];
-  const admissionIds = admissions.map(entry => entry.sourceId);
+  const admissionIds = admissions
+    .map(entry => entry?.sourceId)
+    .filter(id => typeof id === 'string');
 
-  const duplicateCanonicalSourceIds = duplicates(canonicalSourceIds);
+  const duplicateCanonicalSourceIds = duplicates(canonicalSourceIds.filter(Boolean));
   const duplicateCanonicalEndpointUrls = duplicates(canonicalEndpointUrls);
+  const invalidCanonicalSources = sources
+    .map((source, index) => ({ source, index }))
+    .filter(({ source }) => !safeSourceId(source) || typeof source?.url !== 'string')
+    .map(({ index }) => `source-index:${index}`);
   const missingSourceIds = sourceIds.filter(id => !admissionById.has(id));
   const orphanSourceIds = admissionIds.filter(id => !sourceById.has(id));
   const duplicateIds = duplicates(admissionIds);
-  const invalidEntries = admissions.filter(entry => !validAdmission(entry)).map(entry => entry?.sourceId || '(missing-id)');
+  const invalidEntries = admissions
+    .filter(entry => !validAdmission(entry))
+    .map(entry => entry?.sourceId || '(missing-id)');
   const endpointDriftSourceIds = admissions
-    .filter(entry => sourceById.has(entry.sourceId) && sourceById.get(entry.sourceId).url !== entry.endpointUrl)
+    .filter(
+      entry =>
+        typeof entry?.sourceId === 'string' &&
+        sourceById.has(entry.sourceId) &&
+        sourceById.get(entry.sourceId).url !== entry.endpointUrl
+    )
     .map(entry => entry.sourceId);
   const nameDriftSourceIds = admissions
-    .filter(entry => sourceById.has(entry.sourceId) && sourceById.get(entry.sourceId).name !== entry.name)
+    .filter(
+      entry =>
+        typeof entry?.sourceId === 'string' &&
+        sourceById.has(entry.sourceId) &&
+        sourceById.get(entry.sourceId).name !== entry.name
+    )
     .map(entry => entry.sourceId);
   const unadmittedNewSourceIds = sourceIds.filter(id => {
     if (LEGACY_SOURCE_IDS.includes(id)) return false;
@@ -186,6 +213,7 @@ export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_
   const result = {
     duplicateCanonicalSourceIds,
     duplicateCanonicalEndpointUrls,
+    invalidCanonicalSources,
     missingSourceIds: unique(missingSourceIds),
     orphanSourceIds: unique(orphanSourceIds),
     duplicateIds,
@@ -201,30 +229,34 @@ export function validateSourceAdmissions(sources = SOURCES, admissions = SOURCE_
 }
 
 export function isProductionAdmissible(entry) {
+  if (!validAdmission(entry)) return false;
   return Boolean(
-    entry &&
-      entry.legacy === false &&
+    entry.legacy === false &&
       entry.reviewState === 'reviewed' &&
-      typeof entry.reviewedAt === 'string' &&
-      entry.reviewedAt.trim() &&
       entry.allowedUseStatus === 'verified-public-use' &&
       ['first-party', 'authorized-third-party'].includes(entry.endpointAuthority) &&
       entry.endpointEvidenceUrls.length > 0 &&
       entry.usagePolicyUrls.length > 0 &&
       entry.healthVerificationStatus === 'verified' &&
-      entry.itemLevelReviewRequired !== true &&
+      entry.itemLevelReviewRequired === false &&
       entry.currentUse.every(use => entry.permittedUse.includes(use))
   );
 }
 
 export function evaluateItemUse(entry, itemAllowedUseStatus = null) {
-  if (!entry) return { allowedUseStatus: 'unknown', displayMode: 'headline-link' };
+  if (!entry || !USE_STATUS_SET.has(entry.allowedUseStatus)) {
+    return { allowedUseStatus: 'unknown', displayMode: 'headline-link' };
+  }
   const statuses = [entry.allowedUseStatus];
   if (itemAllowedUseStatus != null) {
-    if (!USE_STATUS_SET.has(itemAllowedUseStatus)) throw new TypeError('item allowed-use status is not supported');
+    if (!USE_STATUS_SET.has(itemAllowedUseStatus)) {
+      throw new TypeError('item allowed-use status is not supported');
+    }
     statuses.push(itemAllowedUseStatus);
   }
-  const allowedUseStatus = statuses.sort((a, b) => useRestrictionRank(b) - useRestrictionRank(a))[0];
+  const allowedUseStatus = statuses.sort(
+    (a, b) => useRestrictionRank(b) - useRestrictionRank(a)
+  )[0];
   return {
     allowedUseStatus,
     displayMode:
@@ -241,14 +273,20 @@ export function admissionSummary(admissions = SOURCE_ADMISSIONS) {
   return {
     valid: validation.valid,
     totalLiveSources: admissions.length,
-    reviewedSources: admissions.filter(entry => entry.reviewState === 'reviewed').length,
-    legacyUnreviewedSources: admissions.filter(entry => entry.reviewState === 'legacy-unreviewed').length,
+    reviewedSources: admissions.filter(entry => entry?.reviewState === 'reviewed').length,
+    legacyUnreviewedSources: admissions.filter(
+      entry => entry?.reviewState === 'legacy-unreviewed'
+    ).length,
     remediationSourceIds: admissions
-      .filter(entry => ['permission-required', 'contract-required', 'prohibited'].includes(entry.allowedUseStatus))
+      .filter(entry =>
+        ['permission-required', 'contract-required', 'prohibited'].includes(
+          entry?.allowedUseStatus
+        )
+      )
       .map(entry => entry.sourceId)
       .sort(),
     unknownRightsSourceIds: admissions
-      .filter(entry => entry.allowedUseStatus === 'unknown')
+      .filter(entry => entry?.allowedUseStatus === 'unknown')
       .map(entry => entry.sourceId)
       .sort(),
   };
@@ -273,7 +311,8 @@ function legacy(name, endpointUrl, options = {}) {
     itemLevelStrategy: 'restrict-on-explicit-item-signal',
     reviewState: 'legacy-unreviewed',
     reviewedAt: null,
-    reviewerNotes: 'Legacy source predates the admission contract; usage rights remain explicitly unreviewed.',
+    reviewerNotes:
+      'Legacy source predates the admission contract; usage rights remain explicitly unreviewed.',
     healthVerificationStatus: 'telemetry-managed',
     legacy: true,
     ...options,
@@ -299,14 +338,14 @@ function reviewedLegacy(name, endpointUrl, options) {
     itemLevelStrategy: 'restrict-on-explicit-item-signal',
     reviewState: 'reviewed',
     reviewedAt: ADMISSION_REVIEW_DATE,
-    reviewerNotes: '',
+    reviewerNotes: 'Reviewed legacy source.',
     healthVerificationStatus: 'telemetry-managed',
     legacy: true,
     ...options,
   });
 }
 
-function admission(definition) {
+function admission(definition = {}) {
   return Object.freeze({
     ...definition,
     endpointEvidenceUrls: Object.freeze([...(definition.endpointEvidenceUrls || [])]),
@@ -332,49 +371,59 @@ function candidate(definition) {
 }
 
 function validAdmission(entry) {
-  const reviewedAtValid =
-    entry?.reviewState === 'legacy-unreviewed'
-      ? entry.reviewedAt == null || (typeof entry.reviewedAt === 'string' && entry.reviewedAt.trim())
-      : typeof entry?.reviewedAt === 'string' && entry.reviewedAt.trim();
-  return Boolean(
-    entry &&
-      typeof entry.sourceId === 'string' &&
-      entry.sourceId === slugifySourceName(entry.name) &&
-      typeof entry.name === 'string' &&
-      /^https:\/\//.test(entry.endpointUrl) &&
-      typeof entry.endpointType === 'string' &&
-      AUTHORITY_SET.has(entry.endpointAuthority) &&
-      Array.isArray(entry.endpointEvidenceUrls) &&
-      entry.endpointEvidenceUrls.length > 0 &&
-      entry.endpointEvidenceUrls.every(url => /^https:\/\//.test(url)) &&
-      typeof entry.authenticationRequirement === 'string' &&
-      Array.isArray(entry.usagePolicyUrls) &&
-      entry.usagePolicyUrls.every(url => /^https:\/\//.test(url)) &&
-      USE_STATUS_SET.has(entry.allowedUseStatus) &&
-      Array.isArray(entry.currentUse) &&
-      entry.currentUse.every(use => CURRENT_USE_SET.has(use)) &&
-      Array.isArray(entry.permittedUse) &&
-      entry.permittedUse.every(use => CURRENT_USE_SET.has(use)) &&
-      Number.isInteger(entry.excerptMaxChars) &&
-      entry.excerptMaxChars >= 0 &&
-      typeof entry.syndicatedContentBehavior === 'string' &&
-      typeof entry.itemLevelReviewRequired === 'boolean' &&
-      typeof entry.itemLevelStrategy === 'string' &&
-      REVIEW_STATE_SET.has(entry.reviewState) &&
-      reviewedAtValid &&
-      typeof entry.reviewerNotes === 'string' &&
-      entry.reviewerNotes.trim() &&
-      typeof entry.healthVerificationStatus === 'string' &&
-      typeof entry.legacy === 'boolean'
-  );
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+  if (typeof entry.name !== 'string' || !entry.name.trim()) return false;
+  if (typeof entry.sourceId !== 'string' || entry.sourceId !== slugifySourceName(entry.name)) {
+    return false;
+  }
+  if (typeof entry.endpointUrl !== 'string' || !isHttps(entry.endpointUrl)) return false;
+  if (typeof entry.endpointType !== 'string' || !entry.endpointType.trim()) return false;
+  if (!AUTHORITY_SET.has(entry.endpointAuthority)) return false;
+  if (!nonEmptyHttpsList(entry.endpointEvidenceUrls)) return false;
+  if (typeof entry.authenticationRequirement !== 'string') return false;
+  if (!httpsList(entry.usagePolicyUrls)) return false;
+  if (!USE_STATUS_SET.has(entry.allowedUseStatus)) return false;
+  if (!useList(entry.currentUse) || !useList(entry.permittedUse)) return false;
+  if (!Number.isInteger(entry.excerptMaxChars) || entry.excerptMaxChars < 0) return false;
+  if (typeof entry.syndicatedContentBehavior !== 'string') return false;
+  if (typeof entry.itemLevelReviewRequired !== 'boolean') return false;
+  if (typeof entry.itemLevelStrategy !== 'string' || !entry.itemLevelStrategy.trim()) return false;
+  if (!REVIEW_STATE_SET.has(entry.reviewState)) return false;
+  if (!reviewDateValid(entry.reviewState, entry.reviewedAt)) return false;
+  if (typeof entry.reviewerNotes !== 'string' || !entry.reviewerNotes.trim()) return false;
+  if (typeof entry.healthVerificationStatus !== 'string') return false;
+  return typeof entry.legacy === 'boolean';
 }
 
+function safeSourceId(source) {
+  return typeof source?.name === 'string' && source.name.trim()
+    ? slugifySourceName(source.name)
+    : null;
+}
+function reviewDateValid(reviewState, reviewedAt) {
+  if (reviewState === 'legacy-unreviewed') return reviewedAt == null || validDateText(reviewedAt);
+  return validDateText(reviewedAt);
+}
+function validDateText(value) {
+  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value.trim());
+}
+function isHttps(value) {
+  return /^https:\/\//.test(value);
+}
+function httpsList(values) {
+  return Array.isArray(values) && values.every(value => typeof value === 'string' && isHttps(value));
+}
+function nonEmptyHttpsList(values) {
+  return httpsList(values) && values.length > 0;
+}
+function useList(values) {
+  return Array.isArray(values) && values.every(use => CURRENT_USE_SET.has(use));
+}
 function currentUse(translated) {
   return translated
     ? ['headline-link', 'metadata', 'excerpt', 'translated-headline-summary']
     : ['headline-link', 'metadata', 'excerpt'];
 }
-
 function useRestrictionRank(status) {
   return {
     'verified-public-use': 0,
@@ -384,7 +433,6 @@ function useRestrictionRank(status) {
     prohibited: 4,
   }[status];
 }
-
 function duplicates(values) {
   const seen = new Set();
   const repeated = new Set();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/tests/news-admission-api.test.mjs
+++ b/tests/news-admission-api.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const root = mkdtempSync(join(tmpdir(), 'globaldeets-admission-api-'));
+const functions = join(root, 'functions');
+const files = [
+  ['../functions/api/news.js', join(functions, 'api', 'news.js')],
+  ['../functions/lib/news-source-admission.js', join(functions, 'lib', 'news-source-admission.js')],
+  ['../functions/api/news/admission.js', join(functions, 'api', 'news', 'admission.js')],
+];
+for (const [, target] of files) mkdirSync(dirname(target), { recursive: true });
+writeFileSync(join(functions, 'package.json'), '{"type":"module"}\n');
+for (const [source, target] of files) copyFileSync(fileURLToPath(new URL(source, import.meta.url)), target);
+
+const news = await import(pathToFileURL(join(functions, 'api', 'news.js')).href);
+const api = await import(pathToFileURL(join(functions, 'api', 'news', 'admission.js')).href);
+
+test('/api/news/admission exposes live review debt, research candidates, and fail-closed rules', async () => {
+  const response = await api.onRequestGet({
+    request: new Request('https://globaldeets.com/api/news/admission', {
+      headers: { Origin: 'https://globaldeets.com' },
+    }),
+  });
+  const json = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(json.sourceFingerprint, news.SOURCE_FINGERPRINT);
+  assert.match(json.admissionFingerprint, /^[0-9a-f]{8}$/);
+  assert.equal(json.validation.valid, true);
+  assert.equal(json.summary.totalLiveSources, 19);
+  assert.equal(json.summary.reviewedSources, 2);
+  assert.equal(json.summary.legacyUnreviewedSources, 17);
+  assert.deepEqual(json.summary.remediationSourceIds, ['ap', 'guardian']);
+  assert.equal(json.liveAdmissions.length, 19);
+  assert.equal(json.researchCandidates.length, 2);
+  assert.equal(json.rules.newSourcesRequireReviewedAdmission, true);
+  assert.equal(json.rules.itemRestrictionsOverrideSourcePermission, true);
+  assert.equal(json.rules.endpointAuthorityIsUsagePermission, false);
+  assert.equal(json.rules.feedHealthIsUsagePermission, false);
+  assert.equal(json.rules.admissionMetadataChangesNewsCacheIdentity, false);
+});

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -12,6 +12,7 @@ const fixtureCoverageApi = join(fixtureFunctions, 'api', 'news', 'coverage.js');
 const fixtureSourcesApi = join(fixtureFunctions, 'api', 'news', 'sources.js');
 const fixtureCoverageLib = join(fixtureFunctions, 'lib', 'news-coverage.js');
 const fixtureProvenanceLib = join(fixtureFunctions, 'lib', 'news-source-provenance.js');
+const fixtureAdmissionLib = join(fixtureFunctions, 'lib', 'news-source-admission.js');
 
 mkdirSync(dirname(fixtureCoverageApi), { recursive: true });
 mkdirSync(dirname(fixtureCoverageLib), { recursive: true });
@@ -33,15 +34,21 @@ copyFileSync(
   fileURLToPath(new URL('../functions/lib/news-source-provenance.js', import.meta.url)),
   fixtureProvenanceLib
 );
+copyFileSync(
+  fileURLToPath(new URL('../functions/lib/news-source-admission.js', import.meta.url)),
+  fixtureAdmissionLib
+);
 
 const newsModule = await import(pathToFileURL(fixtureNews).href);
 const provenanceModule = await import(pathToFileURL(fixtureProvenanceLib).href);
+const admissionModule = await import(pathToFileURL(fixtureAdmissionLib).href);
 const coverageModule = await import(pathToFileURL(fixtureCoverageLib).href);
 const coverageApiModule = await import(pathToFileURL(fixtureCoverageApi).href);
 const sourcesApiModule = await import(pathToFileURL(fixtureSourcesApi).href);
 
 const { SOURCES, SOURCE_FINGERPRINT } = newsModule;
 const { SOURCE_PROVENANCE, validateSourceProvenance } = provenanceModule;
+const { SOURCE_ADMISSIONS, createSourceAdmission } = admissionModule;
 const { buildCoverageInventory } = coverageModule;
 const { onRequestGet: getCoverage } = coverageApiModule;
 const { onRequestGet: getSources } = sourcesApiModule;
@@ -49,6 +56,35 @@ const { onRequestGet: getSources } = sourcesApiModule;
 function request(path = '/api/news/coverage') {
   return new Request(`https://globaldeets.com${path}`, {
     headers: { Origin: 'https://globaldeets.com' },
+  });
+}
+
+function reviewedAdmission(source) {
+  const currentUse =
+    source.lang === 'en'
+      ? ['headline-link', 'metadata', 'excerpt']
+      : ['headline-link', 'metadata', 'excerpt', 'translated-headline-summary'];
+  return createSourceAdmission({
+    sourceId: source.name.toLowerCase(),
+    name: source.name,
+    endpointUrl: source.url,
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [`${source.url}#evidence`],
+    authenticationRequirement: 'none',
+    usagePolicyUrls: [`${source.url}#terms`],
+    allowedUseStatus: 'verified-public-use',
+    currentUse,
+    permittedUse: currentUse,
+    excerptMaxChars: 280,
+    syndicatedContentBehavior: 'none-reviewed',
+    itemLevelReviewRequired: false,
+    itemLevelStrategy: 'preserve-origin-and-restrict-on-item-signal',
+    reviewState: 'reviewed',
+    reviewedAt: '2026-09-03',
+    reviewerNotes: 'Coverage fixture.',
+    healthVerificationStatus: 'verified',
+    legacy: false,
   });
 }
 
@@ -88,11 +124,7 @@ test('provenance validation rejects missing, orphaned, duplicate, drifted, and i
   assert.deepEqual(missing.missingSourceIds, [targetId]);
 
   const orphanEntry = { ...target, sourceId: 'not-a-live-source' };
-  const orphan = validateSourceProvenance(SOURCES, [
-    ...base,
-    orphanEntry,
-    { ...orphanEntry },
-  ]);
+  const orphan = validateSourceProvenance(SOURCES, [...base, orphanEntry, { ...orphanEntry }]);
   assert.equal(orphan.valid, false);
   assert.deepEqual(orphan.orphanSourceIds, ['not-a-live-source']);
 
@@ -123,11 +155,12 @@ test('provenance validation rejects missing, orphaned, duplicate, drifted, and i
   assert.ok(languageDrift.invalidEntries.includes(targetId));
 });
 
-test('coverage inventory is deterministic and enriched from reviewed provenance', () => {
-  const first = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE);
+test('coverage inventory is deterministic and enriched from reviewed provenance and admission state', () => {
+  const first = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE, SOURCE_ADMISSIONS);
   const second = buildCoverageInventory(
     SOURCES.map(source => ({ ...source })),
-    SOURCE_PROVENANCE.map(entry => ({ ...entry }))
+    SOURCE_PROVENANCE.map(entry => ({ ...entry })),
+    SOURCE_ADMISSIONS.map(entry => ({ ...entry }))
   );
 
   assert.deepEqual(first, second);
@@ -137,6 +170,10 @@ test('coverage inventory is deterministic and enriched from reviewed provenance'
   assert.equal(first.provenance.valid, true);
   assert.equal(first.provenance.reviewedSources, 19);
   assert.deepEqual(first.provenance.unknownOwnershipOperatorSourceIds, []);
+  assert.equal(first.admission.valid, true);
+  assert.equal(first.admission.reviewedSources, 2);
+  assert.equal(first.admission.legacyUnreviewedSources, 17);
+  assert.deepEqual(first.admission.remediationSourceIds, ['ap', 'guardian']);
   assert.equal(first.nonEnglishSources.length, 1);
   assert.ok(first.nonEnglishSources.includes('nhk'));
   assert.ok(first.sourceClasses.some(group => group.sourceClass === 'news-agency'));
@@ -144,8 +181,8 @@ test('coverage inventory is deterministic and enriched from reviewed provenance'
   assert.ok(first.sourceOriginCountries.some(group => group.country === 'UA'));
 });
 
-test('coverage inventory surfaces current evidence, locality, redundancy, and language blind spots', () => {
-  const inventory = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE);
+test('coverage inventory surfaces evidence, locality, language, and admission blind spots', () => {
+  const inventory = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE, SOURCE_ADMISSIONS);
   const gapIds = new Set(inventory.gaps.map(gap => gap.id));
 
   assert.equal(inventory.primarySourceInputs, 0);
@@ -158,9 +195,11 @@ test('coverage inventory surfaces current evidence, locality, redundancy, and la
   assert.ok(gapIds.has('source-language-diversity:europe'));
   assert.ok(gapIds.has('source-language-diversity:middle-east'));
   assert.ok(gapIds.has('source-language-diversity:pacific'));
+  assert.ok(gapIds.has('source-admission:legacy-review-backlog'));
+  assert.ok(gapIds.has('source-admission:remediation-required'));
 });
 
-test('coverage gap logic responds to stronger regional, language, primary-source, and local diversity', () => {
+test('coverage gap logic responds to stronger regional, language, primary-source, local, and admission diversity', () => {
   const sample = [
     { name: 'A', url: 'https://a.example/rss', region: 'alpha', lang: 'en' },
     { name: 'B', url: 'https://b.example/rss', region: 'alpha', lang: 'fr' },
@@ -181,16 +220,19 @@ test('coverage gap logic responds to stronger regional, language, primary-source
     evidenceUrls: [`https://${source.name.toLowerCase()}.example/about`],
     reviewedAt: '2026-09-03',
   }));
-  const inventory = buildCoverageInventory(sample, sampleProvenance);
+  const sampleAdmissions = sample.map(reviewedAdmission);
+  const inventory = buildCoverageInventory(sample, sampleProvenance, sampleAdmissions);
 
   assert.equal(inventory.gaps.length, 0);
   assert.equal(inventory.totalRegions, 2);
   assert.equal(inventory.totalLanguages, 4);
   assert.equal(inventory.englishSourceShare, 0.25);
   assert.equal(inventory.primarySourceInputs, 1);
+  assert.equal(inventory.admission.valid, true);
+  assert.equal(inventory.admission.legacyUnreviewedSources, 0);
 });
 
-test('/api/news/coverage exposes source fingerprint, provenance integrity, and actionable inventory', async () => {
+test('/api/news/coverage exposes source fingerprint, provenance integrity, admission debt, and actionable inventory', async () => {
   const response = await getCoverage({ request: request() });
   const json = await response.json();
 
@@ -200,14 +242,18 @@ test('/api/news/coverage exposes source fingerprint, provenance integrity, and a
   assert.equal(json.totalRegions, 7);
   assert.equal(json.provenance.valid, true);
   assert.equal(json.provenance.reviewedSources, 19);
+  assert.equal(json.admission.valid, true);
+  assert.equal(json.admission.legacyUnreviewedSources, 17);
+  assert.deepEqual(json.admission.remediationSourceIds, ['ap', 'guardian']);
   assert.ok(Array.isArray(json.sourceClasses));
   assert.ok(Array.isArray(json.evidenceRoles));
   assert.ok(Array.isArray(json.sourceOriginCountries));
   assert.ok(json.gaps.some(gap => gap.id === 'evidence-role:primary-source-inputs'));
+  assert.ok(json.gaps.some(gap => gap.id === 'source-admission:legacy-review-backlog'));
   assert.match(json.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 
-test('/api/news/sources exposes the reviewed registry and its evidence links', async () => {
+test('/api/news/sources exposes the reviewed provenance registry and its evidence links', async () => {
   const response = await getSources({ request: request('/api/news/sources') });
   const json = await response.json();
 

--- a/tests/news-source-admission-hardening.test.mjs
+++ b/tests/news-source-admission-hardening.test.mjs
@@ -76,3 +76,24 @@ test('production admission cannot be self-certified without dated review and usa
   const good = reviewed();
   assert.equal(admission.isProductionAdmissible(good), true);
 });
+
+test('malformed source and admission objects fail validation without throwing', () => {
+  const malformedAdmissions = [...admission.SOURCE_ADMISSIONS, { sourceId: 'broken' }, null];
+  const malformedSources = [...news.SOURCES, { url: 'https://broken.example/rss' }, null];
+
+  assert.doesNotThrow(() => admission.validateSourceAdmissions(news.SOURCES, malformedAdmissions));
+  assert.doesNotThrow(() => admission.validateSourceAdmissions(malformedSources, admission.SOURCE_ADMISSIONS));
+
+  const badAdmissionResult = admission.validateSourceAdmissions(news.SOURCES, malformedAdmissions);
+  assert.equal(badAdmissionResult.valid, false);
+  assert.ok(badAdmissionResult.invalidEntries.includes('broken'));
+  assert.ok(badAdmissionResult.invalidEntries.includes('(missing-id)'));
+
+  const badSourceResult = admission.validateSourceAdmissions(
+    malformedSources,
+    admission.SOURCE_ADMISSIONS
+  );
+  assert.equal(badSourceResult.valid, false);
+  assert.deepEqual(badSourceResult.invalidCanonicalSources, ['source-index:19', 'source-index:20']);
+  assert.equal(admission.isProductionAdmissible({ sourceId: 'broken' }), false);
+});

--- a/tests/news-source-admission-hardening.test.mjs
+++ b/tests/news-source-admission-hardening.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const root = mkdtempSync(join(tmpdir(), 'globaldeets-admission-hardening-'));
+const functions = join(root, 'functions');
+const newsPath = join(functions, 'api', 'news.js');
+const admissionPath = join(functions, 'lib', 'news-source-admission.js');
+mkdirSync(dirname(newsPath), { recursive: true });
+mkdirSync(dirname(admissionPath), { recursive: true });
+writeFileSync(join(functions, 'package.json'), '{"type":"module"}\n');
+copyFileSync(fileURLToPath(new URL('../functions/api/news.js', import.meta.url)), newsPath);
+copyFileSync(fileURLToPath(new URL('../functions/lib/news-source-admission.js', import.meta.url)), admissionPath);
+
+const news = await import(pathToFileURL(newsPath).href);
+const admission = await import(pathToFileURL(admissionPath).href);
+
+function reviewed(name = 'Example News', url = 'https://example.com/rss.xml', overrides = {}) {
+  const currentUse = ['headline-link', 'metadata', 'excerpt'];
+  return admission.createSourceAdmission({
+    sourceId: news.slugifySourceName(name),
+    name,
+    endpointUrl: url,
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [`${url}#feed`],
+    authenticationRequirement: 'none',
+    usagePolicyUrls: [`${url}#terms`],
+    allowedUseStatus: 'verified-public-use',
+    currentUse,
+    permittedUse: currentUse,
+    excerptMaxChars: 280,
+    syndicatedContentBehavior: 'none-reviewed',
+    itemLevelReviewRequired: false,
+    itemLevelStrategy: 'preserve-origin-and-restrict-on-item-signal',
+    reviewState: 'reviewed',
+    reviewedAt: '2026-09-03',
+    reviewerNotes: 'Reviewed fixture.',
+    healthVerificationStatus: 'verified',
+    legacy: false,
+    ...overrides,
+  });
+}
+
+test('duplicate canonical source IDs and duplicate endpoint URLs fail admission integrity', () => {
+  const duplicate = { ...news.SOURCES[0] };
+  const result = admission.validateSourceAdmissions([...news.SOURCES, duplicate]);
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.duplicateCanonicalSourceIds, [news.slugifySourceName(duplicate.name)]);
+  assert.deepEqual(result.duplicateCanonicalEndpointUrls, [duplicate.url]);
+});
+
+test('a second name cannot count the same endpoint twice even with an otherwise reviewed admission', () => {
+  const duplicateEndpointSource = {
+    name: 'Example News',
+    url: news.SOURCES[0].url,
+    region: 'global',
+    lang: 'en',
+  };
+  const entry = reviewed('Example News', duplicateEndpointSource.url);
+  const result = admission.validateSourceAdmissions(
+    [...news.SOURCES, duplicateEndpointSource],
+    [...admission.SOURCE_ADMISSIONS, entry]
+  );
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.duplicateCanonicalEndpointUrls, [duplicateEndpointSource.url]);
+});
+
+test('production admission cannot be self-certified without dated review and usage-policy evidence', () => {
+  assert.throws(() => reviewed('No Date News', 'https://nodate.example/rss', { reviewedAt: null }), /invalid/);
+  const noPolicy = reviewed('No Policy News', 'https://nopolicy.example/rss', { usagePolicyUrls: [] });
+  assert.equal(admission.isProductionAdmissible(noPolicy), false);
+  const good = reviewed();
+  assert.equal(admission.isProductionAdmissible(good), true);
+});

--- a/tests/news-source-admission.test.mjs
+++ b/tests/news-source-admission.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+const root = mkdtempSync(join(tmpdir(), 'globaldeets-admission-'));
+const functions = join(root, 'functions');
+const newsPath = join(functions, 'api', 'news.js');
+const admissionPath = join(functions, 'lib', 'news-source-admission.js');
+mkdirSync(dirname(newsPath), { recursive: true });
+mkdirSync(dirname(admissionPath), { recursive: true });
+writeFileSync(join(functions, 'package.json'), '{"type":"module"}\n');
+copyFileSync(fileURLToPath(new URL('../functions/api/news.js', import.meta.url)), newsPath);
+copyFileSync(fileURLToPath(new URL('../functions/lib/news-source-admission.js', import.meta.url)), admissionPath);
+
+const news = await import(pathToFileURL(newsPath).href);
+const admission = await import(pathToFileURL(admissionPath).href);
+
+function reviewedNewSource(overrides = {}) {
+  return admission.createSourceAdmission({
+    sourceId: 'example-news',
+    name: 'Example News',
+    endpointUrl: 'https://example.com/rss.xml',
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: ['https://example.com/rss-info'],
+    authenticationRequirement: 'none',
+    usagePolicyUrls: ['https://example.com/terms'],
+    allowedUseStatus: 'verified-public-use',
+    currentUse: ['headline-link', 'metadata', 'excerpt'],
+    permittedUse: ['headline-link', 'metadata', 'excerpt'],
+    excerptMaxChars: 280,
+    syndicatedContentBehavior: 'none-reviewed',
+    itemLevelReviewRequired: false,
+    itemLevelStrategy: 'preserve-origin-and-restrict-on-item-signal',
+    reviewState: 'reviewed',
+    reviewedAt: '2026-09-03',
+    reviewerNotes: 'Test fixture.',
+    healthVerificationStatus: 'verified',
+    legacy: false,
+    ...overrides,
+  });
+}
+
+const EXAMPLE_SOURCE = Object.freeze({
+  name: 'Example News',
+  url: 'https://example.com/rss.xml',
+  region: 'global',
+  lang: 'en',
+});
+
+test('all 19 live sources have exact admission records and explicit migration state', () => {
+  const validation = admission.validateSourceAdmissions();
+  assert.equal(validation.valid, true);
+  assert.equal(news.SOURCES.length, 19);
+  assert.equal(admission.SOURCE_ADMISSIONS.length, 19);
+  assert.equal(admission.LEGACY_SOURCE_IDS.length, 19);
+  assert.equal(new Set(admission.SOURCE_ADMISSIONS.map(entry => entry.sourceId)).size, 19);
+  assert.equal(admission.SOURCE_ADMISSIONS.every(entry => entry.legacy === true), true);
+  assert.equal(
+    admission.SOURCE_ADMISSIONS.every(entry => ['legacy-unreviewed', 'reviewed'].includes(entry.reviewState)),
+    true
+  );
+  const nhk = admission.SOURCE_ADMISSIONS.find(entry => entry.sourceId === 'nhk');
+  assert.ok(nhk.currentUse.includes('translated-headline-summary'));
+  assert.equal(nhk.excerptMaxChars, 280);
+});
+
+test('known AP and Guardian constraints remain visible without silently removing either source', () => {
+  const ap = admission.SOURCE_ADMISSIONS.find(entry => entry.sourceId === 'ap');
+  const guardian = admission.SOURCE_ADMISSIONS.find(entry => entry.sourceId === 'guardian');
+  assert.equal(ap.allowedUseStatus, 'contract-required');
+  assert.equal(ap.endpointAuthority, 'unverified-third-party');
+  assert.equal(guardian.allowedUseStatus, 'permission-required');
+  assert.equal(guardian.endpointAuthority, 'first-party');
+  assert.ok(news.SOURCES.some(source => source.name === 'AP'));
+  assert.ok(news.SOURCES.some(source => source.name === 'Guardian'));
+});
+
+test('a new canonical source without admission fails closed', () => {
+  const sources = [...news.SOURCES, EXAMPLE_SOURCE];
+  const result = admission.validateSourceAdmissions(sources, admission.SOURCE_ADMISSIONS);
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.missingSourceIds, ['example-news']);
+  assert.deepEqual(result.unadmittedNewSourceIds, ['example-news']);
+});
+
+test('a new source cannot masquerade as legacy to bypass admission', () => {
+  const fakeLegacy = reviewedNewSource({ legacy: true });
+  const sources = [...news.SOURCES, EXAMPLE_SOURCE];
+  const result = admission.validateSourceAdmissions(sources, [...admission.SOURCE_ADMISSIONS, fakeLegacy]);
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.newSourceMarkedLegacyIds, ['example-news']);
+  assert.deepEqual(result.unadmittedNewSourceIds, ['example-news']);
+});
+
+test('new source admission requires reviewed public use, endpoint authority, health, and permitted current use', () => {
+  const sources = [...news.SOURCES, EXAMPLE_SOURCE];
+  const good = reviewedNewSource();
+  assert.equal(admission.isProductionAdmissible(good), true);
+  assert.equal(
+    admission.validateSourceAdmissions(sources, [...admission.SOURCE_ADMISSIONS, good]).valid,
+    true
+  );
+
+  const badAuthority = reviewedNewSource({ endpointAuthority: 'unverified-third-party' });
+  const badRights = reviewedNewSource({ allowedUseStatus: 'permission-required' });
+  const badHealth = reviewedNewSource({ healthVerificationStatus: 'telemetry-managed' });
+  const badUse = reviewedNewSource({ permittedUse: ['headline-link', 'metadata'] });
+  for (const entry of [badAuthority, badRights, badHealth, badUse]) {
+    assert.equal(admission.isProductionAdmissible(entry), false);
+    const result = admission.validateSourceAdmissions(sources, [...admission.SOURCE_ADMISSIONS, entry]);
+    assert.deepEqual(result.unadmittedNewSourceIds, ['example-news']);
+  }
+});
+
+test('endpoint identity drift invalidates its admission review separately from feed health', () => {
+  const changedSources = news.SOURCES.map(source =>
+    source.name === 'BBC World' ? { ...source, url: 'https://example.com/changed-feed.xml' } : source
+  );
+  const result = admission.validateSourceAdmissions(changedSources);
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.endpointDriftSourceIds, ['bbc-world']);
+});
+
+test('item-level restriction overrides broader source-level permission', () => {
+  const entry = reviewedNewSource();
+  assert.deepEqual(admission.evaluateItemUse(entry), {
+    allowedUseStatus: 'verified-public-use',
+    displayMode: 'current-use',
+  });
+  assert.deepEqual(admission.evaluateItemUse(entry, 'permission-required'), {
+    allowedUseStatus: 'permission-required',
+    displayMode: 'headline-link',
+  });
+  assert.deepEqual(admission.evaluateItemUse(entry, 'prohibited'), {
+    allowedUseStatus: 'prohibited',
+    displayMode: 'exclude',
+  });
+  const sourceRestricted = reviewedNewSource({ allowedUseStatus: 'contract-required' });
+  assert.equal(
+    admission.evaluateItemUse(sourceRestricted, 'verified-public-use').allowedUseStatus,
+    'contract-required'
+  );
+});
+
+test('research candidates remain queryable but cannot become production by implication', () => {
+  const rnz = admission.SOURCE_RESEARCH_CANDIDATES.find(entry => entry.candidateId === 'rnz-pacific');
+  const brasil = admission.SOURCE_RESEARCH_CANDIDATES.find(entry => entry.candidateId === 'agencia-brasil');
+  assert.equal(rnz.disposition, 'research');
+  assert.equal(rnz.allowedUseStatus, 'permission-required');
+  assert.equal(brasil.disposition, 'research');
+  assert.equal(brasil.allowedUseStatus, 'verified-public-use');
+  assert.equal(brasil.itemLevelReviewRequired, true);
+  assert.equal(brasil.syndicatedContentBehavior, 'mixed-rights-partner-content');
+  assert.equal(admission.SOURCE_RESEARCH_CANDIDATES.some(entry => entry.name === 'RNZ Pacific'), true);
+  assert.equal(admission.SOURCE_RESEARCH_CANDIDATES.some(entry => entry.name === 'Agencia Brasil'), true);
+});
+
+test('admission telemetry changes independently of the canonical news feed cache fingerprint', () => {
+  const sourceFingerprint = news.SOURCE_FINGERPRINT;
+  const changed = admission.SOURCE_ADMISSIONS.map(entry =>
+    entry.sourceId === 'bbc-world' ? { ...entry, reviewerNotes: `${entry.reviewerNotes} Reviewed note.` } : entry
+  );
+  assert.equal(news.getSourceFingerprint(news.SOURCES), sourceFingerprint);
+  assert.notEqual(admission.getAdmissionFingerprint(changed), admission.ADMISSION_FINGERPRINT);
+});

--- a/tools/verify-intelligence-prod.js
+++ b/tools/verify-intelligence-prod.js
@@ -30,24 +30,53 @@ function requireCondition(condition, message) {
 }
 
 (async () => {
-  const [coverage, sources, schema, evidenceSchema] = await Promise.all([
+  const [coverage, sources, admission, schema, evidenceSchema] = await Promise.all([
     fetchJson('/api/news/coverage'),
     fetchJson('/api/news/sources'),
+    fetchJson('/api/news/admission'),
     fetchJson('/api/intelligence/schema'),
     fetchJson('/api/intelligence/evidence-schema'),
   ]);
 
   requireCondition(typeof coverage.sourceFingerprint === 'string', 'coverage fingerprint missing');
   requireCondition(typeof sources.sourceFingerprint === 'string', 'sources fingerprint missing');
-  requireCondition(coverage.sourceFingerprint === sources.sourceFingerprint, 'coverage and source provenance fingerprints disagree');
+  requireCondition(typeof admission.sourceFingerprint === 'string', 'admission source fingerprint missing');
+  requireCondition(
+    coverage.sourceFingerprint === sources.sourceFingerprint &&
+      sources.sourceFingerprint === admission.sourceFingerprint,
+    'coverage, provenance, and admission source fingerprints disagree'
+  );
   requireCondition(coverage.provenance?.valid === true, 'coverage provenance validation failed');
+  requireCondition(coverage.admission?.valid === true, 'coverage admission validation failed');
   requireCondition(sources.validation?.valid === true, 'source registry validation failed');
+  requireCondition(admission.validation?.valid === true, 'source admission registry validation failed');
   requireCondition(Number.isInteger(coverage.totalSources), 'coverage totalSources missing');
   requireCondition(Number.isInteger(sources.totalSources), 'sources totalSources missing');
   requireCondition(Array.isArray(sources.sources), 'sources array missing');
+  requireCondition(Array.isArray(admission.liveAdmissions), 'live admission array missing');
+  requireCondition(Array.isArray(admission.researchCandidates), 'admission research candidate array missing');
   requireCondition(Array.isArray(coverage.gaps), 'coverage gaps array missing');
-  requireCondition(coverage.totalSources === sources.totalSources && sources.totalSources === sources.sources.length, 'source counts disagree across intelligence APIs');
-  requireCondition(sources.sources.every(source => Array.isArray(source.evidenceUrls) && source.evidenceUrls.length > 0), 'one or more source provenance records lack evidence URLs');
+  requireCondition(
+    coverage.totalSources === sources.totalSources &&
+      sources.totalSources === sources.sources.length &&
+      sources.totalSources === admission.liveAdmissions.length,
+    'source counts disagree across intelligence APIs'
+  );
+  requireCondition(
+    sources.sources.every(source => Array.isArray(source.evidenceUrls) && source.evidenceUrls.length > 0),
+    'one or more source provenance records lack evidence URLs'
+  );
+  requireCondition(typeof admission.admissionFingerprint === 'string', 'admission fingerprint missing');
+  requireCondition(admission.rules?.newSourcesRequireReviewedAdmission === true, 'new source admission gate changed');
+  requireCondition(admission.rules?.legacyUnreviewedMayRemainTemporarily === true, 'legacy migration boundary changed');
+  requireCondition(admission.rules?.endpointAuthorityIsUsagePermission === false, 'endpoint authority must remain separate from usage permission');
+  requireCondition(admission.rules?.feedHealthIsUsagePermission === false, 'feed health must remain separate from usage permission');
+  requireCondition(admission.rules?.itemRestrictionsOverrideSourcePermission === true, 'item restriction override contract changed');
+  requireCondition(admission.rules?.admissionMetadataChangesNewsCacheIdentity === false, 'admission metadata must not alter news cache identity');
+  requireCondition(
+    admission.liveAdmissions.every(entry => ['legacy-unreviewed', 'reviewed'].includes(entry.reviewState)),
+    'one or more live admissions lack explicit migration state'
+  );
 
   requireCondition(typeof schema.modelVersion === 'string', 'intelligence model version missing');
   requireCondition(Array.isArray(schema.entityTypes) && schema.entityTypes.includes('place'), 'place entity type missing');
@@ -74,7 +103,9 @@ function requireCondition(condition, message) {
   requireCondition(Number.isInteger(evidenceSchema.institutionalSources?.reviewedSources) && evidenceSchema.institutionalSources.reviewedSources > 0, 'reviewed institutional source count missing');
   requireCondition(evidenceSchema.institutionalSources?.collectionEligibleSources === 0, 'GD-015 must not silently enable institutional collection');
 
-  console.log(`Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} reviewed institutional candidates, models ${schema.modelVersion}/${evidenceSchema.modelVersion}`);
+  console.log(
+    `Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} reviewed institutional candidates, admission ${admission.admissionFingerprint}, models ${schema.modelVersion}/${evidenceSchema.modelVersion}`
+  );
 })().catch(error => {
   console.error(`Intelligence API verification failed: ${error.message}`);
   process.exit(1);


### PR DESCRIPTION
## Source admission / usage-rights governance

Implements the fail-closed gate specified in #20 without changing any live feed endpoint, item display behavior, or news cache identity.

### What changes
- Adds one admission record for each of the existing 19 live sources, with explicit `legacy-unreviewed` or `reviewed` migration state.
- Freezes the pre-gate 19-source ID set so a future source cannot self-declare as legacy to bypass review.
- Requires every genuinely new canonical source to have reviewed public-use status, acceptable endpoint authority, verified health, resolved item-level handling, and reviewed permission for every intended use.
- Records the actual GlobalDeets RSS use profile: headline/link, metadata, 280-character summary/excerpt, and translated headline/summary for non-English feeds.
- Separates endpoint authority, usage rights, provenance, and technical health.
- Preserves AP as a visible legacy source while recording the current RSSHub dependency as `unverified-third-party` / `contract-required` research debt.
- Preserves Guardian while recording its reviewed `permission-required` remediation state.
- Preserves RNZ Pacific and Agencia Brasil as queryable non-live research candidates rather than repeatedly rediscovering them or silently admitting them.
- Adds deterministic item-level override semantics so stricter item rights override broader source-level permission.
- Rejects duplicate canonical source IDs and duplicate endpoint URLs so one feed cannot inflate coverage under multiple definitions.
- Requires dated review and usage-policy evidence before a new source can become production-admissible.
- Adds independent admission fingerprinting without altering the existing news source/cache fingerprint.
- Adds `GET /api/news/admission`.
- Adds admission integrity/backlog/remediation signals to `/api/news/coverage` for later GD-017 consumption.
- Extends production intelligence verification to certify admission invariants after deploy.
- Adds adversarial contracts for missing admission, fake legacy bypass, duplicate feeds, endpoint drift, unreviewed authority/rights/health/use, item-level restrictions, research-candidate preservation, and cache-identity separation.

### Explicit backlog, not hidden completion
- 17 legacy live sources remain `legacy-unreviewed` for usage rights and are surfaced as a high-severity review backlog.
- AP and Guardian are the two reviewed live remediation cases in this tranche.
- The remaining 17 source-by-source reviews are explicitly tracked in #25.

### Non-goals
- no legal conclusion
- no inference from robots.txt
- no inference from feed health or first-party hosting
- no live source additions/removals
- no automatic display restriction enforcement in the parser yet
- no unofficial AP replacement

Closes #20 after merge. Issue #25 remains open until the other 17 legacy live sources have publisher/endpoint-specific reviews.