### PR TITLE
GD-016: Ship Santa Ynez evidence dossier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           echo "Checking required files..."
           test -f index.html     || (echo "MISSING: index.html" && exit 1)
           test -f _headers       || (echo "MISSING: _headers" && exit 1)
+          test -f dossiers/santa-ynez-pipeline/index.html || (echo "MISSING: Santa Ynez dossier" && exit 1)
           echo "All required files present."
 
       - name: Verify GA4 tag present
@@ -52,6 +53,7 @@ jobs:
           node --check functions/api/news/admission.js
           node --check functions/api/intelligence/schema.js
           node --check functions/api/intelligence/evidence-schema.js
+          node --check functions/api/intelligence/dossiers/santa-ynez-pipeline.js
           node --check functions/lib/news-coverage.js
           node --check functions/lib/news-source-provenance.js
           node --check functions/lib/news-source-admission.js
@@ -59,6 +61,9 @@ jobs:
           node --check functions/lib/m49-place-seed.js
           node --check functions/lib/claim-evidence-model.js
           node --check functions/lib/institutional-evidence-sources.js
+          node --check functions/lib/dossier-integrity.js
+          node --check functions/lib/santa-ynez-dossier.js
+          node --check dossiers/santa-ynez-pipeline/dossier.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
           node --check tests/news-source-admission.test.mjs
@@ -66,6 +71,7 @@ jobs:
           node --check tests/news-admission-api.test.mjs
           node --check tests/intelligence-model.test.mjs
           node --check tests/claim-evidence-model.test.mjs
+          node --check tests/santa-ynez-dossier.test.mjs
 
       - name: Lint JavaScript
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           node --check functions/lib/dossier-integrity.js
           node --check functions/lib/santa-ynez-dossier.js
           node --check dossiers/santa-ynez-pipeline/dossier.js
+          node --check shared/ecosystem-nav.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
           node --check tests/news-source-admission.test.mjs

--- a/dossiers/dossier.css
+++ b/dossiers/dossier.css
@@ -1,0 +1,561 @@
+:root {
+  color-scheme: dark;
+  --bg: #071014;
+  --panel: rgba(14, 28, 34, 0.82);
+  --panel-strong: rgba(18, 37, 44, 0.96);
+  --line: rgba(139, 216, 232, 0.18);
+  --line-strong: rgba(139, 216, 232, 0.38);
+  --text: #edf8fa;
+  --muted: #9fb8be;
+  --accent: #8bd8e8;
+  --accent-strong: #d7f7ff;
+  --amber: #e7bc73;
+  --danger: #e8a39b;
+  --max: 1180px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 80% -10%, rgba(57, 142, 159, 0.18), transparent 34rem),
+    linear-gradient(180deg, #071014 0%, #09151a 55%, #071014 100%);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(139, 216, 232, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(139, 216, 232, 0.025) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, black, transparent 70%);
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent-strong);
+}
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 10;
+  padding: 0.55rem 0.8rem;
+  border-radius: 0.5rem;
+  background: var(--text);
+  color: var(--bg);
+  transform: translateY(-180%);
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.dossier-shell {
+  width: min(calc(100% - 2rem), var(--max));
+  margin-inline: auto;
+}
+
+.dossier-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 84px;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  color: var(--accent-strong);
+  font-weight: 800;
+  letter-spacing: -0.05em;
+  box-shadow: inset 0 0 20px rgba(139, 216, 232, 0.08);
+}
+
+.brand strong,
+.brand small {
+  display: block;
+}
+
+.brand strong {
+  letter-spacing: -0.02em;
+}
+
+.brand small {
+  color: var(--muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.dossier-nav,
+.dossier-footer div {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.dossier-nav a,
+.dossier-footer a {
+  color: var(--muted);
+  font-size: 0.88rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.dossier-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(230px, 320px);
+  gap: clamp(2rem, 6vw, 5rem);
+  align-items: end;
+  padding: clamp(4rem, 9vw, 8rem) 0 2.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.7rem;
+  color: var(--accent);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1,
+h2 {
+  font-family: "Space Grotesk", Inter, ui-sans-serif, system-ui, sans-serif;
+  line-height: 1.05;
+  letter-spacing: -0.04em;
+}
+
+h1 {
+  max-width: 900px;
+  margin-bottom: 1.3rem;
+  font-size: clamp(2.6rem, 7vw, 6.3rem);
+}
+
+h1 span {
+  color: var(--muted);
+  font-weight: 520;
+}
+
+h2 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.9rem, 4vw, 3.3rem);
+}
+
+.hero-dek,
+.section-heading > p:last-child {
+  max-width: 780px;
+  color: var(--muted);
+  font-size: clamp(1rem, 1.8vw, 1.18rem);
+}
+
+.integrity-panel {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--line);
+  border-radius: 0.85rem;
+  background: var(--panel);
+}
+
+.integrity-panel strong,
+.integrity-panel small {
+  display: block;
+}
+
+.integrity-panel small {
+  margin-top: 0.15rem;
+  color: var(--muted);
+}
+
+.integrity-light {
+  width: 11px;
+  height: 11px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 18px rgba(231, 188, 115, 0.5);
+}
+
+body[data-dossier-ready="true"] .integrity-light {
+  background: var(--accent);
+  box-shadow: 0 0 18px rgba(139, 216, 232, 0.65);
+}
+
+body[data-dossier-error="true"] .integrity-light {
+  background: var(--danger);
+  box-shadow: 0 0 18px rgba(232, 163, 155, 0.55);
+}
+
+.status-line {
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.error-panel {
+  margin: 1.5rem 0;
+  padding: 1rem 1.2rem;
+  border: 1px solid rgba(232, 163, 155, 0.45);
+  border-radius: 0.75rem;
+  background: rgba(93, 32, 28, 0.32);
+  color: #ffd9d5;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  margin: 2rem 0 clamp(4rem, 8vw, 7rem);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: var(--line);
+}
+
+.stat-grid article {
+  min-height: 120px;
+  padding: 1.25rem;
+  background: var(--panel-strong);
+}
+
+.stat-grid strong,
+.stat-grid span {
+  display: block;
+}
+
+.stat-grid strong {
+  color: var(--accent-strong);
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1;
+}
+
+.stat-grid span {
+  margin-top: 0.7rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+}
+
+.dossier-section {
+  padding: clamp(3.5rem, 8vw, 7rem) 0;
+  border-top: 1px solid var(--line);
+}
+
+.section-heading {
+  margin-bottom: 2rem;
+}
+
+.card-grid,
+.evidence-grid,
+.method-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.claim-card,
+.evidence-card,
+.method-grid article,
+.correction-card,
+.conflict-card {
+  border: 1px solid var(--line);
+  border-radius: 0.9rem;
+  background: var(--panel);
+}
+
+.claim-card,
+.evidence-card,
+.method-grid article {
+  padding: 1.25rem;
+}
+
+.claim-meta,
+.evidence-meta,
+.timeline-meta {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.8rem;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.pill {
+  padding: 0.16rem 0.48rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+}
+
+.claim-card p,
+.conflict-side p,
+.evidence-card p,
+.correction-card p,
+.method-grid p {
+  color: #d5e7ea;
+}
+
+.claim-source,
+.evidence-issuer {
+  margin-bottom: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.conflict-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.conflict-card {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 1rem;
+  align-items: stretch;
+  padding: 1rem;
+}
+
+.conflict-side {
+  padding: 1.1rem;
+  border-radius: 0.7rem;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.conflict-divider {
+  display: grid;
+  place-items: center;
+  color: var(--amber);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.correction-section {
+  border-top-color: rgba(231, 188, 115, 0.38);
+}
+
+.correction-card {
+  padding: clamp(1.25rem, 4vw, 2rem);
+  border-color: rgba(231, 188, 115, 0.38);
+  background: linear-gradient(135deg, rgba(77, 57, 24, 0.28), var(--panel));
+}
+
+.correction-card strong {
+  color: #f2d59f;
+}
+
+.timeline-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: minmax(100px, 140px) 1fr;
+  gap: 1.5rem;
+  padding: 1.35rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.timeline-date {
+  color: var(--accent);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.timeline-copy h3,
+.evidence-card h3 {
+  margin: 0 0 0.55rem;
+  font-size: 1.03rem;
+}
+
+.timeline-copy p {
+  margin-bottom: 0.65rem;
+  color: var(--muted);
+}
+
+.record-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.55rem;
+  font-size: 0.84rem;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.source-details {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.source-details summary {
+  padding: 1rem 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 750;
+}
+
+.source-list {
+  display: grid;
+  gap: 0;
+}
+
+.source-row {
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) minmax(180px, 0.75fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 0.9rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.source-row span {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.unknown-section {
+  border-top-color: rgba(231, 188, 115, 0.28);
+}
+
+.unknown-list {
+  display: grid;
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.unknown-list li {
+  padding: 1rem 1.1rem;
+  border-left: 2px solid var(--amber);
+  background: rgba(231, 188, 115, 0.055);
+  color: #e7d8bb;
+}
+
+.method-grid article strong {
+  display: block;
+  margin-bottom: 0.45rem;
+  color: var(--accent-strong);
+}
+
+.method-grid article p {
+  margin-bottom: 0;
+  color: var(--muted);
+}
+
+.dossier-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 2rem 0 4rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.noscript {
+  width: min(calc(100% - 2rem), var(--max));
+  margin: 1rem auto;
+  color: var(--danger);
+}
+
+@media (max-width: 760px) {
+  .dossier-header,
+  .dossier-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-block: 1rem;
+  }
+
+  .dossier-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .dossier-hero {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    padding-top: 3.5rem;
+  }
+
+  h1 {
+    font-size: clamp(2.6rem, 15vw, 4.5rem);
+  }
+
+  .stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .card-grid,
+  .evidence-grid,
+  .method-grid,
+  .conflict-card,
+  .timeline-item,
+  .source-row {
+    grid-template-columns: 1fr;
+  }
+
+  .conflict-divider {
+    min-height: 34px;
+  }
+
+  .timeline-item {
+    gap: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/dossiers/santa-ynez-pipeline/dossier.js
+++ b/dossiers/santa-ynez-pipeline/dossier.js
@@ -1,0 +1,260 @@
+const DOSSIER_API = '/api/intelligence/dossiers/santa-ynez-pipeline';
+
+const app = document.getElementById('dossier-app');
+const statusLine = document.getElementById('dossier-status');
+const errorPanel = document.getElementById('dossier-error');
+
+loadDossier();
+
+async function loadDossier() {
+  try {
+    const response = await fetch(DOSSIER_API, {
+      headers: { Accept: 'application/json', 'Cache-Control': 'no-cache' },
+    });
+    if (!response.ok) throw new Error(`Evidence API returned HTTP ${response.status}`);
+    const dossier = await response.json();
+    if (dossier?.validation?.valid !== true || dossier?.integrity?.valid !== true) {
+      throw new Error('Evidence graph failed integrity validation');
+    }
+    if (dossier.dossierId !== 'santa-ynez-pipeline') {
+      throw new Error('Unexpected dossier identity');
+    }
+
+    renderDossier(dossier);
+    document.body.dataset.dossierReady = 'true';
+    app.setAttribute('aria-busy', 'false');
+    statusLine.textContent = `Integrity validated · ${dossier.claims.length} attributed claims · ${dossier.evidence.length} evidence records`;
+  } catch (error) {
+    document.body.dataset.dossierError = 'true';
+    app.setAttribute('aria-busy', 'false');
+    errorPanel.hidden = false;
+    errorPanel.textContent = `This dossier is unavailable because GlobalDeets could not verify a consistent evidence graph. ${errorMessage(error)}`;
+    statusLine.textContent = 'Evidence graph withheld';
+    document.getElementById('integrity-label').textContent = 'Integrity check failed';
+    document.getElementById('reviewed-label').textContent = 'Inconsistent intelligence is not published';
+  }
+}
+
+function renderDossier(dossier) {
+  const sourceById = new Map(dossier.sources.map(source => [source.id, source]));
+  const entityById = new Map(dossier.entities.map(entity => [entity.id, entity]));
+  const eventById = new Map(dossier.events.map(event => [event.id, event]));
+  const claimById = new Map(dossier.claims.map(claim => [claim.id, claim]));
+  const evidenceById = new Map(dossier.evidence.map(evidence => [evidence.id, evidence]));
+
+  document.getElementById('integrity-label').textContent = 'Graph integrity validated';
+  document.getElementById('reviewed-label').textContent = `Reviewed ${formatDate(dossier.reviewedAt)} · version ${dossier.dossierVersion}`;
+  setText('stat-entities', dossier.entities.length);
+  setText('stat-events', dossier.events.length);
+  setText('stat-claims', dossier.claims.length);
+  setText('stat-evidence', dossier.evidence.length);
+
+  renderClaimCards(
+    'established-claims',
+    dossier.claims.filter(claim => claim.type === 'fact-assertion' && claim.state === 'corroborated'),
+    sourceById
+  );
+
+  renderConflicts(dossier.claimRelations, claimById, sourceById);
+
+  renderClaimCards(
+    'attributed-claims',
+    dossier.claims.filter(
+      claim => claim.state === 'single-source' || claim.type === 'official-position'
+    ),
+    sourceById
+  );
+
+  renderCorrections(dossier.corrections, entityById, evidenceById);
+  renderTimeline(dossier.timeline, eventById, claimById, evidenceById);
+  renderEvidence(dossier.evidence, entityById);
+  renderSources(dossier.sources);
+  renderUnknowns(dossier.unknowns);
+}
+
+function renderClaimCards(containerId, claims, sourceById) {
+  const container = document.getElementById(containerId);
+  container.replaceChildren(
+    ...claims.map(claim => {
+      const source = sourceById.get(claim.originSourceId);
+      const card = element('article', 'claim-card');
+      const meta = element('div', 'claim-meta');
+      meta.append(
+        pill(humanize(claim.state)),
+        pill(humanize(claim.type))
+      );
+      card.append(
+        meta,
+        element('p', null, claim.proposition),
+        element('p', 'claim-source', `Origin: ${source?.name || claim.originSourceId}`)
+      );
+      if (source?.url) card.append(recordLink(source.url, 'Open origin record'));
+      return card;
+    })
+  );
+}
+
+function renderConflicts(relations, claimById, sourceById) {
+  const container = document.getElementById('conflict-list');
+  const conflicts = relations.filter(relation => relation.relation === 'contradicts');
+  container.replaceChildren(
+    ...conflicts.map(relation => {
+      const leftClaim = claimById.get(relation.claimId);
+      const rightClaim = claimById.get(relation.relatedClaimId);
+      const card = element('article', 'conflict-card');
+      card.append(
+        conflictSide(leftClaim, sourceById),
+        element('div', 'conflict-divider', 'conflicts with'),
+        conflictSide(rightClaim, sourceById)
+      );
+      return card;
+    })
+  );
+}
+
+function conflictSide(claim, sourceById) {
+  const side = element('div', 'conflict-side');
+  if (!claim) {
+    side.append(element('p', null, 'Referenced claim unavailable.'));
+    return side;
+  }
+  const source = sourceById.get(claim.originSourceId);
+  side.append(
+    element('div', 'claim-meta', source?.name || claim.originSourceId),
+    element('p', null, claim.proposition)
+  );
+  if (source?.url) side.append(recordLink(source.url, 'Open attributed source'));
+  return side;
+}
+
+function renderCorrections(corrections, entityById, evidenceById) {
+  const container = document.getElementById('correction-list');
+  container.replaceChildren(
+    ...corrections.map(correction => {
+      const card = element('article', 'correction-card');
+      const issuer = entityById.get(correction.issuerEntityId);
+      const evidence = correction.evidenceIds.map(id => evidenceById.get(id)).filter(Boolean);
+      card.append(
+        element('div', 'claim-meta', `${formatDate(correction.observedAt)} · ${issuer?.displayName || 'Attributed issuer'}`),
+        element('strong', null, 'Correction retained in the provenance graph'),
+        element('p', null, correction.description),
+        element(
+          'p',
+          'claim-source',
+          correction.originalArtifactRetained
+            ? 'The original corrected artifact is retained.'
+            : 'The original mistaken artifact is not retained in this snapshot; that absence remains explicit.'
+        )
+      );
+      if (evidence[0]?.canonicalRef) card.append(recordLink(evidence[0].canonicalRef, 'Open corrected record'));
+      return card;
+    })
+  );
+}
+
+function renderTimeline(timeline, eventById, claimById, evidenceById) {
+  const container = document.getElementById('timeline-list');
+  container.replaceChildren(
+    ...timeline.map(item => {
+      const event = eventById.get(item.eventId);
+      const claims = item.claimIds.map(id => claimById.get(id)).filter(Boolean);
+      const evidence = item.evidenceIds.map(id => evidenceById.get(id)).filter(Boolean);
+      const row = element('li', 'timeline-item');
+      const copy = element('div', 'timeline-copy');
+      copy.append(
+        element('div', 'timeline-meta', `${humanize(event?.eventType || 'event')} · ${humanize(event?.status || 'recorded')}`),
+        element('h3', null, item.label)
+      );
+      if (claims.length) copy.append(element('p', null, claims.map(claim => claim.proposition).join(' ')));
+      if (evidence.length) {
+        const refs = element('div', 'timeline-meta');
+        refs.append(...evidence.map(record => pill(humanize(record.documentType))));
+        copy.append(refs);
+      }
+      row.append(element('time', 'timeline-date', formatDate(item.date)), copy);
+      return row;
+    })
+  );
+}
+
+function renderEvidence(evidence, entityById) {
+  const container = document.getElementById('evidence-list');
+  container.replaceChildren(
+    ...evidence.map(record => {
+      const issuer = entityById.get(record.issuerEntityId);
+      const card = element('article', 'evidence-card');
+      const meta = element('div', 'evidence-meta');
+      meta.append(pill(humanize(record.documentType)), pill(formatDate(record.publishedAt)));
+      card.append(
+        meta,
+        element('h3', null, issuer?.displayName || 'Primary record'),
+        element('p', 'evidence-issuer', record.evidenceKey),
+        recordLink(record.canonicalRef, 'Open source record')
+      );
+      return card;
+    })
+  );
+}
+
+function renderSources(sources) {
+  const container = document.getElementById('source-list');
+  container.replaceChildren(
+    ...sources.map(source => {
+      const row = element('div', 'source-row');
+      row.append(
+        element('strong', null, source.name),
+        element('span', null, `${humanize(source.sourceClass)} · ${humanize(source.evidenceRole)}`),
+        recordLink(source.url, 'Open')
+      );
+      return row;
+    })
+  );
+}
+
+function renderUnknowns(unknowns) {
+  const container = document.getElementById('unknown-list');
+  container.replaceChildren(...unknowns.map(unknown => element('li', null, unknown)));
+}
+
+function pill(text) {
+  return element('span', 'pill', text);
+}
+
+function recordLink(url, label) {
+  const link = element('a', 'record-link', `${label} ↗`);
+  link.href = url;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  return link;
+}
+
+function setText(id, value) {
+  document.getElementById(id).textContent = String(value);
+}
+
+function element(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text != null) node.textContent = String(text);
+  return node;
+}
+
+function humanize(value) {
+  return String(value || '').replace(/-/g, ' ');
+}
+
+function formatDate(value) {
+  if (!value) return 'date unavailable';
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/dossiers/santa-ynez-pipeline/index.html
+++ b/dossiers/santa-ynez-pipeline/index.html
@@ -1,0 +1,168 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="GlobalDeets evidence dossier for the 2026 Santa Ynez Pipeline and Sable Offshore dispute: attributed claims, primary records, contradictions, chronology, corrections, and unresolved questions."
+    />
+    <meta name="author" content="GlobalDeets - Good Flippin Design" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://globaldeets.com/dossiers/santa-ynez-pipeline/" />
+    <meta property="og:title" content="Santa Ynez Pipeline — Evidence Dossier | GlobalDeets" />
+    <meta
+      property="og:description"
+      content="Trace the 2026 Santa Ynez Pipeline dispute through attributed claims, evidence, contradictions, corrections, and unresolved questions."
+    />
+    <link rel="canonical" href="https://globaldeets.com/dossiers/santa-ynez-pipeline/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="stylesheet" href="../dossier.css" />
+    <title>Santa Ynez Pipeline — Evidence Dossier | GlobalDeets</title>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Santa Ynez Pipeline — Evidence Dossier",
+        "url": "https://globaldeets.com/dossiers/santa-ynez-pipeline/",
+        "description": "A source-first evidence interface for the 2026 Santa Ynez Pipeline and Sable Offshore dispute.",
+        "isPartOf": { "@type": "WebSite", "name": "GlobalDeets", "url": "https://globaldeets.com" }
+      }
+    </script>
+  </head>
+  <body data-dossier-id="santa-ynez-pipeline">
+    <a class="skip-link" href="#dossier-app">Skip to dossier</a>
+
+    <header class="dossier-shell dossier-header">
+      <a class="brand" href="/" aria-label="GlobalDeets home">
+        <span class="brand-mark" aria-hidden="true">GD</span>
+        <span>
+          <strong>GlobalDeets</strong>
+          <small>Evidence Intelligence</small>
+        </span>
+      </a>
+      <nav class="dossier-nav" aria-label="Dossier navigation">
+        <a href="/news">News</a>
+        <a href="/knowledge">Sources</a>
+        <a href="/about">Method</a>
+      </nav>
+    </header>
+
+    <main id="dossier-app" class="dossier-shell" aria-busy="true">
+      <section class="dossier-hero" aria-labelledby="dossier-title">
+        <div>
+          <p class="eyebrow">Evidence dossier <span aria-hidden="true">·</span> Developing</p>
+          <h1 id="dossier-title">Santa Ynez Pipeline <span>/ Sable Offshore</span></h1>
+          <p class="hero-dek">
+            A source-first record of the 2026 restart dispute, regulatory actions, court rulings,
+            appeals, and a documented government correction. Claims remain attributed; disagreement
+            is preserved rather than flattened into a verdict.
+          </p>
+        </div>
+        <div class="integrity-panel" aria-live="polite">
+          <span class="integrity-light" aria-hidden="true"></span>
+          <div>
+            <strong id="integrity-label">Checking graph integrity…</strong>
+            <small id="reviewed-label">Loading reviewed evidence</small>
+          </div>
+        </div>
+      </section>
+
+      <p id="dossier-status" class="status-line" role="status">Loading evidence graph…</p>
+      <div id="dossier-error" class="error-panel" role="alert" hidden></div>
+
+      <section class="stat-grid" aria-label="Dossier graph totals">
+        <article><strong id="stat-entities">—</strong><span>Canonical entities</span></article>
+        <article><strong id="stat-events">—</strong><span>Distinct events</span></article>
+        <article><strong id="stat-claims">—</strong><span>Attributed claims</span></article>
+        <article><strong id="stat-evidence">—</strong><span>Evidence records</span></article>
+      </section>
+
+      <section class="dossier-section" aria-labelledby="established-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Corroborated record</p>
+          <h2 id="established-heading">What the evidence establishes</h2>
+          <p>Fact assertions marked corroborated in the graph. This is an evidence state, not a truth score.</p>
+        </div>
+        <div id="established-claims" class="card-grid"></div>
+      </section>
+
+      <section class="dossier-section conflict-section" aria-labelledby="conflict-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Disagreement preserved</p>
+          <h2 id="conflict-heading">Where accounts conflict</h2>
+          <p>GlobalDeets keeps competing attributed positions distinct instead of manufacturing consensus.</p>
+        </div>
+        <div id="conflict-list" class="conflict-list"></div>
+      </section>
+
+      <section class="dossier-section" aria-labelledby="attributed-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Attributed, not promoted</p>
+          <h2 id="attributed-heading">Other sourced claims</h2>
+          <p>Single-source claims and official positions remain visibly attributed to their origin.</p>
+        </div>
+        <div id="attributed-claims" class="card-grid"></div>
+      </section>
+
+      <section class="dossier-section correction-section" aria-labelledby="correction-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Provenance event</p>
+          <h2 id="correction-heading">Correction on the record</h2>
+        </div>
+        <div id="correction-list"></div>
+      </section>
+
+      <section class="dossier-section" aria-labelledby="timeline-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Evidence-linked chronology</p>
+          <h2 id="timeline-heading">What happened, and when</h2>
+          <p>Related proceedings remain separate events even when they concern the same pipeline dispute.</p>
+        </div>
+        <ol id="timeline-list" class="timeline-list"></ol>
+      </section>
+
+      <section class="dossier-section" aria-labelledby="evidence-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Trace the record</p>
+          <h2 id="evidence-heading">Evidence and source library</h2>
+          <p>Open the retained court, regulatory, corporate, government, and reporting records at their source.</p>
+        </div>
+        <div id="evidence-list" class="evidence-grid"></div>
+        <details class="source-details">
+          <summary>Show all source records</summary>
+          <div id="source-list" class="source-list"></div>
+        </details>
+      </section>
+
+      <section class="dossier-section unknown-section" aria-labelledby="unknown-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Explicit uncertainty</p>
+          <h2 id="unknown-heading">What remains unresolved</h2>
+        </div>
+        <ul id="unknown-list" class="unknown-list"></ul>
+      </section>
+
+      <section class="dossier-section method-section" aria-labelledby="method-heading">
+        <div class="section-heading">
+          <p class="eyebrow">Method contract</p>
+          <h2 id="method-heading">How to read this dossier</h2>
+        </div>
+        <div class="method-grid">
+          <article><strong>No editorial verdict</strong><p>The interface does not decide a winner in the underlying dispute.</p></article>
+          <article><strong>No truth score</strong><p>Evidence states describe sourcing and relationships, not a numeric truth probability.</p></article>
+          <article><strong>Corrections persist</strong><p>Supersession and correction events remain visible instead of silently replacing history.</p></article>
+          <article><strong>Unknown means unknown</strong><p>Missing primary records and unresolved outcomes are named rather than inferred.</p></article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="dossier-shell dossier-footer">
+      <p>GlobalDeets · Source-first public intelligence</p>
+      <div><a href="/news">World News</a><a href="/knowledge">Knowledge Sources</a><a href="/">Home</a></div>
+    </footer>
+
+    <noscript><p class="noscript">JavaScript is required to load and validate this evidence graph.</p></noscript>
+    <script src="./dossier.js" defer></script>
+  </body>
+</html>

--- a/functions/api/intelligence/dossiers/santa-ynez-pipeline.js
+++ b/functions/api/intelligence/dossiers/santa-ynez-pipeline.js
@@ -1,0 +1,35 @@
+import { getSantaYnezDossier } from '../../../lib/santa-ynez-dossier.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+function headers(request) {
+  const origin = request?.headers?.get('Origin');
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json',
+    'Cache-Control': 'public, max-age=300',
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: headers(request) });
+}
+
+export async function onRequestGet({ request }) {
+  const dossier = getSantaYnezDossier();
+  if (!dossier.validation.valid) {
+    return new Response(
+      JSON.stringify({ error: 'dossier-integrity-failed', validation: dossier.validation }),
+      { status: 500, headers: headers(request) }
+    );
+  }
+  return new Response(JSON.stringify(dossier), { status: 200, headers: headers(request) });
+}

--- a/functions/api/intelligence/dossiers/santa-ynez-pipeline.js
+++ b/functions/api/intelligence/dossiers/santa-ynez-pipeline.js
@@ -1,3 +1,4 @@
+import { validateDossierIntegrity } from '../../../lib/dossier-integrity.js';
 import { getSantaYnezDossier } from '../../../lib/santa-ynez-dossier.js';
 
 const ALLOWED_ORIGINS = new Set([
@@ -23,13 +24,24 @@ export async function onRequestOptions({ request }) {
   return new Response(null, { status: 204, headers: headers(request) });
 }
 
-export async function onRequestGet({ request }) {
-  const dossier = getSantaYnezDossier();
-  if (!dossier.validation.valid) {
+export function respondWithDossier(dossier, request) {
+  const integrity = validateDossierIntegrity(dossier);
+  if (dossier?.validation?.valid !== true || integrity.valid !== true) {
     return new Response(
-      JSON.stringify({ error: 'dossier-integrity-failed', validation: dossier.validation }),
+      JSON.stringify({
+        error: 'dossier-integrity-failed',
+        validation: dossier?.validation ?? null,
+        integrity,
+      }),
       { status: 500, headers: headers(request) }
     );
   }
-  return new Response(JSON.stringify(dossier), { status: 200, headers: headers(request) });
+  return new Response(JSON.stringify({ ...dossier, integrity }), {
+    status: 200,
+    headers: headers(request),
+  });
+}
+
+export async function onRequestGet({ request }) {
+  return respondWithDossier(getSantaYnezDossier(), request);
 }

--- a/functions/lib/dossier-integrity.js
+++ b/functions/lib/dossier-integrity.js
@@ -1,0 +1,279 @@
+import { validateClaimEvidenceGraph } from './claim-evidence-model.js';
+import { validateIntelligenceGraph } from './intelligence-model.js';
+
+const REQUIRED_ARRAY_FIELDS = Object.freeze([
+  'sources',
+  'entities',
+  'events',
+  'claims',
+  'evidence',
+  'claimRelations',
+  'evidenceRelations',
+  'timeline',
+  'corrections',
+  'unknowns',
+]);
+const CLAIM_RELATIONS = new Set(['corroborates', 'contradicts', 'supersedes']);
+const EVIDENCE_RELATIONS = new Set(['supports', 'contradicts', 'supersedes']);
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateDossierIntegrity(dossier) {
+  const issues = {
+    structureErrors: [],
+    invalidRecords: [],
+    duplicateIds: [],
+    duplicateSourceUrls: [],
+    uncitedClaims: [],
+    invalidRelationTypes: [],
+    timelineOrphans: [],
+    correctionOrphans: [],
+    invalidCorrections: [],
+    invalidUnknowns: [],
+    engineErrors: [],
+  };
+
+  if (!plainObject(dossier)) {
+    issues.structureErrors.push('dossier:not-object');
+    return finish(issues, null, null);
+  }
+
+  requireText(dossier.dossierId, 'dossierId', issues);
+  requireText(dossier.dossierVersion, 'dossierVersion', issues);
+  requireText(dossier.title, 'title', issues);
+  if (!plainObject(dossier.rules)) issues.structureErrors.push('rules:not-object');
+  else {
+    if (dossier.rules.truthScore !== false) issues.structureErrors.push('rules.truthScore:must-be-false');
+    if (dossier.rules.editorialVerdict !== false) {
+      issues.structureErrors.push('rules.editorialVerdict:must-be-false');
+    }
+  }
+
+  for (const field of REQUIRED_ARRAY_FIELDS) {
+    if (!Array.isArray(dossier[field])) issues.structureErrors.push(`${field}:not-array`);
+  }
+
+  const sources = array(dossier.sources);
+  const entities = array(dossier.entities);
+  const events = array(dossier.events);
+  const claims = array(dossier.claims);
+  const evidence = array(dossier.evidence);
+  const claimRelations = array(dossier.claimRelations);
+  const evidenceRelations = array(dossier.evidenceRelations);
+  const timeline = array(dossier.timeline);
+  const corrections = array(dossier.corrections);
+  const unknowns = array(dossier.unknowns);
+
+  const objectCollections = {
+    sources,
+    entities,
+    events,
+    claims,
+    evidence,
+    claimRelations,
+    evidenceRelations,
+    timeline,
+    corrections,
+  };
+  for (const [name, records] of Object.entries(objectCollections)) {
+    records.forEach((record, index) => {
+      if (!plainObject(record)) issues.invalidRecords.push(`${name}[${index}]:not-object`);
+    });
+  }
+
+  for (const [name, records] of Object.entries(objectCollections)) {
+    addDuplicateIds(name, records, issues);
+  }
+
+  const sourceById = mapById(sources);
+  const sourceUrls = [];
+  for (const [index, source] of sources.entries()) {
+    if (!plainObject(source)) continue;
+    if (!text(source.id) || !text(source.name) || !text(source.url)) {
+      issues.invalidRecords.push(`sources[${index}]:missing-core-field`);
+      continue;
+    }
+    sourceUrls.push(source.url);
+  }
+  for (const url of duplicates(sourceUrls)) issues.duplicateSourceUrls.push(url);
+
+  const entityById = mapById(entities);
+  const eventById = mapById(events);
+  const claimById = mapById(claims);
+  const evidenceById = mapById(evidence);
+
+  for (const [index, claim] of claims.entries()) {
+    if (!plainObject(claim)) continue;
+    const source = sourceById.get(claim.originSourceId);
+    if (!source || source.url !== claim.originRef) {
+      issues.uncitedClaims.push(text(claim.id) ? claim.id : `claims[${index}]`);
+    }
+  }
+
+  for (const [index, relation] of claimRelations.entries()) {
+    if (!plainObject(relation)) continue;
+    if (!CLAIM_RELATIONS.has(relation.relation)) {
+      issues.invalidRelationTypes.push(text(relation.id) ? relation.id : `claimRelations[${index}]`);
+    }
+  }
+  for (const [index, relation] of evidenceRelations.entries()) {
+    if (!plainObject(relation)) continue;
+    if (!EVIDENCE_RELATIONS.has(relation.relation)) {
+      issues.invalidRelationTypes.push(text(relation.id) ? relation.id : `evidenceRelations[${index}]`);
+    }
+  }
+
+  for (const [index, item] of timeline.entries()) {
+    if (!plainObject(item)) continue;
+    const itemId = text(item.id) ? item.id : `timeline[${index}]`;
+    if (!ISO_DATE.test(item.date || '')) issues.invalidRecords.push(`${itemId}:invalid-date`);
+    if (!eventById.has(item.eventId)) issues.timelineOrphans.push(`${itemId}:${item.eventId || '(missing-event)'}`);
+    if (!Array.isArray(item.evidenceIds)) issues.invalidRecords.push(`${itemId}:evidenceIds:not-array`);
+    else {
+      for (const id of item.evidenceIds) {
+        if (!evidenceById.has(id)) issues.timelineOrphans.push(`${itemId}:${id}`);
+      }
+    }
+    if (!Array.isArray(item.claimIds)) issues.invalidRecords.push(`${itemId}:claimIds:not-array`);
+    else {
+      for (const id of item.claimIds) {
+        if (!claimById.has(id)) issues.timelineOrphans.push(`${itemId}:${id}`);
+      }
+    }
+  }
+
+  const topLevelUnknowns = new Set();
+  for (const [index, unknown] of unknowns.entries()) {
+    if (!text(unknown)) issues.invalidUnknowns.push(`unknowns[${index}]:not-text`);
+    else if (topLevelUnknowns.has(unknown)) issues.invalidUnknowns.push(`unknowns[${index}]:duplicate`);
+    else topLevelUnknowns.add(unknown);
+  }
+
+  for (const [index, correction] of corrections.entries()) {
+    if (!plainObject(correction)) continue;
+    const itemId = text(correction.id) ? correction.id : `corrections[${index}]`;
+    if (!text(correction.correctedRef)) issues.invalidCorrections.push(`${itemId}:missing-correctedRef`);
+    if (!entityById.has(correction.issuerEntityId)) {
+      issues.correctionOrphans.push(`${itemId}:${correction.issuerEntityId || '(missing-issuer)'}`);
+    }
+    checkReferences(itemId, correction.eventIds, eventById, 'eventIds', issues);
+    checkReferences(itemId, correction.evidenceIds, evidenceById, 'evidenceIds', issues);
+    checkReferences(itemId, correction.claimIds, claimById, 'claimIds', issues);
+    if (!Array.isArray(correction.unknowns)) issues.invalidCorrections.push(`${itemId}:unknowns:not-array`);
+    else {
+      for (const unknown of correction.unknowns) {
+        if (!topLevelUnknowns.has(unknown)) issues.invalidCorrections.push(`${itemId}:unknown-not-declared`);
+      }
+    }
+    if (Array.isArray(correction.evidenceIds) && text(correction.correctedRef)) {
+      const linkedRefs = correction.evidenceIds
+        .map(id => evidenceById.get(id)?.canonicalRef)
+        .filter(Boolean);
+      if (!linkedRefs.includes(correction.correctedRef)) {
+        issues.invalidCorrections.push(`${itemId}:correctedRef-not-linked-evidence`);
+      }
+    }
+  }
+
+  let intelligence = null;
+  let claimEvidence = null;
+  const safeForEngines = Object.values(objectCollections).every(records => records.every(plainObject));
+  if (safeForEngines && Array.isArray(dossier.entities) && Array.isArray(dossier.events)) {
+    try {
+      intelligence = validateIntelligenceGraph({ entities, events });
+    } catch (error) {
+      issues.engineErrors.push(`intelligence:${errorMessage(error)}`);
+    }
+  }
+  if (
+    safeForEngines &&
+    Array.isArray(dossier.claims) &&
+    Array.isArray(dossier.evidence) &&
+    Array.isArray(dossier.claimRelations) &&
+    Array.isArray(dossier.evidenceRelations)
+  ) {
+    try {
+      claimEvidence = validateClaimEvidenceGraph({
+        entities,
+        events,
+        claims,
+        evidence,
+        claimRelations,
+        evidenceRelations,
+      });
+    } catch (error) {
+      issues.engineErrors.push(`claim-evidence:${errorMessage(error)}`);
+    }
+  }
+
+  return finish(issues, intelligence, claimEvidence);
+}
+
+function checkReferences(itemId, ids, registry, field, issues) {
+  if (!Array.isArray(ids)) {
+    issues.invalidCorrections.push(`${itemId}:${field}:not-array`);
+    return;
+  }
+  for (const id of ids) {
+    if (!registry.has(id)) issues.correctionOrphans.push(`${itemId}:${id}`);
+  }
+}
+
+function finish(issues, intelligence, claimEvidence) {
+  for (const key of Object.keys(issues)) issues[key] = unique(issues[key]);
+  const issueFree = Object.values(issues).every(values => values.length === 0);
+  const enginesValid = intelligence?.valid === true && claimEvidence?.valid === true;
+  return {
+    valid: issueFree && enginesValid,
+    ...issues,
+    intelligence,
+    claimEvidence,
+  };
+}
+
+function addDuplicateIds(name, records, issues) {
+  const ids = records.filter(plainObject).map(record => record.id).filter(text);
+  for (const id of duplicates(ids)) issues.duplicateIds.push(`${name}:${id}`);
+}
+
+function mapById(records) {
+  return new Map(
+    records
+      .filter(plainObject)
+      .filter(record => text(record.id))
+      .map(record => [record.id, record])
+  );
+}
+
+function requireText(value, field, issues) {
+  if (!text(value)) issues.structureErrors.push(`${field}:missing`);
+}
+
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function plainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function text(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  const repeated = new Set();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated].sort();
+}
+
+function unique(values) {
+  return [...new Set(values)].sort();
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/functions/lib/dossier-integrity.js
+++ b/functions/lib/dossier-integrity.js
@@ -15,6 +15,7 @@ const REQUIRED_ARRAY_FIELDS = Object.freeze([
 ]);
 const CLAIM_RELATIONS = new Set(['corroborates', 'contradicts', 'supersedes']);
 const EVIDENCE_RELATIONS = new Set(['supports', 'contradicts', 'supersedes']);
+const CORRECTION_STATUSES = new Set(['corrected', 'superseded', 'withdrawn']);
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
 export function validateDossierIntegrity(dossier) {
@@ -88,7 +89,13 @@ export function validateDossierIntegrity(dossier) {
   const sourceUrls = [];
   for (const [index, source] of sources.entries()) {
     if (!plainObject(source)) continue;
-    if (!text(source.id) || !text(source.name) || !text(source.url)) {
+    if (
+      !text(source.id) ||
+      !text(source.name) ||
+      !text(source.sourceClass) ||
+      !text(source.evidenceRole) ||
+      !text(source.url)
+    ) {
       issues.invalidRecords.push(`sources[${index}]:missing-core-field`);
       continue;
     }
@@ -125,8 +132,13 @@ export function validateDossierIntegrity(dossier) {
   for (const [index, item] of timeline.entries()) {
     if (!plainObject(item)) continue;
     const itemId = text(item.id) ? item.id : `timeline[${index}]`;
+    if (!text(item.id) || !text(item.label) || !text(item.eventId)) {
+      issues.invalidRecords.push(`${itemId}:missing-core-field`);
+    }
     if (!ISO_DATE.test(item.date || '')) issues.invalidRecords.push(`${itemId}:invalid-date`);
-    if (!eventById.has(item.eventId)) issues.timelineOrphans.push(`${itemId}:${item.eventId || '(missing-event)'}`);
+    if (!eventById.has(item.eventId)) {
+      issues.timelineOrphans.push(`${itemId}:${item.eventId || '(missing-event)'}`);
+    }
     if (!Array.isArray(item.evidenceIds)) issues.invalidRecords.push(`${itemId}:evidenceIds:not-array`);
     else {
       for (const id of item.evidenceIds) {
@@ -151,7 +163,23 @@ export function validateDossierIntegrity(dossier) {
   for (const [index, correction] of corrections.entries()) {
     if (!plainObject(correction)) continue;
     const itemId = text(correction.id) ? correction.id : `corrections[${index}]`;
-    if (!text(correction.correctedRef)) issues.invalidCorrections.push(`${itemId}:missing-correctedRef`);
+    if (
+      !text(correction.id) ||
+      !text(correction.issuerEntityId) ||
+      !text(correction.description) ||
+      !text(correction.correctedRef)
+    ) {
+      issues.invalidCorrections.push(`${itemId}:missing-core-field`);
+    }
+    if (!CORRECTION_STATUSES.has(correction.status)) {
+      issues.invalidCorrections.push(`${itemId}:invalid-status`);
+    }
+    if (!ISO_DATE.test(correction.observedAt || '')) {
+      issues.invalidCorrections.push(`${itemId}:invalid-observedAt`);
+    }
+    if (typeof correction.originalArtifactRetained !== 'boolean') {
+      issues.invalidCorrections.push(`${itemId}:originalArtifactRetained:not-boolean`);
+    }
     if (!entityById.has(correction.issuerEntityId)) {
       issues.correctionOrphans.push(`${itemId}:${correction.issuerEntityId || '(missing-issuer)'}`);
     }
@@ -160,8 +188,11 @@ export function validateDossierIntegrity(dossier) {
     checkReferences(itemId, correction.claimIds, claimById, 'claimIds', issues);
     if (!Array.isArray(correction.unknowns)) issues.invalidCorrections.push(`${itemId}:unknowns:not-array`);
     else {
+      const localUnknowns = new Set();
       for (const unknown of correction.unknowns) {
-        if (!topLevelUnknowns.has(unknown)) issues.invalidCorrections.push(`${itemId}:unknown-not-declared`);
+        if (!text(unknown)) issues.invalidCorrections.push(`${itemId}:unknown-not-text`);
+        else if (localUnknowns.has(unknown)) issues.invalidCorrections.push(`${itemId}:duplicate-unknown`);
+        else localUnknowns.add(unknown);
       }
     }
     if (Array.isArray(correction.evidenceIds) && text(correction.correctedRef)) {

--- a/functions/lib/santa-ynez-dossier.js
+++ b/functions/lib/santa-ynez-dossier.js
@@ -1,0 +1,748 @@
+import {
+  createEntity,
+  createEvent,
+  validateIntelligenceGraph,
+} from './intelligence-model.js';
+import { getSeedPlaceByIsoAlpha2 } from './m49-place-seed.js';
+import {
+  createClaim,
+  createClaimRelation,
+  createEvidence,
+  createEvidenceRelation,
+  validateClaimEvidenceGraph,
+} from './claim-evidence-model.js';
+
+export const SANTA_YNEZ_DOSSIER_VERSION = '2026-09-03.1';
+export const SANTA_YNEZ_DOSSIER_ID = 'santa-ynez-pipeline';
+export const SANTA_YNEZ_REVIEWED_AT = '2026-09-03';
+
+const URLS = Object.freeze({
+  doeMarch13:
+    'https://www.energy.gov/articles/secretary-wright-directs-sable-offshore-restore-santa-ynez-unit-and-pipeline',
+  caAgMarch23:
+    'https://www.oag.ca.gov/news/press-releases/attorney-general-bonta-files-lawsuit-against-trump-administration-stop-executive',
+  caAppealJune17: 'https://courts.ca.gov/opinion/published/2026-06-17/b347601',
+  phmsaPermit:
+    'https://www.phmsa.dot.gov/pipeline/special-permits-state-waivers/special-permits-issued',
+  caAgJuly20:
+    'https://oag.ca.gov/news/press-releases/attorney-general-bonta-continues-protect-california%E2%80%99s-environment-and-public-0',
+  federalOrderAug19:
+    'https://www.sec.gov/Archives/edgar/data/1831481/000183148126000108/a2026081986ordergranting.htm',
+  sable8kAug19:
+    'https://www.sec.gov/Archives/edgar/data/1831481/000183148126000108/socc-20260819.htm',
+  dojAug21:
+    'https://www.justice.gov/opa/pr/federal-court-protects-national-energy-security-and-rejects-dangerous-state-efforts-obstruct',
+  laTimesAug20:
+    'https://www.latimes.com/environment/story/2026-08-20/judge-allows-controversial-oil-company-continue-pumping',
+  dojSept3:
+    'https://www.justice.gov/opa/pr/federal-court-dismisses-another-attempt-stymie-sable-offshore-corporations-oil-and-gas',
+  censusCalifornia: 'https://www.census.gov/quickfacts/fact/table/CA/PST045225',
+  censusSantaBarbara:
+    'https://www.census.gov/quickfacts/fact/table/santabarbaracountycalifornia,CA/PST045225',
+  secSable: 'https://www.sec.gov/edgar/browse/?CIK=1831481&owner=exclude',
+  cdca: 'https://www.cacd.uscourts.gov/',
+  doj: 'https://www.justice.gov/',
+  doe: 'https://www.energy.gov/',
+  phmsa: 'https://www.phmsa.dot.gov/',
+  caDoj: 'https://oag.ca.gov/',
+  caCourts: 'https://courts.ca.gov/',
+});
+
+const unitedStates = getSeedPlaceByIsoAlpha2('US');
+if (!unitedStates) throw new TypeError('Santa Ynez dossier requires the reviewed US M49 place');
+
+const california = createEntity({
+  identityKey: 'census-geoid:06',
+  displayName: 'California',
+  type: 'place',
+  countryEntityId: unitedStates.id,
+  standardIds: { censusGeoid: '06' },
+  evidenceRefs: [URLS.censusCalifornia],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const santaBarbaraCounty = createEntity({
+  identityKey: 'census-geoid:06083',
+  displayName: 'Santa Barbara County',
+  type: 'place',
+  countryEntityId: unitedStates.id,
+  standardIds: { censusGeoid: '06083' },
+  evidenceRefs: [URLS.censusSantaBarbara],
+  attributes: { parentPlaceEntityId: california.id },
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const sable = createEntity({
+  identityKey: 'sec-cik:0001831481',
+  displayName: 'Sable Offshore Corp.',
+  type: 'company',
+  standardIds: { secCik: '0001831481' },
+  evidenceRefs: [URLS.secSable],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const cdca = createEntity({
+  identityKey: 'uscourt:cdca',
+  displayName: 'U.S. District Court for the Central District of California',
+  type: 'government-public-body',
+  evidenceRefs: [URLS.cdca],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const doe = createEntity({
+  identityKey: 'us-federal-agency:DOE',
+  displayName: 'U.S. Department of Energy',
+  type: 'government-public-body',
+  evidenceRefs: [URLS.doe],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const phmsa = createEntity({
+  identityKey: 'us-federal-agency:PHMSA',
+  displayName: 'Pipeline and Hazardous Materials Safety Administration',
+  type: 'government-public-body',
+  evidenceRefs: [URLS.phmsa],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const usDoj = createEntity({
+  identityKey: 'us-federal-agency:DOJ',
+  displayName: 'U.S. Department of Justice',
+  type: 'government-public-body',
+  evidenceRefs: [URLS.doj],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const caDoj = createEntity({
+  identityKey: 'ca-state-agency:DOJ',
+  displayName: 'California Department of Justice',
+  type: 'government-public-body',
+  countryEntityId: unitedStates.id,
+  evidenceRefs: [URLS.caDoj],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const caAppealCourt = createEntity({
+  identityKey: 'ca-court:2d-district-court-of-appeal',
+  displayName: 'California Court of Appeal, Second Appellate District',
+  type: 'government-public-body',
+  countryEntityId: unitedStates.id,
+  evidenceRefs: [URLS.caCourts],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+export const SANTA_YNEZ_ENTITIES = Object.freeze([
+  unitedStates,
+  california,
+  santaBarbaraCounty,
+  sable,
+  cdca,
+  doe,
+  phmsa,
+  usDoj,
+  caDoj,
+  caAppealCourt,
+]);
+
+const dpaOrderEvent = createEvent({
+  eventKey: 'santa-ynez:2026-03-13:doe-dpa-restart-order',
+  title: 'Energy Department directs Santa Ynez restart under the Defense Production Act',
+  eventType: 'federal-order',
+  status: 'confirmed',
+  observedAt: '2026-03-13',
+  startedAt: '2026-03-13',
+  entityIds: [doe.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  evidenceRefs: [URLS.doeMarch13],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const stateAppealEvent = createEvent({
+  eventKey: 'santa-ynez:2026-06-17:coastal-commission-appeal-opinion',
+  title: 'California appellate court publishes Sable v. California Coastal Commission opinion',
+  eventType: 'court-ruling',
+  status: 'confirmed',
+  observedAt: '2026-06-17',
+  startedAt: '2026-06-17',
+  entityIds: [sable.id, caAppealCourt.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  evidenceRefs: [URLS.caAppealJune17],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const phmsaPermitEvent = createEvent({
+  eventKey: 'santa-ynez:2026-06-25:phmsa-special-permit',
+  title: 'PHMSA issues Sable hazardous-liquid pipeline special permit',
+  eventType: 'regulatory-action',
+  status: 'confirmed',
+  observedAt: '2026-06-25',
+  startedAt: '2026-06-25',
+  entityIds: [phmsa.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  evidenceRefs: [URLS.phmsaPermit],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const federalOrderEvent = createEvent({
+  eventKey: 'santa-ynez:2026-08-19:cdca-related-pipeline-order',
+  title: 'Federal court issues mixed order across related Santa Ynez pipeline cases',
+  eventType: 'court-ruling',
+  status: 'confirmed',
+  observedAt: '2026-08-19',
+  startedAt: '2026-08-19',
+  entityIds: [cdca.id, sable.id, doe.id, phmsa.id, caDoj.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  evidenceRefs: [URLS.federalOrderAug19],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const appealNoticesEvent = createEvent({
+  eventKey: 'santa-ynez:2026-08-20-21:appeal-notices',
+  title: 'Notices of appeal follow portions of the August 19 federal order',
+  eventType: 'appeal',
+  status: 'developing',
+  observedAt: '2026-08-21',
+  startedAt: '2026-08-20',
+  entityIds: [sable.id, caDoj.id],
+  placeEntityIds: [california.id],
+  evidenceRefs: [URLS.sable8kAug19],
+  unknowns: ['final appellate disposition'],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const relatedDismissalEvent = createEvent({
+  eventKey: 'santa-ynez:2026-08-31:cbd-boem-platform-harmony-dismissal',
+  title: 'Federal court dismisses related Platform Harmony challenge',
+  eventType: 'court-ruling',
+  status: 'confirmed',
+  observedAt: '2026-08-31',
+  startedAt: '2026-08-31',
+  entityIds: [usDoj.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  evidenceRefs: [URLS.dojSept3],
+  unknowns: ['primary court order not yet included in this dossier snapshot'],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const dojCorrectionEvent = createEvent({
+  eventKey: 'santa-ynez:2026-09-03:doj-release-correction',
+  title: 'Justice Department corrects a mistaken Sable press-release reprint',
+  eventType: 'correction',
+  status: 'confirmed',
+  observedAt: '2026-09-03',
+  startedAt: '2026-09-03',
+  entityIds: [usDoj.id, sable.id],
+  placeEntityIds: [california.id],
+  evidenceRefs: [URLS.dojSept3],
+  unknowns: ['original mistaken release artifact is not retained in this dossier snapshot'],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+export const SANTA_YNEZ_EVENTS = Object.freeze([
+  dpaOrderEvent,
+  stateAppealEvent,
+  phmsaPermitEvent,
+  federalOrderEvent,
+  appealNoticesEvent,
+  relatedDismissalEvent,
+  dojCorrectionEvent,
+]);
+
+export const SANTA_YNEZ_SOURCES = Object.freeze([
+  source('source:doe:2026-03-13', 'U.S. Department of Energy', 'institutional-statement', 'official-position', URLS.doeMarch13),
+  source('source:ca-doj:2026-03-23', 'California Department of Justice', 'institutional-statement', 'official-position', URLS.caAgMarch23),
+  source('source:ca-court:2026-06-17', 'California Court of Appeal', 'court-record', 'primary-evidence', URLS.caAppealJune17),
+  source('source:phmsa:2026-06-25', 'PHMSA', 'regulatory-record', 'primary-evidence', URLS.phmsaPermit),
+  source('source:ca-doj:2026-07-20', 'California Department of Justice', 'institutional-statement', 'official-position', URLS.caAgJuly20),
+  source('source:cdca:2026-08-19-order', 'U.S. District Court, Central District of California', 'court-record', 'primary-evidence', URLS.federalOrderAug19),
+  source('source:sable-sec:2026-08-19', 'Sable Offshore Corp. SEC filing', 'corporate-filing', 'primary-disclosure', URLS.sable8kAug19),
+  source('source:latimes:2026-08-20', 'Los Angeles Times', 'independent-reporting', 'reporting', URLS.laTimesAug20),
+  source('source:doj:2026-08-21', 'U.S. Department of Justice', 'institutional-statement', 'official-position', URLS.dojAug21),
+  source('source:doj:2026-09-03', 'U.S. Department of Justice', 'institutional-statement', 'correction', URLS.dojSept3),
+]);
+
+const dpaEvidence = createEvidence({
+  evidenceKey: 'doe:2026-03-13:santa-ynez-dpa-direction',
+  issuerEntityId: doe.id,
+  canonicalRef: URLS.doeMarch13,
+  documentType: 'government-release',
+  publishedAt: '2026-03-13',
+  eventIds: [dpaOrderEvent.id],
+  entityIds: [doe.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.doeMarch13],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const caChallengeEvidence = createEvidence({
+  evidenceKey: 'ca-doj:2026-03-23:dpa-challenge',
+  issuerEntityId: caDoj.id,
+  canonicalRef: URLS.caAgMarch23,
+  documentType: 'government-release',
+  publishedAt: '2026-03-23',
+  eventIds: [dpaOrderEvent.id],
+  entityIds: [caDoj.id, doe.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.caAgMarch23],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const stateAppealEvidence = createEvidence({
+  evidenceKey: 'ca-court:2026-06-17:b347601',
+  issuerEntityId: caAppealCourt.id,
+  canonicalRef: URLS.caAppealJune17,
+  documentType: 'judgment',
+  publishedAt: '2026-06-17',
+  eventIds: [stateAppealEvent.id],
+  entityIds: [caAppealCourt.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.caAppealJune17],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const phmsaPermitEvidence = createEvidence({
+  evidenceKey: 'phmsa:2026-06-25:sable-special-permit',
+  issuerEntityId: phmsa.id,
+  canonicalRef: URLS.phmsaPermit,
+  documentType: 'regulator-release',
+  publishedAt: '2026-06-25',
+  eventIds: [phmsaPermitEvent.id],
+  entityIds: [phmsa.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.phmsaPermit],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const federalOrderEvidence = createEvidence({
+  evidenceKey: 'cdca:2026-08-19:document-86',
+  issuerEntityId: cdca.id,
+  canonicalRef: URLS.federalOrderAug19,
+  documentType: 'judgment',
+  publishedAt: '2026-08-19',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [cdca.id, sable.id, doe.id, phmsa.id, caDoj.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.federalOrderAug19, URLS.sable8kAug19],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const sable8kEvidence = createEvidence({
+  evidenceKey: 'sec:sable:2026-08-19:8-k',
+  issuerEntityId: sable.id,
+  canonicalRef: URLS.sable8kAug19,
+  documentType: 'corporate-filing',
+  publishedAt: '2026-08-19',
+  eventIds: [federalOrderEvent.id, appealNoticesEvent.id],
+  entityIds: [sable.id, cdca.id, caDoj.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.sable8kAug19],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const dojAug21Evidence = createEvidence({
+  evidenceKey: 'doj:2026-08-21:santa-ynez-release',
+  issuerEntityId: usDoj.id,
+  canonicalRef: URLS.dojAug21,
+  documentType: 'government-release',
+  publishedAt: '2026-08-21',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [usDoj.id, doe.id, phmsa.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.dojAug21],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const dojCorrectionEvidence = createEvidence({
+  evidenceKey: 'doj:2026-09-03:sable-release-correction',
+  issuerEntityId: usDoj.id,
+  canonicalRef: URLS.dojSept3,
+  documentType: 'government-release',
+  publishedAt: '2026-09-03',
+  eventIds: [relatedDismissalEvent.id, dojCorrectionEvent.id],
+  entityIds: [usDoj.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  provenanceRefs: [URLS.dojSept3],
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+export const SANTA_YNEZ_EVIDENCE = Object.freeze([
+  dpaEvidence,
+  caChallengeEvidence,
+  stateAppealEvidence,
+  phmsaPermitEvidence,
+  federalOrderEvidence,
+  sable8kEvidence,
+  dojAug21Evidence,
+  dojCorrectionEvidence,
+]);
+
+const doeSecurityClaim = createClaim({
+  claimKey: 'dpa-order-energy-security-rationale',
+  proposition:
+    'The Energy Department said its March 13 direction to restore Santa Ynez operations was issued under Defense Production Act authority to address supply-disruption and national-security risks.',
+  type: 'official-position',
+  state: 'disputed',
+  originSourceId: 'source:doe:2026-03-13',
+  originRef: URLS.doeMarch13,
+  sourceWording: 'DOE described the order as an energy- and national-security action.',
+  eventIds: [dpaOrderEvent.id],
+  entityIds: [doe.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-03-13',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const caLegalityClaim = createClaim({
+  claimKey: 'california-challenges-dpa-authority',
+  proposition:
+    'California challenged the Energy Department order as an unlawful use of the Defense Production Act that could not displace state law and the federal consent decree.',
+  type: 'official-position',
+  state: 'disputed',
+  originSourceId: 'source:ca-doj:2026-03-23',
+  originRef: URLS.caAgMarch23,
+  sourceWording: 'California described the federal order as executive overreach and sued to block it.',
+  eventIds: [dpaOrderEvent.id, federalOrderEvent.id],
+  entityIds: [caDoj.id, doe.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-03-23',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const violationClaim = createClaim({
+  claimKey: 'aug19-consent-decree-violation-159-days',
+  proposition:
+    'The August 19 federal order found that Sable violated the consent decree for 159 days and imposed a $1.449 million penalty.',
+  type: 'fact-assertion',
+  state: 'corroborated',
+  originSourceId: 'source:cdca:2026-08-19-order',
+  originRef: URLS.federalOrderAug19,
+  sourceWording: 'The court calculated 159 days of violation and a total $1.449 million penalty.',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [cdca.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-08-19',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const noShutdownClaim = createClaim({
+  claimKey: 'aug19-court-declines-shutdown-injunction',
+  proposition:
+    'The August 19 federal order declined to order Sable to shut down the onshore pipeline segments.',
+  type: 'fact-assertion',
+  state: 'corroborated',
+  originSourceId: 'source:cdca:2026-08-19-order',
+  originRef: URLS.federalOrderAug19,
+  sourceWording: 'The court declined injunctive relief shutting the pipeline and instead imposed the consent-decree penalty.',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [cdca.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-08-19',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const piDeniedClaim = createClaim({
+  claimKey: 'aug19-california-preliminary-injunction-denied',
+  proposition:
+    'The August 19 federal order denied California’s motion for a preliminary injunction against the Defense Production Act order.',
+  type: 'fact-assertion',
+  state: 'corroborated',
+  originSourceId: 'source:cdca:2026-08-19-order',
+  originRef: URLS.federalOrderAug19,
+  sourceWording: 'The court denied California’s preliminary-injunction motion in California v. Wright.',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [cdca.id, caDoj.id, doe.id, sable.id],
+  placeEntityIds: [california.id],
+  assertedAt: '2026-08-19',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const oversightClaim = createClaim({
+  claimKey: 'aug19-consent-decree-supervision-transferred-phmsa',
+  proposition:
+    'The August 19 order modified the consent decree to transfer supervising regulatory authority over the onshore pipeline to PHMSA during the national emergency.',
+  type: 'fact-assertion',
+  state: 'corroborated',
+  originSourceId: 'source:cdca:2026-08-19-order',
+  originRef: URLS.federalOrderAug19,
+  sourceWording: 'The court modified the consent decree to place supervising regulatory authority with PHMSA.',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [cdca.id, phmsa.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-08-19',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const laTimesMixedOutcomeClaim = createClaim({
+  claimKey: 'latimes-aug20-mixed-outcome',
+  proposition:
+    'The Los Angeles Times reported that the ruling allowed continued pumping and shifted oversight while also fining Sable nearly $1.5 million for violating the consent decree.',
+  type: 'fact-assertion',
+  state: 'corroborated',
+  originSourceId: 'source:latimes:2026-08-20',
+  originRef: URLS.laTimesAug20,
+  sourceWording: 'Independent reporting described both continued operations and the consent-decree penalty.',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [sable.id, cdca.id, phmsa.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-08-20',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const dojVictoryClaim = createClaim({
+  claimKey: 'doj-aug21-energy-security-victory-framing',
+  proposition:
+    'The Justice Department characterized the August 19 rulings as a significant federal energy-security victory and emphasized federal preemption of state barriers.',
+  type: 'official-position',
+  state: 'single-source',
+  originSourceId: 'source:doj:2026-08-21',
+  originRef: URLS.dojAug21,
+  sourceWording: 'DOJ framed the ruling as protecting national energy security from state obstruction.',
+  eventIds: [federalOrderEvent.id],
+  entityIds: [usDoj.id, doe.id, phmsa.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-08-21',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const appealClaim = createClaim({
+  claimKey: 'sable-8k-appeal-notices',
+  proposition:
+    'Sable’s August 19 SEC filing, updated with subsequent events, states that California filed a notice of appeal on August 20 and that a defendant in the Quintero matter filed a notice of appeal on August 21.',
+  type: 'fact-assertion',
+  state: 'single-source',
+  originSourceId: 'source:sable-sec:2026-08-19',
+  originRef: URLS.sable8kAug19,
+  sourceWording: 'The corporate filing records notices of appeal after the federal order.',
+  eventIds: [appealNoticesEvent.id],
+  entityIds: [sable.id, caDoj.id],
+  placeEntityIds: [california.id],
+  assertedAt: '2026-08-21',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const dismissalClaim = createClaim({
+  claimKey: 'doj-aug31-related-platform-harmony-dismissal',
+  proposition:
+    'The Justice Department reported that on August 31 the Central District of California dismissed with prejudice a related Center for Biological Diversity challenge concerning Platform Harmony.',
+  type: 'fact-assertion',
+  state: 'single-source',
+  originSourceId: 'source:doj:2026-09-03',
+  originRef: URLS.dojSept3,
+  sourceWording: 'DOJ reported an August 31 dismissal with prejudice in the related Platform Harmony matter.',
+  eventIds: [relatedDismissalEvent.id],
+  entityIds: [usDoj.id, sable.id],
+  placeEntityIds: [california.id, santaBarbaraCounty.id],
+  assertedAt: '2026-09-03',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+const correctionClaim = createClaim({
+  claimKey: 'doj-sept3-mistaken-release-reprint-corrected',
+  proposition:
+    'The Justice Department states that a press release posted earlier on September 3 mistakenly reprinted its August 21 Sable release and was replaced with the correct release about the August 31 decision.',
+  type: 'fact-assertion',
+  state: 'corroborated',
+  originSourceId: 'source:doj:2026-09-03',
+  originRef: URLS.dojSept3,
+  sourceWording: 'DOJ explicitly labels the earlier September 3 release a mistaken reprint and supplies the corrected release.',
+  eventIds: [dojCorrectionEvent.id, relatedDismissalEvent.id],
+  entityIds: [usDoj.id, sable.id],
+  placeEntityIds: [california.id],
+  assertedAt: '2026-09-03',
+  reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+});
+
+export const SANTA_YNEZ_CLAIMS = Object.freeze([
+  doeSecurityClaim,
+  caLegalityClaim,
+  violationClaim,
+  noShutdownClaim,
+  piDeniedClaim,
+  oversightClaim,
+  laTimesMixedOutcomeClaim,
+  dojVictoryClaim,
+  appealClaim,
+  dismissalClaim,
+  correctionClaim,
+]);
+
+export const SANTA_YNEZ_CLAIM_RELATIONS = Object.freeze([
+  createClaimRelation({
+    claimId: doeSecurityClaim.id,
+    relatedClaimId: caLegalityClaim.id,
+    relation: 'contradicts',
+    evidenceIds: [dpaEvidence.id, caChallengeEvidence.id, federalOrderEvidence.id],
+    reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+  }),
+  createClaimRelation({
+    claimId: violationClaim.id,
+    relatedClaimId: laTimesMixedOutcomeClaim.id,
+    relation: 'corroborates',
+    evidenceIds: [federalOrderEvidence.id],
+    reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+  }),
+  createClaimRelation({
+    claimId: noShutdownClaim.id,
+    relatedClaimId: laTimesMixedOutcomeClaim.id,
+    relation: 'corroborates',
+    evidenceIds: [federalOrderEvidence.id],
+    reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+  }),
+]);
+
+export const SANTA_YNEZ_EVIDENCE_RELATIONS = Object.freeze([
+  link(doeSecurityClaim, dpaEvidence, 'supports'),
+  link(caLegalityClaim, caChallengeEvidence, 'supports'),
+  link(violationClaim, federalOrderEvidence, 'supports'),
+  link(noShutdownClaim, federalOrderEvidence, 'supports'),
+  link(piDeniedClaim, federalOrderEvidence, 'supports'),
+  link(oversightClaim, federalOrderEvidence, 'supports'),
+  link(dojVictoryClaim, dojAug21Evidence, 'supports'),
+  link(appealClaim, sable8kEvidence, 'supports'),
+  link(dismissalClaim, dojCorrectionEvidence, 'supports'),
+  link(correctionClaim, dojCorrectionEvidence, 'supports'),
+]);
+
+export const SANTA_YNEZ_TIMELINE = Object.freeze([
+  timeline('2026-03-13', dpaOrderEvent, [dpaEvidence.id], [doeSecurityClaim.id]),
+  timeline('2026-03-23', dpaOrderEvent, [caChallengeEvidence.id], [caLegalityClaim.id], 'California files its federal challenge to the DPA order.'),
+  timeline('2026-06-17', stateAppealEvent, [stateAppealEvidence.id], [], 'California appellate opinion supplies longer-running state-law chronology.'),
+  timeline('2026-06-25', phmsaPermitEvent, [phmsaPermitEvidence.id], [], 'PHMSA records issuance of Sable’s hazardous-liquid special permit.'),
+  timeline('2026-08-19', federalOrderEvent, [federalOrderEvidence.id, sable8kEvidence.id], [violationClaim.id, noShutdownClaim.id, piDeniedClaim.id, oversightClaim.id]),
+  timeline('2026-08-20', federalOrderEvent, [federalOrderEvidence.id], [laTimesMixedOutcomeClaim.id], 'Independent reporting describes the ruling’s mixed practical outcome.'),
+  timeline('2026-08-21', appealNoticesEvent, [sable8kEvidence.id, dojAug21Evidence.id], [appealClaim.id, dojVictoryClaim.id]),
+  timeline('2026-08-31', relatedDismissalEvent, [dojCorrectionEvidence.id], [dismissalClaim.id], 'Related Platform Harmony litigation is kept as a distinct event.'),
+  timeline('2026-09-03', dojCorrectionEvent, [dojCorrectionEvidence.id], [correctionClaim.id], 'DOJ explicitly corrects an earlier mistaken reprint rather than silently overwriting the record.'),
+]);
+
+export const SANTA_YNEZ_CORRECTIONS = Object.freeze([
+  Object.freeze({
+    id: 'correction:doj:2026-09-03',
+    status: 'corrected',
+    observedAt: '2026-09-03',
+    issuerEntityId: usDoj.id,
+    correctedRef: URLS.dojSept3,
+    description:
+      'DOJ states that an earlier September 3 release mistakenly reprinted the August 21 Sable release; the page now contains the corrected release about the August 31 decision.',
+    originalArtifactRetained: false,
+    unknowns: ['original mistaken release artifact is not retained in this dossier snapshot'],
+    eventIds: [dojCorrectionEvent.id, relatedDismissalEvent.id],
+    evidenceIds: [dojCorrectionEvidence.id],
+    claimIds: [correctionClaim.id],
+  }),
+]);
+
+export const SANTA_YNEZ_UNKNOWNS = Object.freeze([
+  'The ultimate merits and appellate outcomes of the continuing federal/state jurisdiction disputes are not resolved by the August 19 preliminary-injunction ruling.',
+  'The primary August 31 court order for the related Platform Harmony dismissal is not yet included; the current snapshot attributes that event to DOJ’s corrected September 3 release.',
+  'The original mistaken September 3 DOJ release artifact is not retained in this dossier snapshot.',
+]);
+
+export function validateSantaYnezDossier() {
+  const intelligence = validateIntelligenceGraph({
+    entities: SANTA_YNEZ_ENTITIES,
+    events: SANTA_YNEZ_EVENTS,
+  });
+  const claimEvidence = validateClaimEvidenceGraph({
+    entities: SANTA_YNEZ_ENTITIES,
+    events: SANTA_YNEZ_EVENTS,
+    claims: SANTA_YNEZ_CLAIMS,
+    evidence: SANTA_YNEZ_EVIDENCE,
+    claimRelations: SANTA_YNEZ_CLAIM_RELATIONS,
+    evidenceRelations: SANTA_YNEZ_EVIDENCE_RELATIONS,
+  });
+  const ids = {
+    event: new Set(SANTA_YNEZ_EVENTS.map(item => item.id)),
+    evidence: new Set(SANTA_YNEZ_EVIDENCE.map(item => item.id)),
+    claim: new Set(SANTA_YNEZ_CLAIMS.map(item => item.id)),
+  };
+  const timelineOrphans = [];
+  for (const item of SANTA_YNEZ_TIMELINE) {
+    if (!ids.event.has(item.eventId)) timelineOrphans.push(`${item.id}:${item.eventId}`);
+    for (const id of item.evidenceIds) if (!ids.evidence.has(id)) timelineOrphans.push(`${item.id}:${id}`);
+    for (const id of item.claimIds) if (!ids.claim.has(id)) timelineOrphans.push(`${item.id}:${id}`);
+  }
+  const correctionOrphans = [];
+  for (const item of SANTA_YNEZ_CORRECTIONS) {
+    for (const id of item.eventIds) if (!ids.event.has(id)) correctionOrphans.push(`${item.id}:${id}`);
+    for (const id of item.evidenceIds) if (!ids.evidence.has(id)) correctionOrphans.push(`${item.id}:${id}`);
+    for (const id of item.claimIds) if (!ids.claim.has(id)) correctionOrphans.push(`${item.id}:${id}`);
+  }
+  const uncitedClaims = SANTA_YNEZ_CLAIMS
+    .filter(claim => !SANTA_YNEZ_SOURCES.some(sourceRecord => sourceRecord.id === claim.originSourceId && sourceRecord.url === claim.originRef))
+    .map(claim => claim.id);
+
+  return {
+    valid:
+      intelligence.valid &&
+      claimEvidence.valid &&
+      timelineOrphans.length === 0 &&
+      correctionOrphans.length === 0 &&
+      uncitedClaims.length === 0,
+    intelligence,
+    claimEvidence,
+    timelineOrphans: [...new Set(timelineOrphans)].sort(),
+    correctionOrphans: [...new Set(correctionOrphans)].sort(),
+    uncitedClaims: [...new Set(uncitedClaims)].sort(),
+  };
+}
+
+export function getSantaYnezDossier() {
+  const validation = validateSantaYnezDossier();
+  return {
+    dossierId: SANTA_YNEZ_DOSSIER_ID,
+    dossierVersion: SANTA_YNEZ_DOSSIER_VERSION,
+    title: 'Santa Ynez Pipeline — Evidence Dossier',
+    dek:
+      'A source-first record of the 2026 restart dispute, regulatory actions, mixed court rulings, appeals, and a documented DOJ correction.',
+    status: 'developing',
+    reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+    geography: {
+      primaryPlaceEntityId: santaBarbaraCounty.id,
+      placeEntityIds: [unitedStates.id, california.id, santaBarbaraCounty.id],
+    },
+    rules: {
+      editorialVerdict: false,
+      truthScore: false,
+      contradictoryClaimsMayCoexist: true,
+      primaryEvidenceDistinctFromStatements: true,
+      updatesAppendOrSupersede: true,
+      distinctProceedingsRemainDistinctEvents: true,
+    },
+    sources: SANTA_YNEZ_SOURCES,
+    entities: SANTA_YNEZ_ENTITIES,
+    events: SANTA_YNEZ_EVENTS,
+    claims: SANTA_YNEZ_CLAIMS,
+    evidence: SANTA_YNEZ_EVIDENCE,
+    claimRelations: SANTA_YNEZ_CLAIM_RELATIONS,
+    evidenceRelations: SANTA_YNEZ_EVIDENCE_RELATIONS,
+    timeline: SANTA_YNEZ_TIMELINE,
+    corrections: SANTA_YNEZ_CORRECTIONS,
+    unknowns: SANTA_YNEZ_UNKNOWNS,
+    validation,
+  };
+}
+
+function source(id, name, sourceClass, evidenceRole, url) {
+  return Object.freeze({ id, name, sourceClass, evidenceRole, url });
+}
+
+function link(claim, evidence, relation) {
+  return createEvidenceRelation({
+    claimId: claim.id,
+    evidenceId: evidence.id,
+    relation,
+    reviewedAt: SANTA_YNEZ_REVIEWED_AT,
+  });
+}
+
+function timeline(date, event, evidenceIds, claimIds, label = event.title) {
+  return Object.freeze({
+    id: `timeline:${date}:${event.id}`,
+    date,
+    label,
+    eventId: event.id,
+    evidenceIds: [...evidenceIds].sort(),
+    claimIds: [...claimIds].sort(),
+  });
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/santa-ynez-dossier.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/shared/ecosystem-nav.js
+++ b/shared/ecosystem-nav.js
@@ -1,16 +1,40 @@
 /**
  * GFD Ecosystem Navigation Component JavaScript
- * Handles dropdown toggle, accessibility, and keyboard navigation
+ * Handles dropdown toggle, accessibility, keyboard navigation, and GlobalDeets evidence discovery.
  */
 
 (function () {
   'use strict';
 
-  // Wait for DOM to be ready
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initEcosystemNav);
+    document.addEventListener('DOMContentLoaded', initNavigation);
   } else {
+    initNavigation();
+  }
+
+  function initNavigation() {
+    initEvidenceDossierLink();
     initEcosystemNav();
+  }
+
+  function initEvidenceDossierLink() {
+    const path = window.location.pathname.replace(/\/$/, '');
+    if (path !== '/news' && path !== '/news.html') return;
+
+    const primaryNav = document.querySelector('.primary-nav');
+    if (!primaryNav || primaryNav.querySelector('[data-evidence-dossier-link]')) return;
+
+    const link = document.createElement('a');
+    link.href = '/dossiers/santa-ynez-pipeline/';
+    link.className = 'nav-icon-btn';
+    link.title = 'Evidence Dossier — Santa Ynez Pipeline';
+    link.setAttribute('aria-label', 'Evidence Dossier — Santa Ynez Pipeline');
+    link.setAttribute('data-evidence-dossier-link', 'santa-ynez-pipeline');
+    link.textContent = '◇';
+
+    const newsLink = primaryNav.querySelector('a[href="news.html"], a[href="/news"]');
+    if (newsLink) newsLink.insertAdjacentElement('afterend', link);
+    else primaryNav.appendChild(link);
   }
 
   function initEcosystemNav() {
@@ -21,7 +45,6 @@
     const dropdown = nav.querySelector('.ecosystem-dropdown');
     let backdrop = document.querySelector('.ecosystem-backdrop');
 
-    // Create backdrop if it doesn't exist
     if (!backdrop) {
       backdrop = document.createElement('div');
       backdrop.className = 'ecosystem-backdrop';
@@ -33,7 +56,6 @@
 
     let isOpen = false;
 
-    // Toggle dropdown
     function toggleDropdown(open) {
       isOpen = typeof open === 'boolean' ? open : !isOpen;
 
@@ -44,7 +66,6 @@
       dropdown.setAttribute('aria-hidden', !isOpen);
 
       if (isOpen) {
-        // Focus first link when opening
         const firstLink = dropdown.querySelector('.nav-link');
         if (firstLink) {
           setTimeout(() => firstLink.focus(), 100);
@@ -52,12 +73,10 @@
       }
     }
 
-    // Toggle button click
     toggleButton.addEventListener('click', () => {
       toggleDropdown();
     });
 
-    // Close on Escape key
     document.addEventListener('keydown', e => {
       if (e.key === 'Escape' && isOpen) {
         toggleDropdown(false);
@@ -65,14 +84,12 @@
       }
     });
 
-    // Close when clicking outside
     document.addEventListener('click', e => {
       if (isOpen && !nav.contains(e.target)) {
         toggleDropdown(false);
       }
     });
 
-    // Close when clicking backdrop
     backdrop.addEventListener('click', () => {
       if (isOpen) {
         toggleDropdown(false);
@@ -80,7 +97,6 @@
       }
     });
 
-    // Keyboard navigation within dropdown
     const navLinks = dropdown.querySelectorAll('.nav-link, .nav-cta-link');
 
     dropdown.addEventListener('keydown', e => {
@@ -105,7 +121,6 @@
       }
     });
 
-    // Highlight current site
     const currentHostname = window.location.hostname;
     navLinks.forEach(link => {
       try {
@@ -113,8 +128,6 @@
         if (linkHostname === currentHostname) {
           link.classList.add('current-site');
           link.setAttribute('aria-current', 'page');
-
-          // Add visual indicator
           link.style.background = 'rgba(139, 92, 246, 0.12)';
           link.style.borderColor = 'rgba(139, 92, 246, 0.3)';
         }
@@ -123,7 +136,6 @@
       }
     });
 
-    // Track engagement for analytics
     toggleButton.addEventListener('click', () => {
       if (window.gtag) {
         window.gtag('event', 'ecosystem_nav_toggle', {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://globaldeets.com/</loc></url>
   <url><loc>https://globaldeets.com/news</loc></url>
+  <url><loc>https://globaldeets.com/dossiers/santa-ynez-pipeline/</loc></url>
   <url><loc>https://globaldeets.com/globe</loc></url>
   <url><loc>https://globaldeets.com/worldmap</loc></url>
   <url><loc>https://globaldeets.com/knowledge</loc></url>

--- a/tests/santa-ynez-dossier.test.mjs
+++ b/tests/santa-ynez-dossier.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { respondWithDossier } from '../functions/api/intelligence/dossiers/santa-ynez-pipeline.js';
+import { validateDossierIntegrity } from '../functions/lib/dossier-integrity.js';
+import { getSantaYnezDossier } from '../functions/lib/santa-ynez-dossier.js';
+
+const request = { headers: { get: () => null } };
+
+function cloneDossier() {
+  return structuredClone(getSantaYnezDossier());
+}
+
+test('Santa Ynez dossier baseline is deterministic and integrity-valid', () => {
+  const dossier = getSantaYnezDossier();
+  const integrity = validateDossierIntegrity(dossier);
+
+  assert.equal(dossier.dossierId, 'santa-ynez-pipeline');
+  assert.equal(dossier.entities.length, 10);
+  assert.equal(dossier.events.length, 7);
+  assert.equal(dossier.claims.length, 11);
+  assert.equal(dossier.evidence.length, 8);
+  assert.equal(dossier.validation.valid, true);
+  assert.equal(integrity.valid, true);
+  assert.equal(dossier.rules.truthScore, false);
+  assert.equal(dossier.rules.editorialVerdict, false);
+});
+
+test('DOJ correction remains first-class and preserves unresolved provenance', () => {
+  const dossier = getSantaYnezDossier();
+  const correction = dossier.corrections.find(item => item.id === 'correction:doj:2026-09-03');
+
+  assert.ok(correction);
+  assert.equal(correction.status, 'corrected');
+  assert.equal(correction.originalArtifactRetained, false);
+  assert.match(correction.description, /mistakenly reprinted/i);
+  assert.ok(
+    dossier.unknowns.includes('The original mistaken September 3 DOJ release artifact is not retained in this dossier snapshot.')
+  );
+});
+
+test('duplicate source URLs fail dossier integrity', () => {
+  const dossier = cloneDossier();
+  dossier.sources[1].url = dossier.sources[0].url;
+
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.deepEqual(integrity.duplicateSourceUrls, [dossier.sources[0].url]);
+});
+
+test('dangling timeline references fail dossier integrity', () => {
+  const dossier = cloneDossier();
+  dossier.timeline[0].eventId = 'event:missing';
+
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.ok(integrity.timelineOrphans.some(item => item.endsWith(':event:missing')));
+});
+
+test('malformed graph records fail closed instead of throwing', () => {
+  const dossier = cloneDossier();
+  dossier.claimRelations[0] = null;
+
+  assert.doesNotThrow(() => validateDossierIntegrity(dossier));
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.ok(integrity.invalidRecords.includes('claimRelations[0]:not-object'));
+});
+
+test('unsupported claim relation semantics fail dossier integrity', () => {
+  const dossier = cloneDossier();
+  dossier.claimRelations[0].relation = 'agrees-with';
+
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.ok(integrity.invalidRelationTypes.includes(dossier.claimRelations[0].id));
+});
+
+test('correction must link its corrected URL to retained evidence', () => {
+  const dossier = cloneDossier();
+  dossier.corrections[0].correctedRef = 'https://example.invalid/correction';
+
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.ok(
+    integrity.invalidCorrections.includes('correction:doj:2026-09-03:correctedRef-not-linked-evidence')
+  );
+});
+
+test('correction unknowns must also be declared at dossier level', () => {
+  const dossier = cloneDossier();
+  dossier.corrections[0].unknowns.push('untracked correction uncertainty');
+
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.ok(integrity.invalidCorrections.includes('correction:doj:2026-09-03:unknown-not-declared'));
+});
+
+test('dossier API publishes only a graph that passes both validation layers', async () => {
+  const response = respondWithDossier(getSantaYnezDossier(), request);
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.validation.valid, true);
+  assert.equal(body.integrity.valid, true);
+  assert.equal(body.rules.truthScore, false);
+});
+
+test('dossier API withholds a malformed graph with an integrity error', async () => {
+  const dossier = cloneDossier();
+  dossier.timeline[0].claimIds.push('claim:missing');
+
+  const response = respondWithDossier(dossier, request);
+  const body = await response.json();
+
+  assert.equal(response.status, 500);
+  assert.equal(body.error, 'dossier-integrity-failed');
+  assert.equal(body.integrity.valid, false);
+  assert.ok(body.integrity.timelineOrphans.some(item => item.endsWith(':claim:missing')));
+});

--- a/tests/santa-ynez-dossier.test.mjs
+++ b/tests/santa-ynez-dossier.test.mjs
@@ -57,6 +57,16 @@ test('dangling timeline references fail dossier integrity', () => {
   assert.ok(integrity.timelineOrphans.some(item => item.endsWith(':event:missing')));
 });
 
+test('timeline entries require stable identity and display label', () => {
+  const dossier = cloneDossier();
+  delete dossier.timeline[0].id;
+  dossier.timeline[0].label = '';
+
+  const integrity = validateDossierIntegrity(dossier);
+  assert.equal(integrity.valid, false);
+  assert.ok(integrity.invalidRecords.includes('timeline[0]:missing-core-field'));
+});
+
 test('malformed graph records fail closed instead of throwing', () => {
   const dossier = cloneDossier();
   dossier.claimRelations[0] = null;
@@ -87,13 +97,15 @@ test('correction must link its corrected URL to retained evidence', () => {
   );
 });
 
-test('correction unknowns must also be declared at dossier level', () => {
+test('correction shape rejects unsupported status and malformed local unknowns', () => {
   const dossier = cloneDossier();
-  dossier.corrections[0].unknowns.push('untracked correction uncertainty');
+  dossier.corrections[0].status = 'quietly-replaced';
+  dossier.corrections[0].unknowns.push('');
 
   const integrity = validateDossierIntegrity(dossier);
   assert.equal(integrity.valid, false);
-  assert.ok(integrity.invalidCorrections.includes('correction:doj:2026-09-03:unknown-not-declared'));
+  assert.ok(integrity.invalidCorrections.includes('correction:doj:2026-09-03:invalid-status'));
+  assert.ok(integrity.invalidCorrections.includes('correction:doj:2026-09-03:unknown-not-text'));
 });
 
 test('dossier API publishes only a graph that passes both validation layers', async () => {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -53,6 +53,124 @@ const newsFixture = {
   ],
 };
 
+const dossierFixture = {
+  dossierId: 'santa-ynez-pipeline',
+  dossierVersion: '2026-09-03.1',
+  reviewedAt: '2026-09-03',
+  validation: { valid: true },
+  integrity: { valid: true },
+  sources: [
+    {
+      id: 'source:court',
+      name: 'Federal court order',
+      sourceClass: 'court-record',
+      evidenceRole: 'primary-evidence',
+      url: 'https://example.com/court',
+    },
+    {
+      id: 'source:federal',
+      name: 'Federal agency',
+      sourceClass: 'institutional-statement',
+      evidenceRole: 'official-position',
+      url: 'https://example.com/federal',
+    },
+    {
+      id: 'source:state',
+      name: 'State agency',
+      sourceClass: 'institutional-statement',
+      evidenceRole: 'official-position',
+      url: 'https://example.com/state',
+    },
+  ],
+  entities: [
+    { id: 'entity:court', displayName: 'Federal court' },
+    { id: 'entity:federal', displayName: 'Federal agency' },
+    { id: 'entity:state', displayName: 'State agency' },
+  ],
+  events: [
+    { id: 'event:ruling', eventType: 'court-ruling', status: 'confirmed' },
+    { id: 'event:correction', eventType: 'correction', status: 'confirmed' },
+  ],
+  claims: [
+    {
+      id: 'claim:ruling',
+      proposition: 'The court imposed a penalty while declining pipeline shutdown.',
+      type: 'fact-assertion',
+      state: 'corroborated',
+      originSourceId: 'source:court',
+    },
+    {
+      id: 'claim:federal',
+      proposition: 'The federal agency described its action as an energy-security measure.',
+      type: 'official-position',
+      state: 'disputed',
+      originSourceId: 'source:federal',
+    },
+    {
+      id: 'claim:state',
+      proposition: 'The state challenged the federal authority asserted for the action.',
+      type: 'official-position',
+      state: 'disputed',
+      originSourceId: 'source:state',
+    },
+    {
+      id: 'claim:appeal',
+      proposition: 'A subsequent filing reported notices of appeal.',
+      type: 'fact-assertion',
+      state: 'single-source',
+      originSourceId: 'source:court',
+    },
+  ],
+  evidence: [
+    {
+      id: 'evidence:ruling',
+      issuerEntityId: 'entity:court',
+      evidenceKey: 'court-order',
+      documentType: 'judgment',
+      publishedAt: '2026-08-19',
+      canonicalRef: 'https://example.com/court',
+    },
+    {
+      id: 'evidence:correction',
+      issuerEntityId: 'entity:federal',
+      evidenceKey: 'correction',
+      documentType: 'government-release',
+      publishedAt: '2026-09-03',
+      canonicalRef: 'https://example.com/correction',
+    },
+  ],
+  claimRelations: [
+    { claimId: 'claim:federal', relatedClaimId: 'claim:state', relation: 'contradicts' },
+  ],
+  timeline: [
+    {
+      date: '2026-08-19',
+      eventId: 'event:ruling',
+      label: 'Federal court issues mixed order',
+      claimIds: ['claim:ruling'],
+      evidenceIds: ['evidence:ruling'],
+    },
+    {
+      date: '2026-09-03',
+      eventId: 'event:correction',
+      label: 'Agency corrects mistaken release',
+      claimIds: [],
+      evidenceIds: ['evidence:correction'],
+    },
+  ],
+  corrections: [
+    {
+      id: 'correction:doj:2026-09-03',
+      observedAt: '2026-09-03',
+      issuerEntityId: 'entity:federal',
+      evidenceIds: ['evidence:correction'],
+      description: 'The agency states that an earlier release mistakenly reprinted a prior item.',
+      originalArtifactRetained: false,
+    },
+  ],
+  unknowns: ['The final appellate outcome remains unresolved.'],
+};
+
 test.beforeEach(async ({ page }) => {
   await page.route('**/api/news**', async route => {
     await route.fulfill({
@@ -67,6 +185,14 @@ test.beforeEach(async ({ page }) => {
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify(newsFixture),
+    });
+  });
+
+  await page.route('**/api/intelligence/dossiers/santa-ynez-pipeline', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(dossierFixture),
     });
   });
 });
@@ -114,4 +240,33 @@ test('worldmap page loads map and webcam UI', async ({ page }) => {
   await expect(page.locator('#location-search')).toBeVisible();
   await expect(page.locator('#featured-list .featured-item').first()).toBeVisible();
   await expect(page.locator('#total-cams')).not.toHaveText('0');
+});
+
+test('Santa Ynez dossier renders an integrity-valid evidence interface on desktop', async ({ page }) => {
+  await page.goto('/dossiers/santa-ynez-pipeline/');
+
+  await expect(page.getByRole('heading', { name: /Santa Ynez Pipeline/i })).toBeVisible();
+  await expect(page.locator('body[data-dossier-ready="true"]')).toBeVisible();
+  await expect(page.getByText('Graph integrity validated')).toBeVisible();
+  await expect(page.locator('#established-claims .claim-card')).toHaveCount(1);
+  await expect(page.locator('#conflict-list .conflict-card')).toHaveCount(1);
+  await expect(page.getByText(/mistakenly reprinted a prior item/i)).toBeVisible();
+  await expect(page.locator('#timeline-list .timeline-item')).toHaveCount(2);
+  await expect(page.locator('#dossier-error')).toBeHidden();
+});
+
+test.describe('Santa Ynez dossier mobile surface', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('remains readable without horizontal overflow', async ({ page }) => {
+    await page.goto('/dossiers/santa-ynez-pipeline/');
+
+    await expect(page.locator('body[data-dossier-ready="true"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /What remains unresolved/i })).toBeVisible();
+    const dimensions = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
+  });
 });

--- a/tools/stage-deploy.js
+++ b/tools/stage-deploy.js
@@ -26,9 +26,12 @@ const REQUIRED_DEPLOY_FILES = [
   '_headers',
   '_redirects',
   '_routes.json',
+  'dossiers/santa-ynez-pipeline/index.html',
+  'dossiers/santa-ynez-pipeline/dossier.js',
+  'dossiers/dossier.css',
 ];
 
-const PUBLIC_DIRECTORIES = ['assets', 'data', 'functions', 'shared'];
+const PUBLIC_DIRECTORIES = ['assets', 'data', 'dossiers', 'functions', 'shared'];
 
 const EXCLUDED_ROOT_JS = new Set([
   'build-assets.js',
@@ -110,7 +113,7 @@ function relativeParts(fullPath) {
 function assertCleanArtifact() {
   const missing = REQUIRED_DEPLOY_FILES.filter(name => !existsSync(join(OUT_DIR, name)));
   if (missing.length > 0) {
-    console.error('Refusing to deploy artifact missing required Pages controls:');
+    console.error('Refusing to deploy artifact missing required Pages controls or dossier assets:');
     for (const file of missing) console.error(`- ${file}`);
     process.exit(1);
   }

--- a/tools/verify-intelligence-prod.js
+++ b/tools/verify-intelligence-prod.js
@@ -8,8 +8,8 @@ function getArgValue(name) {
 const BASE = (getArgValue('--base=') || 'https://globaldeets.com').replace(/\/$/, '');
 const TIMEOUT_MS = 12_000;
 
-async function fetchJson(path) {
-  const response = await fetch(`${BASE}${path}`, {
+async function request(path) {
+  return fetch(`${BASE}${path}`, {
     headers: {
       'User-Agent': 'GlobalDeets-IntelligenceVerifier/1.0',
       'Cache-Control': 'no-cache',
@@ -17,6 +17,10 @@ async function fetchJson(path) {
     },
     signal: AbortSignal.timeout(TIMEOUT_MS),
   });
+}
+
+async function fetchJson(path) {
+  const response = await request(path);
   if (response.status !== 200) throw new Error(`${path} returned HTTP ${response.status}`);
   const contentType = response.headers.get('content-type') || '';
   if (!contentType.includes('application/json')) {
@@ -25,18 +29,31 @@ async function fetchJson(path) {
   return response.json();
 }
 
+async function fetchText(path) {
+  const response = await request(path);
+  if (response.status !== 200) throw new Error(`${path} returned HTTP ${response.status}`);
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    throw new Error(`${path} returned unexpected content-type ${contentType}`);
+  }
+  return response.text();
+}
+
 function requireCondition(condition, message) {
   if (!condition) throw new Error(message);
 }
 
 (async () => {
-  const [coverage, sources, admission, schema, evidenceSchema] = await Promise.all([
-    fetchJson('/api/news/coverage'),
-    fetchJson('/api/news/sources'),
-    fetchJson('/api/news/admission'),
-    fetchJson('/api/intelligence/schema'),
-    fetchJson('/api/intelligence/evidence-schema'),
-  ]);
+  const [coverage, sources, admission, schema, evidenceSchema, dossier, dossierPage] =
+    await Promise.all([
+      fetchJson('/api/news/coverage'),
+      fetchJson('/api/news/sources'),
+      fetchJson('/api/news/admission'),
+      fetchJson('/api/intelligence/schema'),
+      fetchJson('/api/intelligence/evidence-schema'),
+      fetchJson('/api/intelligence/dossiers/santa-ynez-pipeline'),
+      fetchText('/dossiers/santa-ynez-pipeline/'),
+    ]);
 
   requireCondition(typeof coverage.sourceFingerprint === 'string', 'coverage fingerprint missing');
   requireCondition(typeof sources.sourceFingerprint === 'string', 'sources fingerprint missing');
@@ -103,8 +120,38 @@ function requireCondition(condition, message) {
   requireCondition(Number.isInteger(evidenceSchema.institutionalSources?.reviewedSources) && evidenceSchema.institutionalSources.reviewedSources > 0, 'reviewed institutional source count missing');
   requireCondition(evidenceSchema.institutionalSources?.collectionEligibleSources === 0, 'GD-015 must not silently enable institutional collection');
 
+  requireCondition(dossier.dossierId === 'santa-ynez-pipeline', 'Santa Ynez dossier identity changed');
+  requireCondition(typeof dossier.dossierVersion === 'string', 'Santa Ynez dossier version missing');
+  requireCondition(dossier.validation?.valid === true, 'Santa Ynez graph validation failed');
+  requireCondition(dossier.integrity?.valid === true, 'Santa Ynez dossier integrity failed');
+  requireCondition(dossier.rules?.truthScore === false, 'dossier truth score must remain disabled');
+  requireCondition(dossier.rules?.editorialVerdict === false, 'dossier editorial verdict must remain disabled');
+  requireCondition(Array.isArray(dossier.entities) && dossier.entities.length === 10, 'Santa Ynez entity count changed');
+  requireCondition(Array.isArray(dossier.events) && dossier.events.length === 7, 'Santa Ynez event count changed');
+  requireCondition(Array.isArray(dossier.claims) && dossier.claims.length === 11, 'Santa Ynez claim count changed');
+  requireCondition(Array.isArray(dossier.evidence) && dossier.evidence.length === 8, 'Santa Ynez evidence count changed');
+  requireCondition(Array.isArray(dossier.timeline) && dossier.timeline.length >= 7, 'Santa Ynez chronology missing');
+  requireCondition(
+    Array.isArray(dossier.claimRelations) && dossier.claimRelations.some(relation => relation.relation === 'contradicts'),
+    'Santa Ynez contradiction relationship missing'
+  );
+  const correction = Array.isArray(dossier.corrections)
+    ? dossier.corrections.find(item => item.id === 'correction:doj:2026-09-03')
+    : null;
+  requireCondition(correction?.status === 'corrected', 'DOJ correction record missing');
+  requireCondition(correction?.originalArtifactRetained === false, 'DOJ correction provenance state changed');
+  requireCondition(Array.isArray(dossier.unknowns) && dossier.unknowns.length > 0, 'Santa Ynez unresolved unknowns missing');
+  requireCondition(
+    dossierPage.includes('data-dossier-id="santa-ynez-pipeline"'),
+    'Santa Ynez dossier page identity marker missing'
+  );
+  requireCondition(
+    dossierPage.includes('id="dossier-app"') && dossierPage.includes('Evidence dossier'),
+    'Santa Ynez dossier page shell missing'
+  );
+
   console.log(
-    `Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} reviewed institutional candidates, admission ${admission.admissionFingerprint}, models ${schema.modelVersion}/${evidenceSchema.modelVersion}`
+    `Intelligence APIs certified: ${sources.totalSources} sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} reviewed institutional candidates, admission ${admission.admissionFingerprint}, models ${schema.modelVersion}/${evidenceSchema.modelVersion}, dossier ${dossier.dossierVersion}`
   );
 })().catch(error => {
   console.error(`Intelligence API verification failed: ${error.message}`);


### PR DESCRIPTION
## GD-016 — first user-visible evidence dossier

Ships the Santa Ynez Pipeline / Sable Offshore pilot as a deterministic, fail-closed evidence product rather than an AI-written article.

### Evidence graph
- 10 canonical entities
- 7 deliberately distinct events
- 11 attributed claims
- 8 retained evidence records
- explicit corroboration and contradiction relationships
- evidence-linked chronology
- explicit unresolved unknowns
- first-class DOJ correction record
- no editorial verdict or truth/reliability score

### Publication integrity
- adds a reusable dossier-integrity validator around the lower-level intelligence and claim/evidence validators
- malformed graph records fail closed instead of escaping through validator exceptions
- checks duplicate IDs/URLs, claim origins, relation semantics, timeline references, correction references, and correction unknowns
- API withholds any dossier that fails either validation layer

### User surface
- adds `/dossiers/santa-ynez-pipeline/`
- separates corroborated facts, attributed positions, conflicts, corrections, chronology, source records, and unresolved questions
- refuses to render inconsistent intelligence
- adds a World News navigation entry and sitemap entry

### Regression and release gates
- adversarial dossier contract suite
- desktop Playwright dossier smoke test
- 390x844 mobile smoke test with horizontal-overflow assertion
- deploy staging requires dossier HTML/JS/CSS
- production intelligence verifier certifies both the live dossier API and page after Cloudflare deploy

### Scope boundary
This PR does not add a second dossier, enable bulk institutional ingestion, introduce a truth score, or infer unresolved legal outcomes. It establishes the repeatable product grammar for future dossiers.