### PR TITLE
Brand: replace clipped raster logo with circular GD moon mark

### DIFF
--- a/assets/logo-mark.svg
+++ b/assets/logo-mark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">GlobalDeets GD moon mark</title>
+  <desc id="desc">A transparent circular monogram where a G shapes the left lunar edge and a D shapes the right lunar edge.</desc>
+  <defs>
+    <linearGradient id="gd" x1="32" y1="32" x2="224" y2="224" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00f5ff"/>
+      <stop offset="0.52" stop-color="#65d8ff"/>
+      <stop offset="1" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+
+  <!-- G: the open left-hand lunar rim. -->
+  <path
+    d="M191.5 60.5A96 96 0 1 0 191.5 195.5"
+    fill="none"
+    stroke="url(#gd)"
+    stroke-width="17"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M212 128h-57m57 0v48"
+    fill="none"
+    stroke="url(#gd)"
+    stroke-width="17"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+
+  <!-- D: a clean inner chord and right-hand lunar rim. -->
+  <path
+    d="M119 39v178"
+    fill="none"
+    stroke="url(#gd)"
+    stroke-width="15"
+    stroke-linecap="round"
+  />
+  <path
+    d="M119 39c64 0 101 34 101 89s-37 89-101 89"
+    fill="none"
+    stroke="url(#gd)"
+    stroke-width="15"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -9,52 +9,58 @@
   "orientation": "portrait-primary",
   "icons": [
     {
+      "src": "assets/logo-mark.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
       "src": "assets/icon-72.png",
       "sizes": "72x72",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-96.png",
       "sizes": "96x96",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-128.png",
       "sizes": "128x128",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-144.png",
       "sizes": "144x144",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-152.png",
       "sizes": "152x152",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-384.png",
       "sizes": "384x384",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     },
     {
       "src": "assets/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "maskable"
     }
   ],
   "categories": ["productivity", "utilities"],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/institutional-evidence-acquisition.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/institutional-evidence-acquisition.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs tests/brand-mark.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/shared/ecosystem-nav.css
+++ b/shared/ecosystem-nav.css
@@ -40,10 +40,43 @@
   font-size: 0.9375rem;
 }
 
+/*
+ * GlobalDeets brand mark
+ *
+ * The old raster logo was a wide crop on a black canvas. That made the mark
+ * look clipped anywhere the layout expected a compact square. The canonical
+ * brand mark is now a transparent 1:1 SVG and this shared stylesheet forces
+ * legacy <img> references onto that asset until every old raster reference is
+ * retired. Keeping the mark inside an explicit square also makes browser,
+ * mobile and ecosystem-nav rendering deterministic.
+ */
 .ecosystem-logo {
+  content: url('../assets/logo-mark.svg');
   height: 28px;
-  width: auto;
-  filter: drop-shadow(0 0 6px rgba(139, 92, 246, 0.6)) drop-shadow(0 0 8px rgba(16, 185, 129, 0.3));
+  width: 28px;
+  max-width: 28px;
+  object-fit: contain;
+  display: block;
+  background: transparent;
+  filter: drop-shadow(0 0 6px rgba(0, 245, 255, 0.45))
+    drop-shadow(0 0 8px rgba(168, 85, 247, 0.35));
+}
+
+/* Primary GlobalDeets header mark is also normalized to a true square. */
+.site-logo-mark {
+  content: url('../assets/logo-mark.svg');
+  width: 84px !important;
+  height: 84px !important;
+  max-width: 84px;
+  object-fit: contain;
+  display: block;
+  background: transparent;
+}
+
+header.scrolled .site-logo-mark {
+  width: 54px !important;
+  height: 54px !important;
+  max-width: 54px;
 }
 
 .ecosystem-title {
@@ -232,7 +265,9 @@
   }
 
   .ecosystem-logo {
+    width: 24px;
     height: 24px;
+    max-width: 24px;
   }
 }
 

--- a/shared/ecosystem-nav.js
+++ b/shared/ecosystem-nav.js
@@ -32,7 +32,7 @@
       let pathname;
       try {
         pathname = new URL(image.src, window.location.href).pathname;
-      } catch (_error) {
+      } catch (_) {
         return;
       }
       const filename = pathname.split('/').pop();
@@ -163,7 +163,7 @@
           link.style.background = 'rgba(139, 92, 246, 0.12)';
           link.style.borderColor = 'rgba(139, 92, 246, 0.3)';
         }
-      } catch (_error) {
+      } catch (_) {
         // Invalid URL, skip
       }
     });

--- a/shared/ecosystem-nav.js
+++ b/shared/ecosystem-nav.js
@@ -1,6 +1,7 @@
 /**
  * GFD Ecosystem Navigation Component JavaScript
- * Handles dropdown toggle, accessibility, keyboard navigation, and GlobalDeets evidence discovery.
+ * Handles dropdown toggle, accessibility, keyboard navigation, GlobalDeets evidence discovery,
+ * and canonical GlobalDeets brand-mark normalization.
  */
 
 (function () {
@@ -13,8 +14,39 @@
   }
 
   function initNavigation() {
+    initBrandMarks();
     initEvidenceDossierLink();
     initEcosystemNav();
+  }
+
+  function initBrandMarks() {
+    const canonicalMark = '/assets/logo-mark.svg';
+    const legacyLogoNames = new Set([
+      'logo-mark.png',
+      'logo-vector.png',
+      'logo-nav.png',
+      'logo-globe.png',
+    ]);
+
+    document.querySelectorAll('img').forEach(image => {
+      let pathname;
+      try {
+        pathname = new URL(image.src, window.location.href).pathname;
+      } catch (_error) {
+        return;
+      }
+      const filename = pathname.split('/').pop();
+      if (!legacyLogoNames.has(filename)) return;
+      image.src = canonicalMark;
+      image.removeAttribute('width');
+      image.removeAttribute('height');
+      image.dataset.brandMark = 'gd-moon';
+    });
+
+    document.querySelectorAll('link[rel~="icon"]').forEach(link => {
+      link.href = canonicalMark;
+      link.type = 'image/svg+xml';
+    });
   }
 
   function initEvidenceDossierLink() {
@@ -131,7 +163,7 @@
           link.style.background = 'rgba(139, 92, 246, 0.12)';
           link.style.borderColor = 'rgba(139, 92, 246, 0.3)';
         }
-      } catch (e) {
+      } catch (_error) {
         // Invalid URL, skip
       }
     });

--- a/tests/brand-mark-smoke.spec.js
+++ b/tests/brand-mark-smoke.spec.js
@@ -1,0 +1,33 @@
+const { expect, test } = require('@playwright/test');
+
+test('canonical GD moon mark replaces legacy header assets without clipping', async ({ page }) => {
+  await page.goto('/');
+
+  const primaryMark = page.locator('.site-logo-mark').first();
+  await expect(primaryMark).toHaveAttribute('data-brand-mark', 'gd-moon');
+  await expect(primaryMark).toHaveAttribute('src', '/assets/logo-mark.svg');
+
+  const primaryBox = await primaryMark.boundingBox();
+  expect(primaryBox).not.toBeNull();
+  expect(Math.abs(primaryBox.width - primaryBox.height)).toBeLessThanOrEqual(1);
+
+  const ecosystemMark = page.locator('.ecosystem-logo').first();
+  await expect(ecosystemMark).toHaveAttribute('data-brand-mark', 'gd-moon');
+  const ecosystemBox = await ecosystemMark.boundingBox();
+  expect(ecosystemBox).not.toBeNull();
+  expect(Math.abs(ecosystemBox.width - ecosystemBox.height)).toBeLessThanOrEqual(1);
+});
+
+test.describe('canonical GD moon mark on mobile', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('remains fully contained at compact navigation size', async ({ page }) => {
+    await page.goto('/');
+    const mark = page.locator('.ecosystem-logo').first();
+    await expect(mark).toHaveAttribute('src', '/assets/logo-mark.svg');
+    const box = await mark.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box.width).toBeLessThanOrEqual(25);
+    expect(Math.abs(box.width - box.height)).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/brand-mark.test.mjs
+++ b/tests/brand-mark.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const read = relativePath => readFileSync(fileURLToPath(new URL(`../${relativePath}`, import.meta.url)), 'utf8');
+
+const mark = read('assets/logo-mark.svg');
+const navCss = read('shared/ecosystem-nav.css');
+const navJs = read('shared/ecosystem-nav.js');
+const manifest = JSON.parse(read('manifest.json'));
+
+test('canonical GlobalDeets mark is a transparent square SVG with no raster or background canvas', () => {
+  assert.match(mark, /<svg[^>]+viewBox="0 0 256 256"/);
+  assert.match(mark, /GlobalDeets GD moon mark/);
+  assert.equal(/<rect\b/i.test(mark), false);
+  assert.equal(/<image\b/i.test(mark), false);
+  assert.equal(/(?:fill|stop-color)="(?:#000000|#000|black)"/i.test(mark), false);
+  assert.match(mark, /stroke="url\(#gd\)"/);
+});
+
+test('shared navigation forces legacy raster logo surfaces onto the canonical square mark', () => {
+  assert.match(navCss, /\.ecosystem-logo\s*\{[\s\S]*content:\s*url\('\.\.\/assets\/logo-mark\.svg'\)/);
+  assert.match(navCss, /\.site-logo-mark\s*\{[\s\S]*width:\s*84px\s*!important;[\s\S]*height:\s*84px\s*!important;/);
+  assert.match(navJs, /const canonicalMark = '\/assets\/logo-mark\.svg';/);
+  for (const legacyName of ['logo-mark.png', 'logo-vector.png', 'logo-nav.png', 'logo-globe.png']) {
+    assert.ok(navJs.includes(`'${legacyName}'`), `legacy logo migration missing ${legacyName}`);
+  }
+});
+
+test('web app manifest prefers the scalable transparent mark while retaining maskable fallbacks', () => {
+  const vectorIcon = manifest.icons.find(icon => icon.src === 'assets/logo-mark.svg');
+  assert.deepEqual(vectorIcon, {
+    src: 'assets/logo-mark.svg',
+    sizes: 'any',
+    type: 'image/svg+xml',
+    purpose: 'any',
+  });
+  assert.ok(manifest.icons.some(icon => icon.type === 'image/png' && icon.purpose === 'maskable'));
+});

--- a/tools/stage-deploy.js
+++ b/tools/stage-deploy.js
@@ -26,6 +26,7 @@ const REQUIRED_DEPLOY_FILES = [
   '_headers',
   '_redirects',
   '_routes.json',
+  'assets/logo-mark.svg',
   'dossiers/santa-ynez-pipeline/index.html',
   'dossiers/santa-ynez-pipeline/dossier.js',
   'dossiers/dossier.css',


### PR DESCRIPTION
## Why

The current GlobalDeets/GFD logo assets are wide raster crops on a black canvas. In compact header, ecosystem-nav, favicon, and icon surfaces they are frequently clipped or rendered with the wrong aspect ratio.

## What changes

- adds a canonical transparent 1:1 SVG monogram at `assets/logo-mark.svg`
- the **G** forms the open left lunar rim and the **D** forms the right lunar rim / inner chord
- no background rectangle/canvas
- shared nav CSS normalizes both ecosystem and primary header marks to true square boxes
- shared nav JS migrates legacy `logo-mark.png`, `logo-vector.png`, `logo-nav.png`, and `logo-globe.png` references to the canonical SVG at runtime
- existing favicon links are normalized to the SVG when shared navigation initializes
- PWA manifest prefers the scalable SVG for `purpose:any`, while retaining PNG maskable fallbacks
- deploy staging now fails if the canonical SVG is missing
- static hostile contract verifies transparent-square semantics
- Playwright verifies desktop and 390px mobile rendering remains square and contained

## Explicit visual boundary

This is intentionally a minimal mark: no background plate, no wordmark inside the symbol, no globe crop, no text below the mark, and no rectangular composition. The geometry is designed to survive headers, favicons, mobile nav, cards, and circular presentation without losing its outer shape.

## Baseline

Exact production-certified GD-018 merge: `8393bbae9d550bdd280fdaa44d0deceb256f4b03`.
