### PR TITLE
GD-017: Coverage & Evidence Observatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           test -f index.html     || (echo "MISSING: index.html" && exit 1)
           test -f _headers       || (echo "MISSING: _headers" && exit 1)
           test -f dossiers/santa-ynez-pipeline/index.html || (echo "MISSING: Santa Ynez dossier" && exit 1)
+          test -f observatory/coverage/index.html || (echo "MISSING: Coverage & Evidence Observatory" && exit 1)
           echo "All required files present."
 
       - name: Verify GA4 tag present
@@ -54,6 +55,7 @@ jobs:
           node --check functions/api/intelligence/schema.js
           node --check functions/api/intelligence/evidence-schema.js
           node --check functions/api/intelligence/dossiers/santa-ynez-pipeline.js
+          node --check functions/api/intelligence/observatory/coverage.js
           node --check functions/lib/news-coverage.js
           node --check functions/lib/news-source-provenance.js
           node --check functions/lib/news-source-admission.js
@@ -63,7 +65,9 @@ jobs:
           node --check functions/lib/institutional-evidence-sources.js
           node --check functions/lib/dossier-integrity.js
           node --check functions/lib/santa-ynez-dossier.js
+          node --check functions/lib/coverage-evidence-observatory.js
           node --check dossiers/santa-ynez-pipeline/dossier.js
+          node --check observatory/coverage/observatory.js
           node --check shared/ecosystem-nav.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
@@ -73,6 +77,7 @@ jobs:
           node --check tests/intelligence-model.test.mjs
           node --check tests/claim-evidence-model.test.mjs
           node --check tests/santa-ynez-dossier.test.mjs
+          node --check tests/coverage-evidence-observatory.test.mjs
 
       - name: Lint JavaScript
         run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           node --check tools/stage-deploy.js
           node --check tools/deploy-pages.js
           node --check tools/verify-intelligence-prod.js
+          node --check tools/verify-observatory-prod.js
           node --check functions/api/deploy.js
           node --check functions/api/news/health.js
           node --check functions/api/news/coverage.js
@@ -71,6 +72,7 @@ jobs:
           node --check shared/ecosystem-nav.js
           node --check playwright.config.js
           node --check tests/smoke.spec.js
+          node --check tests/observatory-smoke.spec.js
           node --check tests/news-source-admission.test.mjs
           node --check tests/news-source-admission-hardening.test.mjs
           node --check tests/news-admission-api.test.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,3 +68,6 @@ jobs:
 
             - name: Verify production intelligence APIs
               run: node tools/verify-intelligence-prod.js --base=https://globaldeets.com
+
+            - name: Verify production coverage observatory
+              run: node tools/verify-observatory-prod.js --base=https://globaldeets.com

--- a/docs/coverage-observatory.md
+++ b/docs/coverage-observatory.md
@@ -1,62 +1,100 @@
-# GlobalDeets Coverage Observatory
+# GlobalDeets Coverage & Evidence Observatory
 
-Phase II begins by measuring what the production news contract can and cannot see before adding more feeds.
+GD-017 turns the deficiencies preserved by the Phase II source, provenance, admission, claim/evidence, and dossier contracts into a deterministic operational intelligence surface.
 
-## Current production baseline
+The observatory is not a ranking system. It does not calculate truth, publisher quality, political bias, reliability, or a composite coverage score.
 
-The observatory derives its inventory directly from `SOURCES` in `functions/api/news.js` so the analysis cannot silently drift from the deployed ingestion contract.
+## Surfaces
 
-At the Phase II baseline (`0fc253fb2d3297f5b15c3dbfface64db1ee8a597`):
+- Human interface: `GET /observatory/coverage/`
+- Machine-readable observatory: `GET /api/intelligence/observatory/coverage`
+- Canonical news coverage remains: `GET /api/news/coverage`
+- Operational feed health remains: `GET /api/news/health`
 
-- 19 configured sources
-- 7 coarse regions
-- 2 source languages
-- 18/19 sources are English-language inputs
-- NHK is the only non-English source-language input
-- Pacific has one configured source, so it has no feed-level redundancy
-- Africa, Americas, Europe, Middle East, and Pacific have only English-language source inputs in the present contract
+The machine-readable observatory is generated from existing canonical contracts. It does not maintain a second hand-edited source inventory.
 
-These are coverage signals, not judgments about truth, ideology, or publisher quality.
+## Semantic boundaries
 
-## API
+The observatory preserves these distinctions mechanically:
 
-`GET /api/news/coverage`
+1. **News coverage is not evidence coverage.** A configured reporting source does not imply that an event has primary evidence.
+2. **Publisher provenance is not usage permission.** Provenance metadata does not authorize collection.
+3. **Endpoint authority is not usage permission.** A first-party endpoint can still require permission or contractual access.
+4. **Feed health is not usage permission.** A technically healthy feed can remain governance-ineligible.
+5. **Reviewed institutional identity is not collection authority.** A directory-only institutional candidate remains ineligible until a machine-readable endpoint and its access/usage contract are separately reviewed.
+6. **Unresolved is a first-class state.** Single-source, contradicted, disputed, and unreviewed claims remain visible until evidence justifies a state transition.
+7. **Corrections preserve history.** Correction and supersession activity is observable; corrected-away artifacts are not silently treated as if they never existed.
 
-Returns a deterministic inventory containing:
+## GD-017 production baseline
 
-- current source fingerprint
-- total sources, regions, and source languages
-- English-language concentration
-- per-region source counts and language diversity
-- per-language source counts
-- explicit gap signals generated from a small documented policy
+GD-017 begins from the certified GD-016 main baseline `60ec29982421cda2d535b836413a220ac1d04fa2`:
 
-The endpoint is intentionally read-only and does not probe feeds. Operational availability remains the responsibility of `/api/news/health`.
+- 19 live news sources
+- 17 live legacy sources still requiring source-rights review
+- 2 reviewed live legacy sources (AP and Guardian), both preserving restrictive governance states rather than being silently approved
+- 10 reviewed institutional evidence candidates
+- 0 institutional candidates collection-eligible
+- 1 published evidence dossier (`santa-ynez-pipeline`)
+- explicit geographic, language, provenance, subnational/local, evidence-role, source-rights, dossier-evidence, unresolved-claim, correction, and operational-health signals where the underlying contracts support them
 
-## Initial gap policy
+These counts are a baseline, not permanent acceptance thresholds. Production verification cross-checks them against the canonical APIs so drift cannot be hidden inside the observatory.
 
-The first policy is intentionally narrow and auditable:
+## Gap records
 
-1. A region with fewer than two configured feeds emits a high-severity `regional-redundancy` signal.
-2. A non-global region with English-only source inputs emits a medium-severity `source-language-diversity` signal.
-3. If at least 80% of the complete source portfolio is English-language input, the portfolio emits a high-severity `portfolio-language-concentration` signal.
+Every observatory gap has explicit fields for:
 
-These thresholds are diagnostics, not permanent editorial doctrine. They create a measurable baseline from which better source research can proceed.
+- stable identity
+- domain
+- gap type
+- severity
+- observed state
+- target or desired state
+- affected canonical IDs
+- explanation
+- next permitted action
+- requirements such as manual review, licensing, or code
 
-## Deliberate non-goals of GD-012
+Suggested actions are operational instructions, not automatic source admission. The observatory has no mutation path and `automaticRemediation` is explicitly false.
 
-This tranche does **not** yet claim to measure:
+## Source-health handling
 
-- publisher ownership or independence
-- primary-vs-secondary evidence
-- country-level geographic coverage
-- topic/beat coverage
-- viewpoint or political diversity
-- article-level corroboration or contradiction
-- source reliability or factual accuracy
+The observatory may read the existing matching source-health KV snapshot. It never launches a second set of feed probes. A health snapshot is accepted only when its source fingerprint and source count match the deployed canonical source contract; stale identities are treated as unavailable rather than blended into current telemetry.
 
-Those require explicit provenance metadata and evidence modeling rather than guesses inferred from a publisher name or feed URL.
+## Dossier observability
 
-## Next tranche
+For each published dossier the observatory derives, without changing the dossier:
 
-GD-013 should add a reviewed source-provenance registry beside the runtime feed definitions. The registry should use explicit fields for source class, geographic scope, locality, organization type, languages, and evidence role, with validation that every live feed has a provenance record. That will allow the observatory to expose substantially more meaningful blind spots without contaminating the feed-cache identity contract.
+- event, claim, source, and evidence counts
+- evidence-document classes
+- events with and without linked primary-evidence / primary-disclosure records
+- reporting-source presence per event
+- unresolved claim states
+- contradiction relationships
+- corrections
+- supersession activity
+- explicit unknowns
+- missing retained correction artifacts
+
+The dossier must first pass the existing dossier-integrity contract. Invalid dossiers are not accepted as valid observatory inputs.
+
+## Fail-closed behavior
+
+`functions/lib/coverage-evidence-observatory.js` validates the generated observatory. The API withholds the normal payload with HTTP 503 when integrity fails. The browser surface independently checks the critical semantic rules before rendering and clears the intelligence panels if the payload is invalid.
+
+CI covers hostile contract mutations, desktop rendering, the 390×844 mobile surface, syntax/lint, the Function suite, and clean deployment staging. Production deployment separately verifies the live observatory against the canonical news, admission, evidence-schema, and dossier APIs.
+
+## Non-goals
+
+GD-017 deliberately does not:
+
+- compute a truth score
+- publish an editorial verdict
+- compute a publisher-quality or reliability score
+- infer political or viewpoint diversity
+- combine heterogeneous metrics into a composite coverage score
+- auto-add a source because a gap exists
+- auto-enable collection because an institutional source has been reviewed
+- infer corroboration from repeated institutional statements
+- convert missing evidence into an estimate
+
+The observatory exists to make limits measurable enough that the next research and engineering tranche can be selected from evidence rather than intuition.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,6 +45,7 @@ export default [
         location: 'readonly',
         module: 'readonly',
         navigator: 'readonly',
+        Node: 'readonly',
         performance: 'readonly',
         process: 'readonly',
         projects: 'readonly',

--- a/functions/api/intelligence/observatory/coverage.js
+++ b/functions/api/intelligence/observatory/coverage.js
@@ -1,0 +1,70 @@
+import {
+  buildCoverageEvidenceObservatory,
+  readCachedSourceHealth,
+  validateCoverageEvidenceObservatory,
+} from '../../../lib/coverage-evidence-observatory.js';
+
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+function headers(request, cacheControl = 'public, max-age=300') {
+  const origin = request?.headers?.get('Origin');
+  return {
+    'Access-Control-Allow-Origin': ALLOWED_ORIGINS.has(origin) ? origin : 'https://globaldeets.com',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json',
+    'Cache-Control': cacheControl,
+    Vary: 'Origin',
+  };
+}
+
+export async function onRequestOptions({ request }) {
+  return new Response(null, { status: 204, headers: headers(request) });
+}
+
+export async function onRequestGet({ env, request }) {
+  try {
+    const healthSnapshot = await readCachedSourceHealth(env);
+    const observatory = buildCoverageEvidenceObservatory({ healthSnapshot });
+    const integrity = validateCoverageEvidenceObservatory(observatory);
+
+    if (!integrity.valid) {
+      return new Response(
+        JSON.stringify({
+          error: 'observatory_integrity_failed',
+          observatoryId: observatory.observatoryId,
+          observatoryVersion: observatory.observatoryVersion,
+          integrity,
+        }),
+        { status: 503, headers: headers(request, 'no-store') }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        generatedAt: new Date().toISOString(),
+        ...observatory,
+        integrity,
+      }),
+      { headers: headers(request) }
+    );
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: 'globaldeets.intelligence.observatory.error',
+        error: error?.message || String(error || 'unknown error'),
+      })
+    );
+    return new Response(
+      JSON.stringify({
+        error: 'observatory_generation_failed',
+      }),
+      { status: 503, headers: headers(request, 'no-store') }
+    );
+  }
+}

--- a/functions/lib/coverage-evidence-observatory.js
+++ b/functions/lib/coverage-evidence-observatory.js
@@ -1,0 +1,777 @@
+import { SOURCE_FINGERPRINT, SOURCE_HEALTH_KEY, SOURCES } from '../api/news.js';
+import { buildCoverageInventory } from './news-coverage.js';
+import {
+  ADMISSION_FINGERPRINT,
+  SOURCE_ADMISSIONS,
+  SOURCE_RESEARCH_CANDIDATES,
+} from './news-source-admission.js';
+import {
+  REVIEWED_INSTITUTIONAL_SOURCES,
+  institutionalRegistrySummary,
+} from './institutional-evidence-sources.js';
+import { validateDossierIntegrity } from './dossier-integrity.js';
+import { getSantaYnezDossier } from './santa-ynez-dossier.js';
+
+export const COVERAGE_EVIDENCE_OBSERVATORY_ID = 'coverage-evidence';
+export const COVERAGE_EVIDENCE_OBSERVATORY_VERSION = '2026-09-08.1';
+
+const UNRESOLVED_CLAIM_STATES = new Set([
+  'unreviewed',
+  'single-source',
+  'contradicted',
+  'disputed',
+]);
+const PRIMARY_EVIDENCE_ROLES = new Set(['primary-evidence', 'primary-disclosure']);
+const REPORTING_ROLES = new Set(['reporting']);
+const TERMINAL_CLAIM_STATES = new Set(['superseded', 'withdrawn']);
+const GAP_SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+
+export function buildCoverageEvidenceObservatory({
+  coverage = buildCoverageInventory(),
+  liveAdmissions = SOURCE_ADMISSIONS,
+  researchCandidates = SOURCE_RESEARCH_CANDIDATES,
+  institutionalSources = REVIEWED_INSTITUTIONAL_SOURCES,
+  dossiers = [getSantaYnezDossier()],
+  healthSnapshot = null,
+} = {}) {
+  requireArray(liveAdmissions, 'liveAdmissions');
+  requireArray(researchCandidates, 'researchCandidates');
+  requireArray(institutionalSources, 'institutionalSources');
+  requireArray(dossiers, 'dossiers');
+  if (!plainObject(coverage)) throw new TypeError('coverage must be an object');
+
+  const dossierSummaries = dossiers.map(summarizeDossier).sort(byId('dossierId'));
+  const institutionalSummary = summarizeInstitutionalSources(institutionalSources);
+  const sourceRights = summarizeSourceRights(liveAdmissions, researchCandidates);
+  const evidenceClasses = summarizeEvidenceClasses(dossiers);
+  const dossierProvenance = summarizeDossierProvenance(dossiers);
+  const operationalHealth = summarizeHealthSnapshot(healthSnapshot);
+  const gaps = buildObservatoryGaps({
+    coverage,
+    sourceRights,
+    institutionalSummary,
+    dossierSummaries,
+    operationalHealth,
+  });
+
+  const observatory = {
+    observatoryId: COVERAGE_EVIDENCE_OBSERVATORY_ID,
+    observatoryVersion: COVERAGE_EVIDENCE_OBSERVATORY_VERSION,
+    sourceFingerprint: SOURCE_FINGERPRINT,
+    admissionFingerprint: ADMISSION_FINGERPRINT,
+    rules: {
+      truthScore: false,
+      editorialVerdict: false,
+      compositeCoverageScore: false,
+      publisherQualityScore: false,
+      newsCoverageIsEvidenceCoverage: false,
+      collectionEligibilityRequiresEndpointReview: true,
+      reviewedDirectoryIsCollectionAuthority: false,
+      automaticRemediation: false,
+    },
+    newsCoverage: {
+      totalSources: coverage.totalSources,
+      totalRegions: coverage.totalRegions,
+      totalLanguages: coverage.totalLanguages,
+      englishSourceShare: coverage.englishSourceShare,
+      primarySourceInputs: coverage.primarySourceInputs,
+      regions: cloneArray(coverage.regions),
+      sourceOriginCountries: cloneArray(coverage.sourceOriginCountries),
+      sourceClasses: cloneArray(coverage.sourceClasses),
+      evidenceRoles: cloneArray(coverage.evidenceRoles),
+      geographicScopes: cloneArray(coverage.geographicScopes),
+      provenance: cloneObject(coverage.provenance),
+      admission: cloneObject(coverage.admission),
+      gapCount: Array.isArray(coverage.gaps) ? coverage.gaps.length : null,
+    },
+    sourceRights,
+    institutionalEvidence: institutionalSummary,
+    evidenceCoverage: {
+      dossierCount: dossierSummaries.length,
+      dossierIds: dossierSummaries.map(item => item.dossierId),
+      evidenceClasses,
+      provenance: dossierProvenance,
+      dossiers: dossierSummaries,
+    },
+    operationalHealth,
+    gaps,
+  };
+
+  return Object.freeze(observatory);
+}
+
+export function validateCoverageEvidenceObservatory(observatory) {
+  const issues = {
+    structureErrors: [],
+    semanticErrors: [],
+    countErrors: [],
+    duplicateIds: [],
+    invalidGaps: [],
+  };
+
+  if (!plainObject(observatory)) {
+    issues.structureErrors.push('observatory:not-object');
+    return finishValidation(issues);
+  }
+
+  if (observatory.observatoryId !== COVERAGE_EVIDENCE_OBSERVATORY_ID) {
+    issues.semanticErrors.push('observatoryId:mismatch');
+  }
+  if (observatory.observatoryVersion !== COVERAGE_EVIDENCE_OBSERVATORY_VERSION) {
+    issues.semanticErrors.push('observatoryVersion:mismatch');
+  }
+  if (observatory.sourceFingerprint !== SOURCE_FINGERPRINT) {
+    issues.semanticErrors.push('sourceFingerprint:mismatch');
+  }
+  if (observatory.admissionFingerprint !== ADMISSION_FINGERPRINT) {
+    issues.semanticErrors.push('admissionFingerprint:mismatch');
+  }
+
+  const rules = observatory.rules;
+  if (!plainObject(rules)) issues.structureErrors.push('rules:not-object');
+  else {
+    for (const field of [
+      'truthScore',
+      'editorialVerdict',
+      'compositeCoverageScore',
+      'publisherQualityScore',
+      'newsCoverageIsEvidenceCoverage',
+      'reviewedDirectoryIsCollectionAuthority',
+      'automaticRemediation',
+    ]) {
+      if (rules[field] !== false) issues.semanticErrors.push(`rules.${field}:must-be-false`);
+    }
+    if (rules.collectionEligibilityRequiresEndpointReview !== true) {
+      issues.semanticErrors.push('rules.collectionEligibilityRequiresEndpointReview:must-be-true');
+    }
+  }
+
+  const news = observatory.newsCoverage;
+  if (!plainObject(news)) issues.structureErrors.push('newsCoverage:not-object');
+  else {
+    if (news.totalSources !== SOURCES.length) issues.countErrors.push('newsCoverage.totalSources');
+    if (news.provenance?.valid !== true) issues.semanticErrors.push('newsCoverage.provenance:invalid');
+    if (news.admission?.valid !== true) issues.semanticErrors.push('newsCoverage.admission:invalid');
+    for (const field of [
+      'regions',
+      'sourceOriginCountries',
+      'sourceClasses',
+      'evidenceRoles',
+      'geographicScopes',
+    ]) {
+      if (!Array.isArray(news[field])) issues.structureErrors.push(`newsCoverage.${field}:not-array`);
+    }
+  }
+
+  const rights = observatory.sourceRights;
+  if (!plainObject(rights)) issues.structureErrors.push('sourceRights:not-object');
+  else {
+    for (const field of [
+      'reviewedLiveSourceIds',
+      'legacyUnreviewedSourceIds',
+      'remediationSourceIds',
+      'unknownRightsSourceIds',
+      'researchCandidates',
+    ]) {
+      if (!Array.isArray(rights[field])) issues.structureErrors.push(`sourceRights.${field}:not-array`);
+    }
+    if (rights.totalLiveSources !== SOURCES.length) issues.countErrors.push('sourceRights.totalLiveSources');
+    if (Array.isArray(rights.reviewedLiveSourceIds) && rights.reviewedLiveSources !== rights.reviewedLiveSourceIds.length) {
+      issues.countErrors.push('sourceRights.reviewedLiveSources');
+    }
+    if (
+      Array.isArray(rights.legacyUnreviewedSourceIds) &&
+      rights.legacyUnreviewedSources !== rights.legacyUnreviewedSourceIds.length
+    ) {
+      issues.countErrors.push('sourceRights.legacyUnreviewedSources');
+    }
+    if (
+      Number.isInteger(rights.reviewedLiveSources) &&
+      Number.isInteger(rights.legacyUnreviewedSources) &&
+      rights.reviewedLiveSources + rights.legacyUnreviewedSources !== rights.totalLiveSources
+    ) {
+      issues.countErrors.push('sourceRights.review-state-partition');
+    }
+  }
+
+  const institutional = observatory.institutionalEvidence;
+  if (!plainObject(institutional)) issues.structureErrors.push('institutionalEvidence:not-object');
+  else {
+    if (!Array.isArray(institutional.sources)) issues.structureErrors.push('institutionalEvidence.sources:not-array');
+    if (Array.isArray(institutional.sources) && institutional.reviewedSources !== institutional.sources.length) {
+      issues.countErrors.push('institutionalEvidence.reviewedSources');
+    }
+    if (institutional.collectionEligibleSources > institutional.reviewedSources) {
+      issues.countErrors.push('institutionalEvidence.collectionEligibleSources');
+    }
+    for (const source of array(institutional.sources)) {
+      if (!plainObject(source) || !text(source.sourceId)) {
+        issues.semanticErrors.push('institutionalEvidence.source:invalid');
+        continue;
+      }
+      if (
+        source.collectionEligible === true &&
+        (source.collectionState !== 'endpoint-reviewed' || source.verifiedEndpointCount < 1)
+      ) {
+        issues.semanticErrors.push(`institutionalEvidence.${source.sourceId}:unsafe-collection`);
+      }
+    }
+  }
+
+  const evidence = observatory.evidenceCoverage;
+  if (!plainObject(evidence)) issues.structureErrors.push('evidenceCoverage:not-object');
+  else {
+    for (const field of ['dossierIds', 'evidenceClasses', 'dossiers']) {
+      if (!Array.isArray(evidence[field])) issues.structureErrors.push(`evidenceCoverage.${field}:not-array`);
+    }
+    if (Array.isArray(evidence.dossiers) && evidence.dossierCount !== evidence.dossiers.length) {
+      issues.countErrors.push('evidenceCoverage.dossierCount');
+    }
+    if (Array.isArray(evidence.dossierIds)) {
+      issues.duplicateIds.push(...duplicates(evidence.dossierIds).map(id => `dossier:${id}`));
+    }
+    for (const dossier of array(evidence.dossiers)) validateDossierSummary(dossier, issues);
+  }
+
+  const health = observatory.operationalHealth;
+  if (!plainObject(health)) issues.structureErrors.push('operationalHealth:not-object');
+  else if (!['available', 'unavailable'].includes(health.status)) {
+    issues.semanticErrors.push('operationalHealth.status:invalid');
+  }
+
+  if (!Array.isArray(observatory.gaps)) issues.structureErrors.push('gaps:not-array');
+  else {
+    issues.duplicateIds.push(...duplicates(observatory.gaps.map(gap => gap?.id).filter(text)));
+    for (const [index, gap] of observatory.gaps.entries()) {
+      if (
+        !plainObject(gap) ||
+        !text(gap.id) ||
+        !text(gap.domain) ||
+        !text(gap.type) ||
+        !GAP_SEVERITIES.has(gap.severity) ||
+        !text(gap.detail) ||
+        !text(gap.nextAction)
+      ) {
+        issues.invalidGaps.push(`gap-index:${index}`);
+      }
+    }
+  }
+
+  return finishValidation(issues);
+}
+
+export async function readCachedSourceHealth(env) {
+  if (!env?.NEWS_CACHE) return null;
+  try {
+    const snapshot = await env.NEWS_CACHE.get(SOURCE_HEALTH_KEY, { type: 'json' });
+    if (
+      snapshot?.sourceFingerprint !== SOURCE_FINGERPRINT ||
+      !Array.isArray(snapshot.sourceHealth) ||
+      snapshot.sourceHealth.length !== SOURCES.length
+    ) {
+      return null;
+    }
+    return snapshot;
+  } catch {
+    return null;
+  }
+}
+
+function summarizeDossier(dossier) {
+  const integrity = validateDossierIntegrity(dossier);
+  const sourceById = new Map(array(dossier?.sources).map(source => [source.id, source]));
+  const sourceByUrl = new Map(array(dossier?.sources).map(source => [source.url, source]));
+  const claims = array(dossier?.claims);
+  const evidence = array(dossier?.evidence);
+  const events = array(dossier?.events);
+  const claimRelations = array(dossier?.claimRelations);
+  const evidenceRelations = array(dossier?.evidenceRelations);
+  const corrections = array(dossier?.corrections);
+  const unknowns = array(dossier?.unknowns);
+
+  const unresolvedClaims = claims
+    .filter(claim => UNRESOLVED_CLAIM_STATES.has(claim.state))
+    .map(claim => ({
+      claimId: claim.id,
+      state: claim.state,
+      type: claim.type,
+      originSourceId: claim.originSourceId,
+      eventIds: cloneArray(claim.eventIds),
+      proposition: claim.proposition,
+    }))
+    .sort(byId('claimId'));
+
+  const terminalClaims = claims
+    .filter(claim => TERMINAL_CLAIM_STATES.has(claim.state))
+    .map(claim => ({ claimId: claim.id, state: claim.state }))
+    .sort(byId('claimId'));
+
+  const eventCoverage = events
+    .map(event => {
+      const eventEvidence = evidence.filter(item => array(item.eventIds).includes(event.id));
+      const primaryEvidenceIds = eventEvidence
+        .filter(item => PRIMARY_EVIDENCE_ROLES.has(sourceByUrl.get(item.canonicalRef)?.evidenceRole))
+        .map(item => item.id)
+        .sort();
+      const eventClaims = claims.filter(claim => array(claim.eventIds).includes(event.id));
+      const originSourceIds = unique(eventClaims.map(claim => claim.originSourceId).filter(text));
+      const reportingSourceIds = originSourceIds.filter(sourceId =>
+        REPORTING_ROLES.has(sourceById.get(sourceId)?.evidenceRole)
+      );
+
+      return {
+        eventId: event.id,
+        title: event.title,
+        status: event.status,
+        claimCount: eventClaims.length,
+        distinctClaimOriginSources: originSourceIds.length,
+        reportingSourceCount: reportingSourceIds.length,
+        reportingSourceIds,
+        evidenceCount: eventEvidence.length,
+        primaryEvidenceCount: primaryEvidenceIds.length,
+        primaryEvidenceIds,
+        hasPrimaryEvidence: primaryEvidenceIds.length > 0,
+      };
+    })
+    .sort(byId('eventId'));
+
+  const contradictionClaimIds = unique(
+    claimRelations
+      .filter(relation => relation.relation === 'contradicts')
+      .flatMap(relation => [relation.claimId, relation.relatedClaimId])
+      .filter(text)
+  );
+  const supersessionRelationCount =
+    claimRelations.filter(relation => relation.relation === 'supersedes').length +
+    evidenceRelations.filter(relation => relation.relation === 'supersedes').length +
+    evidence.reduce((count, item) => count + array(item.supersedesEvidenceIds).length, 0);
+
+  return {
+    dossierId: dossier?.dossierId || null,
+    dossierVersion: dossier?.dossierVersion || null,
+    title: dossier?.title || null,
+    status: dossier?.status || null,
+    reviewedAt: dossier?.reviewedAt || null,
+    integrityValid: integrity.valid,
+    sourceCount: array(dossier?.sources).length,
+    eventCount: events.length,
+    claimCount: claims.length,
+    evidenceCount: evidence.length,
+    unresolvedClaimCount: unresolvedClaims.length,
+    unresolvedClaims,
+    terminalClaimCount: terminalClaims.length,
+    terminalClaims,
+    contradictionClaimCount: contradictionClaimIds.length,
+    contradictionClaimIds,
+    unknownCount: unknowns.length,
+    unknowns: [...unknowns],
+    correctionCount: corrections.length,
+    corrections: corrections.map(item => ({
+      correctionId: item.id,
+      status: item.status,
+      observedAt: item.observedAt,
+      originalArtifactRetained: item.originalArtifactRetained,
+    })),
+    supersessionRelationCount,
+    eventCoverage,
+  };
+}
+
+function summarizeInstitutionalSources(sources) {
+  const base = institutionalRegistrySummary();
+  const summaries = sources
+    .map(source => ({
+      sourceId: source.sourceId,
+      sourceClass: source.sourceClass,
+      evidenceRole: source.evidenceRole,
+      jurisdiction: source.jurisdiction,
+      collectionState: source.collectionState,
+      collectionEligible: source.collectionEligible,
+      machineReadableEndpointCount: array(source.machineReadableEndpoints).length,
+      verifiedEndpointCount: array(source.machineReadableEndpoints).filter(
+        endpoint => endpoint?.reviewStatus === 'verified'
+      ).length,
+      documentTypes: cloneArray(source.documentTypes),
+    }))
+    .sort(byId('sourceId'));
+
+  return {
+    reviewedSources: summaries.length,
+    issuingPrimarySources: summaries.filter(source => source.evidenceRole === 'issuing-primary').length,
+    collectionEligibleSources: summaries.filter(source => source.collectionEligible).length,
+    directoryOnlySources: summaries.filter(source => source.collectionState === 'directory-only').length,
+    endpointReviewedSources: summaries.filter(source => source.collectionState === 'endpoint-reviewed').length,
+    knowledgeCatalogIsIngestionAuthority: base.knowledgeCatalogIsIngestionAuthority,
+    endpointReviewRequired: base.endpointReviewRequired,
+    sources: summaries,
+  };
+}
+
+function summarizeSourceRights(admissions, candidates) {
+  const reviewedLiveSourceIds = admissions
+    .filter(entry => entry.reviewState === 'reviewed')
+    .map(entry => entry.sourceId)
+    .sort();
+  const legacyUnreviewedSourceIds = admissions
+    .filter(entry => entry.reviewState === 'legacy-unreviewed')
+    .map(entry => entry.sourceId)
+    .sort();
+  const remediationSourceIds = admissions
+    .filter(entry => ['permission-required', 'contract-required', 'prohibited'].includes(entry.allowedUseStatus))
+    .map(entry => entry.sourceId)
+    .sort();
+  const unknownRightsSourceIds = admissions
+    .filter(entry => entry.allowedUseStatus === 'unknown')
+    .map(entry => entry.sourceId)
+    .sort();
+
+  return {
+    totalLiveSources: admissions.length,
+    reviewedLiveSources: reviewedLiveSourceIds.length,
+    reviewedLiveSourceIds,
+    legacyUnreviewedSources: legacyUnreviewedSourceIds.length,
+    legacyUnreviewedSourceIds,
+    remediationSourceIds,
+    unknownRightsSourceIds,
+    researchCandidates: candidates
+      .map(candidate => ({
+        candidateId: candidate.candidateId,
+        name: candidate.name,
+        disposition: candidate.disposition,
+        endpointAuthority: candidate.endpointAuthority,
+        allowedUseStatus: candidate.allowedUseStatus,
+        collectionEligible: false,
+        itemLevelReviewRequired: candidate.itemLevelReviewRequired === true,
+      }))
+      .sort(byId('candidateId')),
+  };
+}
+
+function summarizeEvidenceClasses(dossiers) {
+  const counts = new Map();
+  for (const dossier of dossiers) {
+    for (const evidence of array(dossier?.evidence)) {
+      const type = text(evidence.documentType) ? evidence.documentType : 'unknown';
+      counts.set(type, (counts.get(type) || 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([documentType, count]) => ({ documentType, count }));
+}
+
+function summarizeDossierProvenance(dossiers) {
+  const sources = dossiers.flatMap(dossier => array(dossier?.sources));
+  return {
+    sourceClasses: groupedCount(sources, 'sourceClass'),
+    evidenceRoles: groupedCount(sources, 'evidenceRole'),
+    uniqueSourceCount: new Set(sources.map(source => source.id).filter(text)).size,
+    scoringApplied: false,
+  };
+}
+
+function summarizeHealthSnapshot(snapshot) {
+  if (
+    !plainObject(snapshot) ||
+    snapshot.sourceFingerprint !== SOURCE_FINGERPRINT ||
+    !Array.isArray(snapshot.sourceHealth) ||
+    snapshot.sourceHealth.length !== SOURCES.length
+  ) {
+    return {
+      status: 'unavailable',
+      generatedAt: null,
+      totalSources: SOURCES.length,
+      healthySources: null,
+      degradedSources: null,
+      degradedSourceIds: [],
+    };
+  }
+
+  const degradedSourceIds = snapshot.sourceHealth
+    .filter(source => source?.lastError)
+    .map(source => source.sourceId)
+    .filter(text)
+    .sort();
+  return {
+    status: 'available',
+    generatedAt: snapshot.generatedAt || null,
+    totalSources: snapshot.sourceHealth.length,
+    healthySources: snapshot.sourceHealth.length - degradedSourceIds.length,
+    degradedSources: degradedSourceIds.length,
+    degradedSourceIds,
+  };
+}
+
+function buildObservatoryGaps({
+  coverage,
+  sourceRights,
+  institutionalSummary,
+  dossierSummaries,
+  operationalHealth,
+}) {
+  const gaps = array(coverage.gaps).map(gap => ({
+    id: `news:${gap.id}`,
+    domain: 'news-coverage',
+    type: gap.type,
+    severity: gap.severity,
+    observed: gap.observed,
+    target: gap.target,
+    affectedIds: gap.region ? [`region:${gap.region}`] : [],
+    detail: gap.detail,
+    nextAction: nextActionForNewsGap(gap.type),
+    requires: requirementsForNewsGap(gap.type),
+  }));
+
+  if (sourceRights.legacyUnreviewedSources > 0) {
+    gaps.push({
+      id: 'governance:source-rights-review-debt',
+      domain: 'source-governance',
+      type: 'source-rights-review-debt',
+      severity: 'high',
+      observed: sourceRights.legacyUnreviewedSources,
+      target: 0,
+      affectedIds: sourceRights.legacyUnreviewedSourceIds,
+      detail: 'Live legacy sources remain explicitly unreviewed for usage rights.',
+      nextAction: 'Complete evidence-backed source-by-source rights review without changing collection eligibility by assumption.',
+      requires: ['manual-review'],
+    });
+  }
+
+  if (institutionalSummary.reviewedSources > institutionalSummary.collectionEligibleSources) {
+    gaps.push({
+      id: 'evidence:institutional-collection-eligibility',
+      domain: 'evidence-coverage',
+      type: 'institutional-collection-eligibility',
+      severity: 'high',
+      observed: institutionalSummary.collectionEligibleSources,
+      target: `review endpoint authority, permissions, and machine-readable access for selected candidates; ${institutionalSummary.reviewedSources} are classification-reviewed`,
+      affectedIds: institutionalSummary.sources
+        .filter(source => !source.collectionEligible)
+        .map(source => source.sourceId),
+      detail: 'Reviewed institutional directories are evidence candidates, not collection authority; no candidate may be ingested until its endpoint contract is separately reviewed.',
+      nextAction: 'Select high-value institutional candidates and perform endpoint-specific collection and rights review.',
+      requires: ['manual-review', 'code'],
+    });
+  }
+
+  for (const dossier of dossierSummaries) {
+    const noPrimary = dossier.eventCoverage.filter(event => !event.hasPrimaryEvidence);
+    if (noPrimary.length > 0) {
+      gaps.push({
+        id: `evidence:dossier:${dossier.dossierId}:events-without-primary-evidence`,
+        domain: 'evidence-coverage',
+        type: 'event-primary-evidence-gap',
+        severity: 'high',
+        observed: noPrimary.length,
+        target: 0,
+        affectedIds: noPrimary.map(event => event.eventId),
+        detail: 'One or more dossier events currently lack a linked record whose source role is primary evidence or primary disclosure.',
+        nextAction: 'Research and link issuing-institution records without replacing attributed reporting or official positions.',
+        requires: ['manual-review'],
+      });
+    }
+
+    const zeroReporting = dossier.eventCoverage.filter(event => event.reportingSourceCount === 0);
+    if (zeroReporting.length > 0) {
+      gaps.push({
+        id: `news:dossier:${dossier.dossierId}:events-without-reporting`,
+        domain: 'news-coverage',
+        type: 'event-reporting-gap',
+        severity: 'medium',
+        observed: zeroReporting.length,
+        target: 0,
+        affectedIds: zeroReporting.map(event => event.eventId),
+        detail: 'Some dossier events have no claim-origin source classified as independent reporting in the current dossier snapshot.',
+        nextAction: 'Research independent reporting relevant to the affected events; do not infer corroboration from institutional repetition.',
+        requires: ['manual-review'],
+      });
+    }
+
+    const singleReporting = dossier.eventCoverage.filter(event => event.reportingSourceCount === 1);
+    if (singleReporting.length > 0) {
+      gaps.push({
+        id: `news:dossier:${dossier.dossierId}:single-reporting-source-events`,
+        domain: 'news-coverage',
+        type: 'single-reporting-source-event',
+        severity: 'medium',
+        observed: singleReporting.length,
+        target: 'independent reporting redundancy where relevant and available',
+        affectedIds: singleReporting.map(event => event.eventId),
+        detail: 'One or more dossier events currently have exactly one claim-origin source classified as reporting.',
+        nextAction: 'Research independent reporting redundancy while preserving distinct source roles and provenance.',
+        requires: ['manual-review'],
+      });
+    }
+
+    if (dossier.unresolvedClaimCount > 0) {
+      gaps.push({
+        id: `evidence:dossier:${dossier.dossierId}:unresolved-claims`,
+        domain: 'evidence-coverage',
+        type: 'unresolved-claims',
+        severity: 'high',
+        observed: dossier.unresolvedClaimCount,
+        target: 'resolve only when additional evidence changes the explicit claim state',
+        affectedIds: dossier.unresolvedClaims.map(claim => claim.claimId),
+        detail: 'The dossier contains claims explicitly marked unreviewed, single-source, contradicted, or disputed.',
+        nextAction: 'Seek independent evidence or primary records; preserve unresolved states when the evidence does not justify a transition.',
+        requires: ['manual-review'],
+      });
+    }
+
+    if (dossier.unknownCount > 0) {
+      gaps.push({
+        id: `evidence:dossier:${dossier.dossierId}:known-unknowns`,
+        domain: 'evidence-coverage',
+        type: 'known-unknowns',
+        severity: 'medium',
+        observed: dossier.unknownCount,
+        target: 'reduce through attributable evidence while preserving genuinely unresolved unknowns',
+        affectedIds: [dossier.dossierId],
+        detail: 'The dossier explicitly preserves unresolved unknowns rather than filling them with inference.',
+        nextAction: 'Research the named unknowns and append evidence only when provenance and identity contracts are satisfied.',
+        requires: ['manual-review'],
+      });
+    }
+
+    const missingCorrectionArtifacts = dossier.corrections.filter(
+      correction => correction.originalArtifactRetained === false
+    );
+    if (missingCorrectionArtifacts.length > 0) {
+      gaps.push({
+        id: `evidence:dossier:${dossier.dossierId}:correction-artifact-retention`,
+        domain: 'evidence-coverage',
+        type: 'correction-artifact-retention',
+        severity: 'medium',
+        observed: missingCorrectionArtifacts.length,
+        target: 0,
+        affectedIds: missingCorrectionArtifacts.map(correction => correction.correctionId),
+        detail: 'A documented correction is present but the original mistaken artifact is not retained in the dossier snapshot.',
+        nextAction: 'Locate an authoritative or immutable copy of the corrected-away artifact if one is legitimately available.',
+        requires: ['manual-review'],
+      });
+    }
+  }
+
+  if (operationalHealth.status === 'available' && operationalHealth.degradedSources > 0) {
+    gaps.push({
+      id: 'operations:degraded-news-sources',
+      domain: 'operations',
+      type: 'degraded-source-health',
+      severity: 'high',
+      observed: operationalHealth.degradedSources,
+      target: 0,
+      affectedIds: operationalHealth.degradedSourceIds,
+      detail: 'The latest matching source-health snapshot contains one or more degraded live feeds.',
+      nextAction: 'Investigate endpoint health separately from provenance and usage-rights decisions.',
+      requires: ['code'],
+    });
+  }
+
+  return gaps.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function validateDossierSummary(dossier, issues) {
+  if (!plainObject(dossier) || !text(dossier.dossierId)) {
+    issues.semanticErrors.push('evidenceCoverage.dossier:invalid');
+    return;
+  }
+  if (dossier.integrityValid !== true) issues.semanticErrors.push(`dossier.${dossier.dossierId}:integrity-invalid`);
+  for (const [countField, arrayField] of [
+    ['unresolvedClaimCount', 'unresolvedClaims'],
+    ['terminalClaimCount', 'terminalClaims'],
+    ['correctionCount', 'corrections'],
+  ]) {
+    if (!Array.isArray(dossier[arrayField])) issues.structureErrors.push(`dossier.${dossier.dossierId}.${arrayField}:not-array`);
+    else if (dossier[countField] !== dossier[arrayField].length) issues.countErrors.push(`dossier.${dossier.dossierId}.${countField}`);
+  }
+  if (!Array.isArray(dossier.eventCoverage)) issues.structureErrors.push(`dossier.${dossier.dossierId}.eventCoverage:not-array`);
+  else {
+    issues.duplicateIds.push(
+      ...duplicates(dossier.eventCoverage.map(event => event?.eventId).filter(text)).map(
+        id => `${dossier.dossierId}:event:${id}`
+      )
+    );
+  }
+}
+
+function nextActionForNewsGap(type) {
+  const actions = {
+    'regional-redundancy': 'Research additional independently operated reporting inputs for the affected region, then run source admission before collection.',
+    'source-language-diversity': 'Research reliable source-language inputs and preserve translation provenance.',
+    'portfolio-language-concentration': 'Expand reviewed non-English source-language coverage without imposing a quota on conclusions.',
+    'evidence-role': 'Review primary institutional evidence endpoints separately from the news-feed contract.',
+    'geographic-scope': 'Research subnational and local reporting inputs where strategically relevant.',
+    'provenance-integrity': 'Repair provenance registry integrity before relying on coverage telemetry.',
+    'source-admission-integrity': 'Repair source-admission integrity before admitting or reclassifying sources.',
+    'source-admission-review': 'Complete the remaining legacy usage-rights reviews.',
+    'source-admission-remediation': 'Establish an authorized use path or restrictive fallback for affected sources.',
+  };
+  return actions[type] || 'Review the observed gap against the canonical source and evidence contracts.';
+}
+
+function requirementsForNewsGap(type) {
+  if (['source-admission-review', 'source-admission-remediation'].includes(type)) return ['manual-review', 'licensing'];
+  if (['provenance-integrity', 'source-admission-integrity'].includes(type)) return ['code', 'manual-review'];
+  return ['manual-review'];
+}
+
+function groupedCount(records, field) {
+  const counts = new Map();
+  for (const record of records) {
+    const value = text(record?.[field]) ? record[field] : 'unknown';
+    counts.set(value, (counts.get(value) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([value, count]) => ({ value, count }));
+}
+
+function finishValidation(issues) {
+  for (const field of Object.keys(issues)) issues[field] = unique(issues[field]);
+  return {
+    valid: Object.values(issues).every(values => values.length === 0),
+    ...issues,
+  };
+}
+
+function cloneArray(value) {
+  return Array.isArray(value) ? value.map(item => (plainObject(item) ? { ...item } : item)) : [];
+}
+
+function cloneObject(value) {
+  return plainObject(value) ? { ...value } : {};
+}
+
+function requireArray(value, name) {
+  if (!Array.isArray(value)) throw new TypeError(`${name} must be an array`);
+}
+
+function array(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function plainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function text(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function unique(values) {
+  return [...new Set(values)].sort();
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  const repeated = new Set();
+  for (const value of values) {
+    if (seen.has(value)) repeated.add(value);
+    seen.add(value);
+  }
+  return [...repeated].sort();
+}
+
+function byId(field) {
+  return (a, b) => String(a?.[field] || '').localeCompare(String(b?.[field] || ''));
+}

--- a/observatory/coverage/index.html
+++ b/observatory/coverage/index.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="GlobalDeets Coverage & Evidence Observatory — measurable news, provenance, source-rights, evidence, and unresolved intelligence gaps.">
+  <title>Coverage & Evidence Observatory | GlobalDeets</title>
+  <link rel="icon" href="/assets/favicon.png">
+  <link rel="stylesheet" href="/shared/ecosystem-nav.css">
+  <link rel="stylesheet" href="/observatory/coverage/observatory.css">
+</head>
+<body data-observatory-id="coverage-evidence" data-observatory-ready="false">
+  <div id="ecosystem-nav"></div>
+  <main class="observatory-shell">
+    <header class="hero">
+      <p class="eyebrow">GlobalDeets intelligence infrastructure</p>
+      <h1>Coverage &amp; Evidence Observatory</h1>
+      <p class="lede">A read-only view of what GlobalDeets can currently observe, what evidence it has, and what remains missing. Coverage signals are not truth, reliability, ideology, or publisher-quality scores.</p>
+      <div class="contract-strip" aria-label="Observatory contract">
+        <span>No truth score</span>
+        <span>No editorial verdict</span>
+        <span>News coverage ≠ evidence coverage</span>
+        <span>Collection eligibility stays explicit</span>
+      </div>
+    </header>
+
+    <section class="status-panel" aria-live="polite">
+      <div>
+        <p class="label">Integrity</p>
+        <p id="integrity-status" class="metric-value">Loading…</p>
+      </div>
+      <div>
+        <p class="label">Generated</p>
+        <p id="generated-at" class="metric-value metric-small">—</p>
+      </div>
+      <div>
+        <p class="label">Observatory version</p>
+        <p id="observatory-version" class="metric-value metric-small">—</p>
+      </div>
+    </section>
+
+    <section aria-labelledby="baseline-heading">
+      <div class="section-heading">
+        <p class="eyebrow">Measured baseline</p>
+        <h2 id="baseline-heading">Separate systems, separate counts</h2>
+      </div>
+      <div id="baseline-grid" class="metric-grid"></div>
+    </section>
+
+    <section class="two-column" aria-label="Coverage inventories">
+      <article class="panel">
+        <div class="panel-heading">
+          <p class="eyebrow">News coverage</p>
+          <h2>Geographic and provenance footprint</h2>
+        </div>
+        <div id="region-list" class="record-list"></div>
+      </article>
+      <article class="panel">
+        <div class="panel-heading">
+          <p class="eyebrow">Evidence coverage</p>
+          <h2>Evidence classes in published dossiers</h2>
+        </div>
+        <div id="evidence-class-list" class="record-list"></div>
+      </article>
+    </section>
+
+    <section class="two-column" aria-label="Governance inventories">
+      <article class="panel">
+        <div class="panel-heading">
+          <p class="eyebrow">Source governance</p>
+          <h2>Rights review debt</h2>
+        </div>
+        <div id="rights-summary" class="record-list"></div>
+      </article>
+      <article class="panel">
+        <div class="panel-heading">
+          <p class="eyebrow">Institutional evidence</p>
+          <h2>Reviewed ≠ collectible</h2>
+        </div>
+        <div id="institutional-summary" class="record-list"></div>
+      </article>
+    </section>
+
+    <section aria-labelledby="dossiers-heading">
+      <div class="section-heading">
+        <p class="eyebrow">Dossier observability</p>
+        <h2 id="dossiers-heading">Unresolved claims, corrections, and event evidence</h2>
+      </div>
+      <div id="dossier-list" class="dossier-grid"></div>
+    </section>
+
+    <section aria-labelledby="gaps-heading">
+      <div class="section-heading">
+        <p class="eyebrow">Operational research queue</p>
+        <h2 id="gaps-heading">Explicit gaps</h2>
+        <p>Each gap shows why it exists, the observed state, and the next permitted research or engineering action. No gap silently admits a new source.</p>
+      </div>
+      <div id="gap-list" class="gap-list"></div>
+    </section>
+
+    <section class="panel method-panel" aria-labelledby="method-heading">
+      <div class="panel-heading">
+        <p class="eyebrow">Method</p>
+        <h2 id="method-heading">What this observatory does not claim</h2>
+      </div>
+      <p>It does not rank publishers, infer political bias, calculate factual accuracy, blend news-source counts with evidence counts, or treat a reviewed directory as permission to collect. Unknowns remain unknown until attributable evidence changes the underlying contract.</p>
+    </section>
+
+    <div id="observatory-error" class="error-panel" hidden>
+      The observatory payload failed its integrity contract and has been withheld.
+    </div>
+  </main>
+  <script src="/shared/ecosystem-nav.js"></script>
+  <script src="/observatory/coverage/observatory.js"></script>
+</body>
+</html>

--- a/observatory/coverage/observatory.css
+++ b/observatory/coverage/observatory.css
@@ -1,0 +1,249 @@
+:root {
+  color-scheme: dark;
+  --bg: #07090c;
+  --panel: rgba(16, 21, 28, 0.88);
+  --panel-strong: rgba(22, 29, 38, 0.96);
+  --line: rgba(156, 196, 220, 0.2);
+  --text: #eef6f8;
+  --muted: #9db0ba;
+  --cyan: #82e9ff;
+  --amber: #ffc977;
+  --danger: #ff9b8f;
+  --ok: #95efc0;
+  --max: 1220px;
+}
+
+* { box-sizing: border-box; }
+html { background: var(--bg); }
+body {
+  margin: 0;
+  min-width: 0;
+  background:
+    radial-gradient(circle at 15% 5%, rgba(40, 134, 168, 0.15), transparent 32rem),
+    radial-gradient(circle at 88% 18%, rgba(117, 74, 153, 0.12), transparent 28rem),
+    var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.55;
+}
+
+a { color: var(--cyan); }
+
+.observatory-shell {
+  width: min(calc(100% - 32px), var(--max));
+  margin: 0 auto;
+  padding: 118px 0 72px;
+}
+
+.hero {
+  padding: clamp(28px, 5vw, 58px);
+  border: 1px solid var(--line);
+  border-radius: 28px;
+  background: linear-gradient(145deg, rgba(16, 25, 34, 0.96), rgba(8, 12, 17, 0.88));
+  box-shadow: 0 28px 90px rgba(0, 0, 0, 0.32);
+}
+
+.eyebrow,
+.label {
+  margin: 0 0 8px;
+  color: var(--cyan);
+  font-size: 0.74rem;
+  font-weight: 750;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p { overflow-wrap: anywhere; }
+
+h1 {
+  max-width: 850px;
+  margin: 0;
+  font-size: clamp(2.25rem, 7vw, 5.4rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(1.45rem, 3vw, 2.25rem);
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+}
+
+h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.lede {
+  max-width: 790px;
+  margin: 24px 0 0;
+  color: #c8d4d9;
+  font-size: clamp(1rem, 2vw, 1.16rem);
+}
+
+.contract-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-top: 28px;
+}
+
+.contract-strip span,
+.tag {
+  max-width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(130, 233, 255, 0.06);
+  color: #d5e6eb;
+  font-size: 0.78rem;
+}
+
+.status-panel,
+.metric-grid,
+.two-column,
+.dossier-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.status-panel {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 18px 0 52px;
+}
+
+.status-panel > div,
+.metric-card,
+.panel,
+.dossier-card,
+.gap-card {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--panel);
+}
+
+.status-panel > div { padding: 17px 18px; }
+.metric-value {
+  margin: 0;
+  font-size: 1.22rem;
+  font-weight: 720;
+}
+.metric-small { font-size: 0.9rem; color: #c7d5db; }
+.metric-value[data-state="valid"] { color: var(--ok); }
+.metric-value[data-state="invalid"] { color: var(--danger); }
+
+.section-heading {
+  max-width: 800px;
+  margin: 52px 0 18px;
+}
+.section-heading > p:last-child { color: var(--muted); }
+
+.metric-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.metric-card { padding: 20px; }
+.metric-number {
+  margin: 0 0 5px;
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  font-weight: 780;
+  letter-spacing: -0.04em;
+}
+.metric-label { margin: 0; color: var(--muted); font-size: 0.86rem; }
+
+.two-column {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.panel { padding: clamp(20px, 4vw, 30px); }
+.panel-heading { margin-bottom: 18px; }
+.method-panel { margin-top: 52px; }
+
+.record-list { display: grid; gap: 9px; }
+.record {
+  min-width: 0;
+  padding: 13px 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+.record-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.record-value { flex: 0 0 auto; color: var(--amber); font-weight: 740; }
+.record-detail { margin: 5px 0 0; color: var(--muted); font-size: 0.82rem; }
+
+.dossier-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.dossier-card { padding: 22px; }
+.dossier-meta,
+.gap-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 13px;
+}
+.dossier-card p { color: var(--muted); }
+.event-list { display: grid; gap: 7px; margin-top: 16px; }
+.event-row {
+  padding: 11px 12px;
+  border-left: 2px solid var(--line);
+  background: rgba(255, 255, 255, 0.02);
+  color: #cedbe0;
+  font-size: 0.84rem;
+}
+
+.gap-list { display: grid; gap: 11px; }
+.gap-card { padding: 21px; }
+.gap-card[data-severity="critical"],
+.gap-card[data-severity="high"] { border-color: rgba(255, 155, 143, 0.38); }
+.gap-card[data-severity="medium"] { border-color: rgba(255, 201, 119, 0.28); }
+.gap-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+.gap-card p { color: #c0cdd2; }
+.gap-card strong { color: var(--text); }
+.gap-action {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.error-panel {
+  margin-top: 24px;
+  padding: 20px;
+  border: 1px solid rgba(255, 155, 143, 0.5);
+  border-radius: 14px;
+  background: rgba(95, 33, 31, 0.25);
+  color: #ffd4cf;
+}
+
+@media (max-width: 880px) {
+  .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .two-column,
+  .dossier-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+  .observatory-shell {
+    width: min(calc(100% - 20px), var(--max));
+    padding-top: 94px;
+  }
+  .hero { padding: 24px 19px; border-radius: 20px; }
+  .status-panel { grid-template-columns: 1fr; }
+  .metric-grid { grid-template-columns: 1fr 1fr; }
+  .gap-header,
+  .record-row { align-items: flex-start; }
+  .gap-header { flex-direction: column; gap: 8px; }
+}
+
+@media (max-width: 390px) {
+  .metric-grid { grid-template-columns: 1fr; }
+}

--- a/observatory/coverage/observatory.js
+++ b/observatory/coverage/observatory.js
@@ -1,0 +1,251 @@
+(() => {
+  'use strict';
+
+  const endpoint = '/api/intelligence/observatory/coverage';
+  const body = document.body;
+  const errorPanel = document.getElementById('observatory-error');
+
+  load().catch(() => failClosed());
+
+  async function load() {
+    const response = await fetch(endpoint, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    });
+    if (!response.ok) throw new Error(`Observatory API returned ${response.status}`);
+    const data = await response.json();
+    assertSafePayload(data);
+    render(data);
+    body.dataset.observatoryReady = 'true';
+  }
+
+  function assertSafePayload(data) {
+    if (!data || typeof data !== 'object') throw new Error('Observatory payload missing');
+    if (data.observatoryId !== 'coverage-evidence') throw new Error('Observatory identity mismatch');
+    if (data.integrity?.valid !== true) throw new Error('Observatory integrity invalid');
+    if (
+      data.rules?.truthScore !== false ||
+      data.rules?.editorialVerdict !== false ||
+      data.rules?.compositeCoverageScore !== false ||
+      data.rules?.publisherQualityScore !== false ||
+      data.rules?.newsCoverageIsEvidenceCoverage !== false ||
+      data.rules?.collectionEligibilityRequiresEndpointReview !== true
+    ) {
+      throw new Error('Observatory semantic contract changed');
+    }
+    for (const field of ['newsCoverage', 'sourceRights', 'institutionalEvidence', 'evidenceCoverage']) {
+      if (!data[field] || typeof data[field] !== 'object') throw new Error(`${field} missing`);
+    }
+    if (!Array.isArray(data.gaps)) throw new Error('Gap inventory missing');
+  }
+
+  function render(data) {
+    setText('integrity-status', 'Integrity validated');
+    const status = document.getElementById('integrity-status');
+    if (status) status.dataset.state = 'valid';
+    setText('generated-at', formatDateTime(data.generatedAt));
+    setText('observatory-version', data.observatoryVersion);
+
+    const dossiers = array(data.evidenceCoverage.dossiers);
+    const unresolvedClaims = dossiers.reduce((sum, dossier) => sum + number(dossier.unresolvedClaimCount), 0);
+    const corrections = dossiers.reduce((sum, dossier) => sum + number(dossier.correctionCount), 0);
+    const evidenceRecords = dossiers.reduce((sum, dossier) => sum + number(dossier.evidenceCount), 0);
+
+    renderInto('baseline-grid', [
+      metric(data.newsCoverage.totalSources, 'Live news sources'),
+      metric(data.newsCoverage.gapCount, 'News coverage gaps'),
+      metric(data.sourceRights.legacyUnreviewedSources, 'Legacy rights reviews open'),
+      metric(data.institutionalEvidence.reviewedSources, 'Institutional candidates reviewed'),
+      metric(data.institutionalEvidence.collectionEligibleSources, 'Institutional sources collection-eligible'),
+      metric(data.evidenceCoverage.dossierCount, 'Published evidence dossiers'),
+      metric(evidenceRecords, 'Evidence records in dossiers'),
+      metric(unresolvedClaims, 'Explicit unresolved claims'),
+      metric(corrections, 'Correction records'),
+    ]);
+
+    renderInto(
+      'region-list',
+      array(data.newsCoverage.regions).map(region =>
+        record(
+          titleCase(region.region || 'unknown'),
+          region.sourceCount,
+          `${region.languageCount} source language${region.languageCount === 1 ? '' : 's'} · ${region.sourceOriginCountryCount} origin countr${region.sourceOriginCountryCount === 1 ? 'y' : 'ies'} · ${region.publisherCount} publisher${region.publisherCount === 1 ? '' : 's'}`
+        )
+      )
+    );
+
+    renderInto(
+      'evidence-class-list',
+      array(data.evidenceCoverage.evidenceClasses).map(item =>
+        record(titleCase(item.documentType), item.count, 'Canonical evidence document type')
+      )
+    );
+
+    const rights = data.sourceRights;
+    renderInto('rights-summary', [
+      record('Reviewed live sources', rights.reviewedLiveSources, joinIds(rights.reviewedLiveSourceIds)),
+      record('Legacy unreviewed', rights.legacyUnreviewedSources, joinIds(rights.legacyUnreviewedSourceIds)),
+      record('Remediation required', array(rights.remediationSourceIds).length, joinIds(rights.remediationSourceIds)),
+      record('Unknown rights status', array(rights.unknownRightsSourceIds).length, joinIds(rights.unknownRightsSourceIds)),
+      record('Research candidates', array(rights.researchCandidates).length, array(rights.researchCandidates).map(item => item.name).join(' · ')),
+    ]);
+
+    const institutional = data.institutionalEvidence;
+    renderInto('institutional-summary', [
+      record('Classification reviewed', institutional.reviewedSources, 'Evidence role and institutional identity reviewed'),
+      record('Issuing-primary candidates', institutional.issuingPrimarySources, 'Role classification only; not collection authority'),
+      record('Directory-only', institutional.directoryOnlySources, 'No machine-readable collection authority implied'),
+      record('Endpoint-reviewed', institutional.endpointReviewedSources, 'Separately reviewed machine-readable endpoints'),
+      record('Collection eligible', institutional.collectionEligibleSources, 'Requires endpoint authority, access, and rights review'),
+    ]);
+
+    renderInto('dossier-list', dossiers.map(dossierCard));
+    renderInto('gap-list', array(data.gaps).map(gapCard));
+  }
+
+  function dossierCard(dossier) {
+    const eventsWithoutPrimary = array(dossier.eventCoverage).filter(event => !event.hasPrimaryEvidence).length;
+    const eventsWithoutReporting = array(dossier.eventCoverage).filter(event => event.reportingSourceCount === 0).length;
+    return element('article', 'dossier-card', [
+      element('p', 'eyebrow', [`${dossier.status || 'unknown'} · ${dossier.dossierVersion || 'version unavailable'}`]),
+      element('h3', '', [dossier.title || dossier.dossierId]),
+      element('div', 'dossier-meta', [
+        tag(`${dossier.eventCount} events`),
+        tag(`${dossier.claimCount} claims`),
+        tag(`${dossier.evidenceCount} evidence records`),
+        tag(`${dossier.unresolvedClaimCount} unresolved claims`),
+        tag(`${dossier.correctionCount} corrections`),
+      ]),
+      element('p', '', [
+        `${eventsWithoutPrimary} event${eventsWithoutPrimary === 1 ? '' : 's'} without linked primary evidence; ${eventsWithoutReporting} without a claim-origin source classified as reporting.`,
+      ]),
+      element(
+        'div',
+        'event-list',
+        array(dossier.eventCoverage).map(event =>
+          element('div', 'event-row', [
+            `${event.title || event.eventId} — ${event.primaryEvidenceCount} primary evidence · ${event.reportingSourceCount} reporting source${event.reportingSourceCount === 1 ? '' : 's'}`,
+          ])
+        )
+      ),
+    ]);
+  }
+
+  function gapCard(gap) {
+    const article = element('article', 'gap-card', [
+      element('div', 'gap-header', [
+        element('div', '', [
+          element('p', 'eyebrow', [gap.domain || 'gap']),
+          element('h3', '', [titleCase(gap.type || gap.id)]),
+        ]),
+        tag(titleCase(gap.severity || 'unknown')),
+      ]),
+      element('p', '', [gap.detail || 'No detail supplied.']),
+      element('div', 'gap-meta', [
+        tag(`Observed: ${displayValue(gap.observed)}`),
+        tag(`Target: ${displayValue(gap.target)}`),
+        ...array(gap.requires).map(requirement => tag(titleCase(requirement))),
+      ]),
+      element('p', 'gap-action', [element('strong', '', ['Next action: ']), gap.nextAction || 'Review manually.']),
+    ]);
+    article.dataset.severity = gap.severity || 'info';
+    return article;
+  }
+
+  function metric(value, label) {
+    return element('article', 'metric-card', [
+      element('p', 'metric-number', [displayValue(value)]),
+      element('p', 'metric-label', [label]),
+    ]);
+  }
+
+  function record(label, value, detail) {
+    return element('div', 'record', [
+      element('div', 'record-row', [
+        element('span', '', [label]),
+        element('span', 'record-value', [displayValue(value)]),
+      ]),
+      detail ? element('p', 'record-detail', [detail]) : null,
+    ]);
+  }
+
+  function tag(text) {
+    return element('span', 'tag', [text]);
+  }
+
+  function element(tagName, className, children = []) {
+    const node = document.createElement(tagName);
+    if (className) node.className = className;
+    for (const child of children) {
+      if (child == null) continue;
+      node.append(child instanceof Node ? child : document.createTextNode(String(child)));
+    }
+    return node;
+  }
+
+  function renderInto(id, nodes) {
+    const target = document.getElementById(id);
+    if (!target) return;
+    target.replaceChildren(...nodes.filter(Boolean));
+  }
+
+  function setText(id, value) {
+    const target = document.getElementById(id);
+    if (target) target.textContent = value == null ? '—' : String(value);
+  }
+
+  function failClosed() {
+    body.dataset.observatoryReady = 'false';
+    const status = document.getElementById('integrity-status');
+    if (status) {
+      status.textContent = 'Payload withheld';
+      status.dataset.state = 'invalid';
+    }
+    for (const id of [
+      'baseline-grid',
+      'region-list',
+      'evidence-class-list',
+      'rights-summary',
+      'institutional-summary',
+      'dossier-list',
+      'gap-list',
+    ]) {
+      const target = document.getElementById(id);
+      if (target) target.replaceChildren();
+    }
+    if (errorPanel) errorPanel.hidden = false;
+  }
+
+  function displayValue(value) {
+    if (value == null) return 'Unavailable';
+    if (typeof value === 'number') return new Intl.NumberFormat('en-US').format(value);
+    if (Array.isArray(value)) return value.join(', ');
+    return String(value);
+  }
+
+  function formatDateTime(value) {
+    if (!value) return 'Unavailable';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return String(value);
+    return date.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+  }
+
+  function joinIds(values) {
+    const items = array(values);
+    return items.length ? items.join(' · ') : 'None';
+  }
+
+  function titleCase(value) {
+    return String(value || '')
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, letter => letter.toUpperCase());
+  }
+
+  function array(value) {
+    return Array.isArray(value) ? value : [];
+  }
+
+  function number(value) {
+    return Number.isFinite(value) ? value : 0;
+  }
+})();

--- a/observatory/coverage/observatory.js
+++ b/observatory/coverage/observatory.js
@@ -69,7 +69,7 @@
         record(
           titleCase(region.region || 'unknown'),
           region.sourceCount,
-          `${region.languageCount} source language${region.languageCount === 1 ? '' : 's'} · ${region.sourceOriginCountryCount} origin countr${region.sourceOriginCountryCount === 1 ? 'y' : 'ies'} · ${region.publisherCount} publisher${region.publisherCount === 1 ? '' : 's'}`
+          `${region.languageCount} source language${region.languageCount === 1 ? '' : 's'} · ${array(region.languages).join(', ') || 'language identities unavailable'}`
         )
       )
     );

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/santa-ynez-dossier.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,6 +3,7 @@
   <url><loc>https://globaldeets.com/</loc></url>
   <url><loc>https://globaldeets.com/news</loc></url>
   <url><loc>https://globaldeets.com/dossiers/santa-ynez-pipeline/</loc></url>
+  <url><loc>https://globaldeets.com/observatory/coverage/</loc></url>
   <url><loc>https://globaldeets.com/globe</loc></url>
   <url><loc>https://globaldeets.com/worldmap</loc></url>
   <url><loc>https://globaldeets.com/knowledge</loc></url>

--- a/tests/coverage-evidence-observatory.test.mjs
+++ b/tests/coverage-evidence-observatory.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  COVERAGE_EVIDENCE_OBSERVATORY_ID,
+  COVERAGE_EVIDENCE_OBSERVATORY_VERSION,
+  buildCoverageEvidenceObservatory,
+  readCachedSourceHealth,
+  validateCoverageEvidenceObservatory,
+} from '../functions/lib/coverage-evidence-observatory.js';
+import { SOURCES, SOURCE_FINGERPRINT } from '../functions/api/news.js';
+import { onRequestGet, onRequestOptions } from '../functions/api/intelligence/observatory/coverage.js';
+
+function canonical() {
+  return buildCoverageEvidenceObservatory();
+}
+
+function mutable(value) {
+  return structuredClone(value);
+}
+
+test('canonical coverage and evidence observatory validates and preserves semantic separation', () => {
+  const observatory = canonical();
+  const validation = validateCoverageEvidenceObservatory(observatory);
+
+  assert.equal(observatory.observatoryId, COVERAGE_EVIDENCE_OBSERVATORY_ID);
+  assert.equal(observatory.observatoryVersion, COVERAGE_EVIDENCE_OBSERVATORY_VERSION);
+  assert.equal(observatory.newsCoverage.totalSources, 19);
+  assert.equal(observatory.sourceRights.totalLiveSources, 19);
+  assert.equal(observatory.sourceRights.reviewedLiveSources, 2);
+  assert.equal(observatory.sourceRights.legacyUnreviewedSources, 17);
+  assert.equal(observatory.institutionalEvidence.reviewedSources, 10);
+  assert.equal(observatory.institutionalEvidence.collectionEligibleSources, 0);
+  assert.equal(observatory.evidenceCoverage.dossierCount, 1);
+  assert.deepEqual(observatory.evidenceCoverage.dossierIds, ['santa-ynez-pipeline']);
+  assert.equal(observatory.rules.truthScore, false);
+  assert.equal(observatory.rules.editorialVerdict, false);
+  assert.equal(observatory.rules.compositeCoverageScore, false);
+  assert.equal(observatory.rules.publisherQualityScore, false);
+  assert.equal(observatory.rules.newsCoverageIsEvidenceCoverage, false);
+  assert.equal(observatory.rules.collectionEligibilityRequiresEndpointReview, true);
+  assert.equal(validation.valid, true, JSON.stringify(validation));
+});
+
+test('dossier observability derives unresolved claims, evidence classes, corrections, and explicit gaps', () => {
+  const observatory = canonical();
+  const dossier = observatory.evidenceCoverage.dossiers[0];
+  const documentTypes = new Set(observatory.evidenceCoverage.evidenceClasses.map(item => item.documentType));
+  const gapTypes = new Set(observatory.gaps.map(gap => gap.type));
+
+  assert.equal(dossier.integrityValid, true);
+  assert.ok(dossier.unresolvedClaimCount > 0);
+  assert.ok(dossier.unresolvedClaims.some(claim => claim.state === 'single-source'));
+  assert.ok(dossier.unresolvedClaims.some(claim => claim.state === 'disputed'));
+  assert.equal(dossier.correctionCount, 1);
+  assert.ok(dossier.unknownCount > 0);
+  assert.ok(documentTypes.has('judgment'));
+  assert.ok(documentTypes.has('regulator-release'));
+  assert.ok(documentTypes.has('corporate-filing'));
+  assert.ok(documentTypes.has('government-release'));
+  assert.ok(gapTypes.has('source-rights-review-debt'));
+  assert.ok(gapTypes.has('institutional-collection-eligibility'));
+  assert.ok(gapTypes.has('unresolved-claims'));
+  assert.ok(gapTypes.has('correction-artifact-retention'));
+});
+
+test('observatory validator fails closed on scoring, count drift, unsafe collection, and duplicate gaps', () => {
+  const score = mutable(canonical());
+  score.rules.truthScore = true;
+  assert.equal(validateCoverageEvidenceObservatory(score).valid, false);
+
+  const countDrift = mutable(canonical());
+  countDrift.newsCoverage.totalSources = SOURCES.length + 1;
+  assert.ok(validateCoverageEvidenceObservatory(countDrift).countErrors.includes('newsCoverage.totalSources'));
+
+  const unsafeCollection = mutable(canonical());
+  unsafeCollection.institutionalEvidence.sources[0].collectionEligible = true;
+  unsafeCollection.institutionalEvidence.sources[0].collectionState = 'directory-only';
+  unsafeCollection.institutionalEvidence.sources[0].verifiedEndpointCount = 0;
+  const unsafeValidation = validateCoverageEvidenceObservatory(unsafeCollection);
+  assert.equal(unsafeValidation.valid, false);
+  assert.ok(unsafeValidation.semanticErrors.some(item => item.includes('unsafe-collection')));
+
+  const duplicateGap = mutable(canonical());
+  duplicateGap.gaps.push({ ...duplicateGap.gaps[0] });
+  const duplicateValidation = validateCoverageEvidenceObservatory(duplicateGap);
+  assert.equal(duplicateValidation.valid, false);
+  assert.ok(duplicateValidation.duplicateIds.includes(duplicateGap.gaps[0].id));
+});
+
+test('cached health is observational only and rejects stale source identities', async () => {
+  assert.equal(await readCachedSourceHealth({}), null);
+
+  const stale = await readCachedSourceHealth({
+    NEWS_CACHE: {
+      async get() {
+        return { sourceFingerprint: 'stale', sourceHealth: [] };
+      },
+    },
+  });
+  assert.equal(stale, null);
+
+  const sourceHealth = SOURCES.map((source, index) => ({
+    sourceId: `source-${index}`,
+    name: source.name,
+    lastError: index === 0 ? 'fixture failure' : null,
+  }));
+  const snapshot = {
+    generatedAt: '2026-09-08T20:00:00.000Z',
+    sourceFingerprint: SOURCE_FINGERPRINT,
+    sourceHealth,
+  };
+  const accepted = await readCachedSourceHealth({
+    NEWS_CACHE: {
+      async get() {
+        return snapshot;
+      },
+    },
+  });
+  assert.equal(accepted, snapshot);
+
+  const observatory = buildCoverageEvidenceObservatory({ healthSnapshot: accepted });
+  assert.equal(observatory.operationalHealth.status, 'available');
+  assert.equal(observatory.operationalHealth.degradedSources, 1);
+  assert.ok(observatory.gaps.some(gap => gap.type === 'degraded-source-health'));
+});
+
+test('observatory API returns only integrity-valid payloads and supports CORS preflight', async () => {
+  const request = new Request('https://globaldeets.com/api/intelligence/observatory/coverage', {
+    headers: { Origin: 'https://globaldeets.com' },
+  });
+  const response = await onRequestGet({ env: {}, request });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.integrity.valid, true);
+  assert.equal(payload.observatoryId, COVERAGE_EVIDENCE_OBSERVATORY_ID);
+  assert.equal(payload.rules.truthScore, false);
+  assert.equal(payload.rules.newsCoverageIsEvidenceCoverage, false);
+
+  const preflight = await onRequestOptions({ request });
+  assert.equal(preflight.status, 204);
+  assert.equal(preflight.headers.get('access-control-allow-origin'), 'https://globaldeets.com');
+});

--- a/tests/observatory-smoke.spec.js
+++ b/tests/observatory-smoke.spec.js
@@ -1,0 +1,191 @@
+const { expect, test } = require('@playwright/test');
+
+const fixture = {
+  generatedAt: '2026-09-08T21:30:00.000Z',
+  observatoryId: 'coverage-evidence',
+  observatoryVersion: '2026-09-08.1',
+  sourceFingerprint: 'fixture-source-fingerprint',
+  admissionFingerprint: 'fixture-admission-fingerprint',
+  rules: {
+    truthScore: false,
+    editorialVerdict: false,
+    compositeCoverageScore: false,
+    publisherQualityScore: false,
+    newsCoverageIsEvidenceCoverage: false,
+    collectionEligibilityRequiresEndpointReview: true,
+    reviewedDirectoryIsCollectionAuthority: false,
+    automaticRemediation: false,
+  },
+  newsCoverage: {
+    totalSources: 19,
+    totalRegions: 7,
+    totalLanguages: 2,
+    englishSourceShare: 18 / 19,
+    primarySourceInputs: 0,
+    gapCount: 11,
+    regions: [
+      {
+        region: 'pacific',
+        sourceCount: 1,
+        languageCount: 1,
+        sourceOriginCountryCount: 1,
+        publisherCount: 1,
+      },
+      {
+        region: 'global',
+        sourceCount: 4,
+        languageCount: 2,
+        sourceOriginCountryCount: 4,
+        publisherCount: 4,
+      },
+    ],
+    sourceOriginCountries: [],
+    sourceClasses: [],
+    evidenceRoles: [],
+    geographicScopes: [],
+    provenance: { valid: true },
+    admission: { valid: true },
+  },
+  sourceRights: {
+    totalLiveSources: 19,
+    reviewedLiveSources: 2,
+    reviewedLiveSourceIds: ['ap', 'guardian'],
+    legacyUnreviewedSources: 17,
+    legacyUnreviewedSourceIds: ['bbc-world', 'cna', 'dawn'],
+    remediationSourceIds: ['ap', 'guardian'],
+    unknownRightsSourceIds: ['bbc-world', 'cna', 'dawn'],
+    researchCandidates: [
+      {
+        candidateId: 'rnz-pacific',
+        name: 'RNZ Pacific',
+        disposition: 'research',
+        collectionEligible: false,
+      },
+    ],
+  },
+  institutionalEvidence: {
+    reviewedSources: 10,
+    issuingPrimarySources: 8,
+    collectionEligibleSources: 0,
+    directoryOnlySources: 10,
+    endpointReviewedSources: 0,
+    knowledgeCatalogIsIngestionAuthority: false,
+    endpointReviewRequired: true,
+    sources: [],
+  },
+  evidenceCoverage: {
+    dossierCount: 1,
+    dossierIds: ['santa-ynez-pipeline'],
+    evidenceClasses: [
+      { documentType: 'government-release', count: 4 },
+      { documentType: 'judgment', count: 2 },
+      { documentType: 'corporate-filing', count: 1 },
+      { documentType: 'regulator-release', count: 1 },
+    ],
+    provenance: { sourceClasses: [], evidenceRoles: [], uniqueSourceCount: 10, scoringApplied: false },
+    dossiers: [
+      {
+        dossierId: 'santa-ynez-pipeline',
+        dossierVersion: '2026-09-03.1',
+        title: 'Santa Ynez Pipeline — Evidence Dossier',
+        status: 'developing',
+        integrityValid: true,
+        eventCount: 7,
+        claimCount: 11,
+        evidenceCount: 8,
+        unresolvedClaimCount: 5,
+        correctionCount: 1,
+        eventCoverage: [
+          {
+            eventId: 'event:order',
+            title: 'Federal court issues mixed order',
+            primaryEvidenceCount: 1,
+            hasPrimaryEvidence: true,
+            reportingSourceCount: 1,
+          },
+          {
+            eventId: 'event:correction',
+            title: 'Justice Department corrects release',
+            primaryEvidenceCount: 0,
+            hasPrimaryEvidence: false,
+            reportingSourceCount: 0,
+          },
+        ],
+      },
+    ],
+  },
+  operationalHealth: {
+    status: 'unavailable',
+    generatedAt: null,
+    totalSources: 19,
+    healthySources: null,
+    degradedSources: null,
+    degradedSourceIds: [],
+  },
+  gaps: [
+    {
+      id: 'governance:source-rights-review-debt',
+      domain: 'source-governance',
+      type: 'source-rights-review-debt',
+      severity: 'high',
+      observed: 17,
+      target: 0,
+      affectedIds: ['bbc-world'],
+      detail: 'Live legacy sources remain explicitly unreviewed for usage rights.',
+      nextAction: 'Complete evidence-backed source-by-source rights review.',
+      requires: ['manual-review'],
+    },
+    {
+      id: 'evidence:institutional-collection-eligibility',
+      domain: 'evidence-coverage',
+      type: 'institutional-collection-eligibility',
+      severity: 'high',
+      observed: 0,
+      target: 'endpoint review',
+      affectedIds: [],
+      detail: 'Reviewed institutional directories are not collection authority.',
+      nextAction: 'Perform endpoint-specific collection and rights review.',
+      requires: ['manual-review', 'code'],
+    },
+  ],
+  integrity: { valid: true },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/intelligence/observatory/coverage', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(fixture),
+    });
+  });
+});
+
+test('coverage observatory renders an integrity-valid decomposed intelligence surface', async ({ page }) => {
+  await page.goto('/observatory/coverage/');
+
+  await expect(page.getByRole('heading', { name: 'Coverage & Evidence Observatory' })).toBeVisible();
+  await expect(page.locator('body[data-observatory-ready="true"]')).toBeVisible();
+  await expect(page.getByText('Integrity validated')).toBeVisible();
+  await expect(page.getByText('Legacy rights reviews open')).toBeVisible();
+  await expect(page.getByText('Institutional sources collection-eligible')).toBeVisible();
+  await expect(page.getByText('News coverage ≠ evidence coverage')).toBeVisible();
+  await expect(page.locator('#dossier-list .dossier-card')).toHaveCount(1);
+  await expect(page.locator('#gap-list .gap-card')).toHaveCount(2);
+  await expect(page.locator('#observatory-error')).toBeHidden();
+});
+
+test.describe('coverage observatory mobile surface', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('remains readable without horizontal overflow', async ({ page }) => {
+    await page.goto('/observatory/coverage/');
+    await expect(page.locator('body[data-observatory-ready="true"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Explicit gaps' })).toBeVisible();
+    const dimensions = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth + 1);
+  });
+});

--- a/tools/stage-deploy.js
+++ b/tools/stage-deploy.js
@@ -29,9 +29,14 @@ const REQUIRED_DEPLOY_FILES = [
   'dossiers/santa-ynez-pipeline/index.html',
   'dossiers/santa-ynez-pipeline/dossier.js',
   'dossiers/dossier.css',
+  'observatory/coverage/index.html',
+  'observatory/coverage/observatory.js',
+  'observatory/coverage/observatory.css',
+  'functions/api/intelligence/observatory/coverage.js',
+  'functions/lib/coverage-evidence-observatory.js',
 ];
 
-const PUBLIC_DIRECTORIES = ['assets', 'data', 'dossiers', 'functions', 'shared'];
+const PUBLIC_DIRECTORIES = ['assets', 'data', 'dossiers', 'functions', 'observatory', 'shared'];
 
 const EXCLUDED_ROOT_JS = new Set([
   'build-assets.js',
@@ -113,7 +118,7 @@ function relativeParts(fullPath) {
 function assertCleanArtifact() {
   const missing = REQUIRED_DEPLOY_FILES.filter(name => !existsSync(join(OUT_DIR, name)));
   if (missing.length > 0) {
-    console.error('Refusing to deploy artifact missing required Pages controls or dossier assets:');
+    console.error('Refusing to deploy artifact missing required Pages controls or intelligence assets:');
     for (const file of missing) console.error(`- ${file}`);
     process.exit(1);
   }

--- a/tools/verify-observatory-prod.js
+++ b/tools/verify-observatory-prod.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+function argValue(name) {
+  const arg = process.argv.find(value => value.startsWith(name));
+  return arg ? arg.slice(name.length) : null;
+}
+
+const BASE = (argValue('--base=') || 'https://globaldeets.com').replace(/\/$/, '');
+const TIMEOUT_MS = 12_000;
+
+async function request(path) {
+  return fetch(`${BASE}${path}`, {
+    headers: {
+      'User-Agent': 'GlobalDeets-ObservatoryVerifier/1.0',
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+    },
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+}
+
+async function json(path) {
+  const response = await request(path);
+  if (response.status !== 200) throw new Error(`${path} returned HTTP ${response.status}`);
+  if (!(response.headers.get('content-type') || '').includes('application/json')) {
+    throw new Error(`${path} returned non-JSON content`);
+  }
+  return response.json();
+}
+
+async function html(path) {
+  const response = await request(path);
+  if (response.status !== 200) throw new Error(`${path} returned HTTP ${response.status}`);
+  if (!(response.headers.get('content-type') || '').includes('text/html')) {
+    throw new Error(`${path} returned non-HTML content`);
+  }
+  return response.text();
+}
+
+function requireCondition(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+(async () => {
+  const [observatory, coverage, sources, admission, evidenceSchema, dossier, page] = await Promise.all([
+    json('/api/intelligence/observatory/coverage'),
+    json('/api/news/coverage'),
+    json('/api/news/sources'),
+    json('/api/news/admission'),
+    json('/api/intelligence/evidence-schema'),
+    json('/api/intelligence/dossiers/santa-ynez-pipeline'),
+    html('/observatory/coverage/'),
+  ]);
+
+  requireCondition(observatory.observatoryId === 'coverage-evidence', 'observatory identity changed');
+  requireCondition(typeof observatory.observatoryVersion === 'string', 'observatory version missing');
+  requireCondition(observatory.integrity?.valid === true, 'observatory integrity failed');
+  requireCondition(observatory.rules?.truthScore === false, 'observatory truth score must remain disabled');
+  requireCondition(observatory.rules?.editorialVerdict === false, 'observatory editorial verdict must remain disabled');
+  requireCondition(observatory.rules?.compositeCoverageScore === false, 'composite coverage score must remain disabled');
+  requireCondition(observatory.rules?.publisherQualityScore === false, 'publisher quality score must remain disabled');
+  requireCondition(observatory.rules?.newsCoverageIsEvidenceCoverage === false, 'news/evidence separation changed');
+  requireCondition(observatory.rules?.collectionEligibilityRequiresEndpointReview === true, 'endpoint review gate changed');
+  requireCondition(observatory.rules?.reviewedDirectoryIsCollectionAuthority === false, 'reviewed directory became collection authority');
+  requireCondition(observatory.rules?.automaticRemediation === false, 'observatory must remain read-only');
+
+  requireCondition(
+    observatory.sourceFingerprint === coverage.sourceFingerprint &&
+      observatory.sourceFingerprint === sources.sourceFingerprint &&
+      observatory.sourceFingerprint === admission.sourceFingerprint,
+    'observatory source fingerprint disagrees with canonical news APIs'
+  );
+  requireCondition(
+    observatory.admissionFingerprint === admission.admissionFingerprint,
+    'observatory admission fingerprint disagrees with admission API'
+  );
+  requireCondition(
+    observatory.newsCoverage?.totalSources === sources.totalSources &&
+      observatory.sourceRights?.totalLiveSources === admission.liveAdmissions.length,
+    'observatory live source counts disagree with canonical APIs'
+  );
+  requireCondition(observatory.newsCoverage?.provenance?.valid === true, 'observatory provenance invalid');
+  requireCondition(observatory.newsCoverage?.admission?.valid === true, 'observatory admission invalid');
+
+  const reviewedLive = admission.liveAdmissions.filter(entry => entry.reviewState === 'reviewed').length;
+  const legacyUnreviewed = admission.liveAdmissions.filter(entry => entry.reviewState === 'legacy-unreviewed').length;
+  requireCondition(observatory.sourceRights?.reviewedLiveSources === reviewedLive, 'reviewed live source count drifted');
+  requireCondition(observatory.sourceRights?.legacyUnreviewedSources === legacyUnreviewed, 'legacy review debt count drifted');
+  requireCondition(legacyUnreviewed === 17, 'GD-017 baseline must preserve the 17-source rights-review debt');
+
+  requireCondition(
+    observatory.institutionalEvidence?.reviewedSources === evidenceSchema.institutionalSources?.reviewedSources,
+    'institutional reviewed source count disagrees with evidence schema'
+  );
+  requireCondition(
+    observatory.institutionalEvidence?.collectionEligibleSources === evidenceSchema.institutionalSources?.collectionEligibleSources,
+    'institutional collection eligibility disagrees with evidence schema'
+  );
+  requireCondition(observatory.institutionalEvidence?.reviewedSources === 10, 'reviewed institutional candidate baseline changed');
+  requireCondition(observatory.institutionalEvidence?.collectionEligibleSources === 0, 'institutional collection silently enabled');
+
+  requireCondition(observatory.evidenceCoverage?.dossierCount === 1, 'GD-017 dossier baseline changed');
+  const dossierSummary = observatory.evidenceCoverage?.dossiers?.find(item => item.dossierId === 'santa-ynez-pipeline');
+  requireCondition(Boolean(dossierSummary), 'Santa Ynez dossier missing from observatory');
+  requireCondition(dossierSummary.integrityValid === true, 'observatory exposes invalid dossier');
+  requireCondition(dossierSummary.eventCount === dossier.events.length, 'observatory event count disagrees with dossier API');
+  requireCondition(dossierSummary.claimCount === dossier.claims.length, 'observatory claim count disagrees with dossier API');
+  requireCondition(dossierSummary.evidenceCount === dossier.evidence.length, 'observatory evidence count disagrees with dossier API');
+  requireCondition(dossierSummary.unresolvedClaimCount > 0, 'unresolved claim debt missing');
+  requireCondition(dossierSummary.correctionCount === dossier.corrections.length, 'correction count disagrees with dossier API');
+  requireCondition(dossierSummary.unknownCount === dossier.unknowns.length, 'unknown count disagrees with dossier API');
+
+  const gapTypes = new Set(observatory.gaps.map(gap => gap.type));
+  requireCondition(gapTypes.has('source-rights-review-debt'), 'source-rights debt gap missing');
+  requireCondition(gapTypes.has('institutional-collection-eligibility'), 'institutional evidence eligibility gap missing');
+  requireCondition(gapTypes.has('unresolved-claims'), 'unresolved dossier claim gap missing');
+  requireCondition(gapTypes.has('correction-artifact-retention'), 'correction artifact gap missing');
+  requireCondition(
+    observatory.gaps.every(gap => typeof gap.nextAction === 'string' && Array.isArray(gap.requires)),
+    'one or more observatory gaps lack operational actions'
+  );
+
+  requireCondition(page.includes('data-observatory-id="coverage-evidence"'), 'observatory page identity marker missing');
+  requireCondition(page.includes('Coverage &amp; Evidence Observatory'), 'observatory page shell missing');
+  requireCondition(page.includes('News coverage ≠ evidence coverage'), 'observatory semantic separation label missing');
+
+  console.log(
+    `Coverage & Evidence Observatory certified: ${observatory.newsCoverage.totalSources} live news sources, ${legacyUnreviewed} rights reviews open, ${observatory.institutionalEvidence.reviewedSources} institutional candidates / ${observatory.institutionalEvidence.collectionEligibleSources} collection-eligible, ${dossierSummary.unresolvedClaimCount} unresolved claims, ${observatory.gaps.length} explicit gaps`
+  );
+})().catch(error => {
+  console.error(`Coverage & Evidence Observatory verification failed: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #19.

## What this ships

- deterministic Coverage & Evidence Observatory contract derived from existing canonical news, provenance, admission, institutional-evidence, and dossier contracts
- fail-closed `/api/intelligence/observatory/coverage`
- human `/observatory/coverage/` interface with desktop/mobile coverage
- explicit source-rights review debt, reviewed-vs-collection-eligible institutional evidence state, evidence classes, unresolved claims, correction activity, event-level primary-evidence/reporting gaps, and cached source-health context
- no truth score, editorial verdict, publisher-quality score, political-bias inference, or composite coverage score
- news coverage and evidence coverage remain mechanically distinct
- cached health is observational only; the observatory never launches duplicate source probes
- clean deploy artifact requirements, sitemap entry, documentation, and production observatory verifier

## Referee boundary

Base is exact certified GD-016 production merge `60ec29982421cda2d535b836413a220ac1d04fa2`.

Frozen review head: `8e20a77de0d426b33a601eae42ca142d428a6ecd`.

The branch is 0 commits behind the certified base and contains only GD-017 changes.

## Required validation

- zero-warning lint
- Function contract suite, including hostile score/count/collection/duplicate/stale-health cases
- existing smoke suite plus observatory desktop and 390×844 mobile no-horizontal-overflow test
- clean deployment staging
- post-merge exact-commit Cloudflare health verification
- existing production intelligence verifier
- new production observatory verifier cross-checking canonical source/admission/evidence/dossier APIs

The observatory is read-only and does not auto-admit or auto-remediate sources.