### PR TITLE
GD-019: Governed local/subnational reporting pilot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           node --check functions/lib/news-coverage.js
           node --check functions/lib/news-source-provenance.js
           node --check functions/lib/news-source-admission.js
+          node --check functions/lib/local-reporting-observatory.js
           node --check functions/lib/intelligence-model.js
           node --check functions/lib/m49-place-seed.js
           node --check functions/lib/claim-evidence-model.js
@@ -83,6 +84,7 @@ jobs:
           node --check tests/institutional-evidence-acquisition.test.mjs
           node --check tests/santa-ynez-dossier.test.mjs
           node --check tests/coverage-evidence-observatory.test.mjs
+          node --check tests/local-reporting-observatory.test.mjs
 
       - name: Lint JavaScript
         run: npm run lint

--- a/functions/api/intelligence/observatory/coverage.js
+++ b/functions/api/intelligence/observatory/coverage.js
@@ -3,6 +3,10 @@ import {
   readCachedSourceHealth,
   validateCoverageEvidenceObservatory,
 } from '../../../lib/coverage-evidence-observatory.js';
+import {
+  buildLocalReportingObservatory,
+  validateLocalReportingObservatory,
+} from '../../../lib/local-reporting-observatory.js';
 
 const ALLOWED_ORIGINS = new Set([
   'https://globaldeets.com',
@@ -31,7 +35,14 @@ export async function onRequestGet({ env, request }) {
   try {
     const healthSnapshot = await readCachedSourceHealth(env);
     const observatory = buildCoverageEvidenceObservatory({ healthSnapshot });
-    const integrity = validateCoverageEvidenceObservatory(observatory);
+    const baseIntegrity = validateCoverageEvidenceObservatory(observatory);
+    const localReporting = buildLocalReportingObservatory();
+    const localIntegrity = validateLocalReportingObservatory(localReporting);
+    const integrity = {
+      ...baseIntegrity,
+      localReporting: localIntegrity,
+      valid: baseIntegrity.valid && localIntegrity.valid,
+    };
 
     if (!integrity.valid) {
       return new Response(
@@ -49,6 +60,7 @@ export async function onRequestGet({ env, request }) {
       JSON.stringify({
         generatedAt: new Date().toISOString(),
         ...observatory,
+        localReporting,
         integrity,
       }),
       { headers: headers(request) }

--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -80,6 +80,20 @@ export const SOURCES = [
     region: 'americas',
     lang: 'en',
   },
+  // GD-019 governed subnational pilot. Routing remains "americas"; the actual
+  // geographic scope is carried separately by reviewed provenance metadata.
+  {
+    name: 'Minnesota Reformer',
+    url: 'https://minnesotareformer.com/feed/localFeed',
+    region: 'americas',
+    lang: 'en',
+  },
+  {
+    name: 'CalMatters',
+    url: 'https://calmatters.org/feed/',
+    region: 'americas',
+    lang: 'en',
+  },
 
   // ── Pacific ───────────────────────────────────────────────────────────────
   {

--- a/functions/lib/local-reporting-observatory.js
+++ b/functions/lib/local-reporting-observatory.js
@@ -1,0 +1,104 @@
+import { buildCoverageInventory } from './news-coverage.js';
+import { SOURCE_RESEARCH_CANDIDATES } from './news-source-admission.js';
+
+export const LOCAL_REPORTING_OBSERVATORY_VERSION = '2026-09-08.1';
+
+export function buildLocalReportingObservatory({
+  coverage = buildCoverageInventory(),
+  researchCandidates = SOURCE_RESEARCH_CANDIDATES,
+} = {}) {
+  const subnational = coverage?.subnationalReporting || emptySubnational();
+  const localCandidates = researchCandidates
+    .filter(candidate => candidate?.candidateId === 'laist-local')
+    .map(candidate => ({
+      candidateId: candidate.candidateId,
+      name: candidate.name,
+      disposition: candidate.disposition,
+      endpointAuthority: candidate.endpointAuthority,
+      allowedUseStatus: candidate.allowedUseStatus,
+      itemLevelReviewRequired: candidate.itemLevelReviewRequired,
+      blocker: candidate.itemLevelReviewRequired
+        ? 'mixed-origin feed requires deterministic item-origin restriction handling'
+        : null,
+    }));
+
+  return Object.freeze({
+    version: LOCAL_REPORTING_OBSERVATORY_VERSION,
+    rules: Object.freeze({
+      routingRegionIsGeographicScope: false,
+      publisherOriginIsEventLocality: false,
+      sourceScopeMakesEveryItemLocal: false,
+      localReportingIsPrimaryEvidence: false,
+      localPublisherImpliesIndependentCorroboration: false,
+      observatoryIsAdmissionAuthority: false,
+      automaticSourceWeighting: false,
+    }),
+    sourceCount: subnational.sourceCount,
+    sourceIds: Object.freeze([...(subnational.sourceIds || [])]),
+    jurisdictionCount: subnational.jurisdictionCount,
+    jurisdictionIds: Object.freeze([...(subnational.jurisdictionIds || [])]),
+    operatorCount: subnational.operatorCount,
+    operators: Object.freeze([...(subnational.operators || [])]),
+    sources: Object.freeze((subnational.sources || []).map(source => Object.freeze({ ...source }))),
+    researchCandidates: Object.freeze(localCandidates.map(candidate => Object.freeze(candidate))),
+  });
+}
+
+export function validateLocalReportingObservatory(locality) {
+  const errors = [];
+  if (!locality || typeof locality !== 'object' || Array.isArray(locality)) {
+    return { valid: false, errors: ['locality:not-object'] };
+  }
+  if (locality.version !== LOCAL_REPORTING_OBSERVATORY_VERSION) {
+    errors.push('locality:version-mismatch');
+  }
+  for (const field of [
+    'routingRegionIsGeographicScope',
+    'publisherOriginIsEventLocality',
+    'sourceScopeMakesEveryItemLocal',
+    'localReportingIsPrimaryEvidence',
+    'localPublisherImpliesIndependentCorroboration',
+    'observatoryIsAdmissionAuthority',
+    'automaticSourceWeighting',
+  ]) {
+    if (locality.rules?.[field] !== false) errors.push(`locality.rules.${field}:must-be-false`);
+  }
+  if (!Array.isArray(locality.sourceIds) || locality.sourceCount !== locality.sourceIds.length) {
+    errors.push('locality:source-count-drift');
+  }
+  if (!Array.isArray(locality.jurisdictionIds) || locality.jurisdictionCount !== locality.jurisdictionIds.length) {
+    errors.push('locality:jurisdiction-count-drift');
+  }
+  if (!Array.isArray(locality.operators) || locality.operatorCount !== locality.operators.length) {
+    errors.push('locality:operator-count-drift');
+  }
+  if (!Array.isArray(locality.sources) || locality.sources.length !== locality.sourceCount) {
+    errors.push('locality:sources-drift');
+  }
+  for (const source of locality.sources || []) {
+    if (source.routingRegion === source.scopeType) {
+      errors.push(`locality:${source.sourceId}:routing-scope-collapse`);
+    }
+    if (!source.scopeType || !Array.isArray(source.jurisdictionIds) || source.jurisdictionIds.length === 0) {
+      errors.push(`locality:${source.sourceId}:missing-reviewed-scope`);
+    }
+  }
+  for (const candidate of locality.researchCandidates || []) {
+    if (locality.sourceIds.includes(candidate.candidateId) || candidate.disposition !== 'research') {
+      errors.push(`locality:${candidate.candidateId}:research-self-promotion`);
+    }
+  }
+  return { valid: errors.length === 0, errors: [...new Set(errors)].sort() };
+}
+
+function emptySubnational() {
+  return {
+    sourceCount: 0,
+    sourceIds: [],
+    jurisdictionCount: 0,
+    jurisdictionIds: [],
+    operatorCount: 0,
+    operators: [],
+    sources: [],
+  };
+}

--- a/functions/lib/news-coverage.js
+++ b/functions/lib/news-coverage.js
@@ -9,6 +9,7 @@ export const COVERAGE_POLICY = Object.freeze({
   minimumSourcesPerRegion: 2,
   portfolioEnglishConcentrationThreshold: 0.8,
   minimumPrimarySourceInputs: 1,
+  minimumSubnationalJurisdictions: 2,
 });
 
 export function buildCoverageInventory(
@@ -35,6 +36,14 @@ export function buildCoverageInventory(
         geographicScope: metadata.geographicScope || 'unknown',
         primaryCountry: metadata.primaryCountry || null,
         locality: metadata.locality || 'unknown',
+        scopeType: metadata.scopeType || null,
+        jurisdictionScheme: metadata.jurisdictionScheme || null,
+        jurisdictionIds: Array.isArray(metadata.jurisdictionIds) ? [...metadata.jurisdictionIds] : [],
+        scopeBasis: metadata.scopeBasis || null,
+        scopeEvidenceUrls: Array.isArray(metadata.scopeEvidenceUrls)
+          ? [...metadata.scopeEvidenceUrls]
+          : [],
+        ownershipOperator: metadata.ownershipOperator || null,
         ownershipOperatorKnown: Boolean(metadata.ownershipOperator),
         admissionReviewState: admission.reviewState || 'missing',
         allowedUseStatus: admission.allowedUseStatus || 'missing',
@@ -62,6 +71,7 @@ export function buildCoverageInventory(
   const evidenceRoles = summarizeGroups(evidenceRoleGroups, 'evidenceRole');
   const geographicScopes = summarizeGroups(geographicScopeGroups, 'geographicScope');
   const sourceOriginCountries = summarizeGroups(countryGroups, 'country');
+  const subnationalReporting = summarizeSubnationalReporting(normalizedSources);
 
   const admission = buildAdmissionInventory(admissions, admissionValidation);
   const gaps = buildGapSignals(
@@ -69,7 +79,8 @@ export function buildCoverageInventory(
     regions,
     provenanceValidation,
     admissionValidation,
-    admission
+    admission,
+    subnationalReporting
   );
   const englishSources = normalizedSources.filter(source => source.lang === 'en').length;
   const primarySourceInputs = normalizedSources.filter(
@@ -86,6 +97,14 @@ export function buildCoverageInventory(
       .filter(source => source.lang !== 'en')
       .map(source => source.sourceId),
     primarySourceInputs,
+    localityRules: {
+      routingRegionIsGeographicScope: false,
+      publisherOriginIsEventLocality: false,
+      sourceScopeMakesEveryItemLocal: false,
+      subnationalReportingIsPrimaryEvidence: false,
+      localPublisherImpliesIndependentCorroboration: false,
+    },
+    subnationalReporting,
     provenance: {
       valid: provenanceValidation.valid,
       reviewedSources: provenance.length,
@@ -105,6 +124,32 @@ export function buildCoverageInventory(
     geographicScopes,
     sourceOriginCountries,
     gaps,
+  };
+}
+
+function summarizeSubnationalReporting(sources) {
+  const subnational = sources.filter(source => source.geographicScope === 'subnational');
+  const jurisdictionIds = unique(subnational.flatMap(source => source.jurisdictionIds));
+  const operators = unique(subnational.map(source => source.ownershipOperator).filter(Boolean));
+  return {
+    sourceCount: subnational.length,
+    sourceIds: subnational.map(source => source.sourceId).sort(),
+    jurisdictionCount: jurisdictionIds.length,
+    jurisdictionIds,
+    operatorCount: operators.length,
+    operators,
+    sources: subnational
+      .map(source => ({
+        sourceId: source.sourceId,
+        routingRegion: source.region,
+        primaryCountry: source.primaryCountry,
+        scopeType: source.scopeType,
+        jurisdictionScheme: source.jurisdictionScheme,
+        jurisdictionIds: [...source.jurisdictionIds],
+        scopeBasis: source.scopeBasis,
+        scopeEvidenceUrls: [...source.scopeEvidenceUrls],
+      }))
+      .sort((a, b) => a.sourceId.localeCompare(b.sourceId)),
   };
 }
 
@@ -133,7 +178,8 @@ function buildGapSignals(
   regions,
   provenanceValidation,
   admissionValidation,
-  admission
+  admission,
+  subnationalReporting
 ) {
   const gaps = [];
 
@@ -194,8 +240,7 @@ function buildGapSignals(
     });
   }
 
-  const subnationalSources = sources.filter(source => source.geographicScope === 'subnational').length;
-  if (subnationalSources === 0) {
+  if (subnationalReporting.sourceCount === 0) {
     gaps.push({
       id: 'geographic-scope:subnational',
       type: 'geographic-scope',
@@ -204,6 +249,18 @@ function buildGapSignals(
       observed: 0,
       target: 'measurable subnational/local coverage where strategically relevant',
       detail: 'No current source is classified as a subnational/local source, limiting visibility below national and regional narratives.',
+    });
+  }
+
+  if (subnationalReporting.jurisdictionCount < COVERAGE_POLICY.minimumSubnationalJurisdictions) {
+    gaps.push({
+      id: 'geographic-scope:subnational-jurisdictions',
+      type: 'geographic-scope',
+      severity: 'medium',
+      region: null,
+      observed: subnationalReporting.jurisdictionIds,
+      target: COVERAGE_POLICY.minimumSubnationalJurisdictions,
+      detail: 'The reviewed subnational source portfolio does not yet span the minimum number of explicit jurisdictions.',
     });
   }
 
@@ -280,4 +337,8 @@ function groupSources(sources, field) {
 
 function roundRatio(value) {
   return Math.round(value * 10000) / 10000;
+}
+
+function unique(values) {
+  return [...new Set(values)].sort();
 }

--- a/functions/lib/news-source-admission.js
+++ b/functions/lib/news-source-admission.js
@@ -4,6 +4,7 @@
 import { SOURCES, slugifySourceName } from '../api/news.js';
 
 export const ADMISSION_REVIEW_DATE = '2026-09-03';
+export const GD019_REVIEW_DATE = '2026-09-08';
 export const ALLOWED_USE_STATUSES = Object.freeze([
   'verified-public-use',
   'permission-required',
@@ -88,6 +89,41 @@ export const SOURCE_ADMISSIONS = Object.freeze([
   legacy('Dawn', 'https://www.dawn.com/feeds/home/'),
   legacy('NPR', 'https://feeds.npr.org/1004/rss.xml'),
   legacy('Mercopress', 'https://en.mercopress.com/rss/'),
+  reviewedNew('Minnesota Reformer', 'https://minnesotareformer.com/feed/localFeed', {
+    endpointEvidenceUrls: [
+      'https://minnesotareformer.com/feed/localFeed',
+      'https://statesnewsroom.com/rss-feeds/',
+      'https://minnesotareformer.com/about/',
+    ],
+    usagePolicyUrls: [
+      'https://statesnewsroom.com/rss-feeds/',
+      'https://minnesotareformer.com/about/',
+    ],
+    allowedUseStatus: 'verified-public-use',
+    permittedUse: currentUse(false),
+    syndicatedContentBehavior: 'republisher-local-feed-excludes-network-national-content',
+    itemLevelReviewRequired: false,
+    itemLevelStrategy: 'dedicated-local-feed',
+    reviewerNotes:
+      'States Newsroom explicitly documents state-site /feed/localFeed endpoints for republishers and says those feeds contain republishable state-newsroom stories while excluding D.C./National team content. Minnesota Reformer states its work is CC BY-NC-ND 4.0 with attribution/link conditions. GlobalDeets uses only headline/link, metadata and a bounded excerpt.',
+  }),
+  reviewedNew('CalMatters', 'https://calmatters.org/feed/', {
+    endpointEvidenceUrls: [
+      'https://calmatters.org/feed/',
+      'https://calmatters.org/about/republish/',
+    ],
+    usagePolicyUrls: [
+      'https://calmatters.org/about/republish/',
+      'https://calmatters.org/about/policies-and-standards/',
+    ],
+    allowedUseStatus: 'verified-public-use',
+    permittedUse: currentUse(false),
+    syndicatedContentBehavior: 'publisher-text-republishable-third-party-visuals-restricted',
+    itemLevelReviewRequired: false,
+    itemLevelStrategy: 'text-metadata-only-no-third-party-visual-use',
+    reviewerNotes:
+      'CalMatters publishes a first-party RSS endpoint and explicitly permits free article republication subject to attribution, canonical-link, editing and commercial-use conditions. GlobalDeets uses only headline/link, metadata and a bounded excerpt and does not ingest article imagery, avoiding the separately restricted wire/third-party visual lane.',
+  }),
   legacy('ABC Australia', 'https://www.abc.net.au/news/feed/51120/rss.xml'),
   legacy('Premium Times', 'https://www.premiumtimesng.com/feed/'),
   legacy('The East African', 'https://www.theeastafrican.co.ke/rss.xml'),
@@ -124,6 +160,24 @@ export const SOURCE_RESEARCH_CANDIDATES = Object.freeze([
     itemLevelReviewRequired: true,
     reviewerNotes:
       'Agencia Brasil publishes a journalistic reproduction policy, but partner-agency material can carry separate restrictions. Production admission requires a verified item-origin/restriction signal strategy first.',
+  }),
+  candidate({
+    candidateId: 'laist-local',
+    name: 'LAist',
+    endpointUrl: 'https://laist.com/rss/latest-news',
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [
+      'https://laist.com/rss-feed',
+      'https://laist.com/rss/latest-news',
+    ],
+    usagePolicyUrls: ['https://laist.com/editorial-ethics-and-guidelines/republish'],
+    allowedUseStatus: 'verified-public-use',
+    disposition: 'research',
+    syndicatedContentBehavior: 'mixed-origin-partner-content',
+    itemLevelReviewRequired: true,
+    reviewerNotes:
+      'LAist is a strong metro-local candidate and permits republication of its original editorial content, but its current latest-stories feed visibly includes partner material while its republication policy excludes partner content. Keep research-only until a deterministic item-origin restriction signal or narrower authorized feed is proven.',
   }),
 ]);
 
@@ -345,6 +399,32 @@ function reviewedLegacy(name, endpointUrl, options) {
   });
 }
 
+function reviewedNew(name, endpointUrl, options) {
+  return admission({
+    sourceId: slugifySourceName(name),
+    name,
+    endpointUrl,
+    endpointType: 'rss',
+    endpointAuthority: 'first-party',
+    endpointEvidenceUrls: [endpointUrl],
+    authenticationRequirement: 'none-observed',
+    usagePolicyUrls: [],
+    allowedUseStatus: 'unknown',
+    currentUse: currentUse(false),
+    permittedUse: [],
+    excerptMaxChars: 280,
+    syndicatedContentBehavior: 'unknown',
+    itemLevelReviewRequired: true,
+    itemLevelStrategy: 'restrict-on-explicit-item-signal',
+    reviewState: 'reviewed',
+    reviewedAt: GD019_REVIEW_DATE,
+    reviewerNotes: 'Reviewed new source.',
+    healthVerificationStatus: 'verified',
+    legacy: false,
+    ...options,
+  });
+}
+
 function admission(definition = {}) {
   return Object.freeze({
     ...definition,
@@ -364,7 +444,7 @@ function candidate(definition) {
     permittedUse: Object.freeze([]),
     authenticationRequirement: definition.authenticationRequirement || 'unknown',
     healthVerificationStatus: 'research-only',
-    reviewedAt: ADMISSION_REVIEW_DATE,
+    reviewedAt: GD019_REVIEW_DATE,
     itemLevelReviewRequired: definition.itemLevelReviewRequired === true,
     syndicatedContentBehavior: definition.syndicatedContentBehavior || 'unknown',
   });

--- a/functions/lib/news-source-provenance.js
+++ b/functions/lib/news-source-provenance.js
@@ -4,6 +4,20 @@
 import { SOURCES, slugifySourceName } from '../api/news.js';
 
 export const PROVENANCE_REVIEW_DATE = '2026-09-03';
+export const SUBNATIONAL_SCOPE_TYPES = Object.freeze([
+  'local',
+  'metro',
+  'state-province',
+  'regional-subnational',
+]);
+export const SCOPE_BASES = Object.freeze([
+  'publisher-declared-reviewed',
+  'independently-reviewed',
+  'unknown',
+]);
+
+const SUBNATIONAL_SCOPE_TYPE_SET = new Set(SUBNATIONAL_SCOPE_TYPES);
+const SCOPE_BASIS_SET = new Set(SCOPE_BASES);
 
 export const SOURCE_PROVENANCE = Object.freeze([
   record({
@@ -199,6 +213,48 @@ export const SOURCE_PROVENANCE = Object.freeze([
     evidenceUrls: ['https://en.mercopress.com/about-mercopress'],
   }),
   record({
+    sourceId: 'minnesota-reformer',
+    name: 'Minnesota Reformer',
+    organizationName: 'Minnesota Reformer',
+    sourceClass: 'nonprofit-state-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'subnational',
+    primaryCountry: 'US',
+    locality: 'state-province',
+    ownershipOperator: 'States Newsroom',
+    evidenceUrls: [
+      'https://minnesotareformer.com/about/',
+      'https://statesnewsroom.com/rss-feeds/',
+    ],
+    scopeType: 'state-province',
+    jurisdictionIds: ['US-MN'],
+    jurisdictionScheme: 'ISO 3166-2',
+    scopeBasis: 'publisher-declared-reviewed',
+    scopeEvidenceUrls: ['https://minnesotareformer.com/about/'],
+    reviewedAt: '2026-09-08',
+  }),
+  record({
+    sourceId: 'calmatters',
+    name: 'CalMatters',
+    organizationName: 'CalMatters',
+    sourceClass: 'nonprofit-state-newsroom',
+    evidenceRole: 'reporting',
+    geographicScope: 'subnational',
+    primaryCountry: 'US',
+    locality: 'state-province',
+    ownershipOperator: 'CalMatters',
+    evidenceUrls: [
+      'https://calmatters.org/about/',
+      'https://calmatters.org/about/republish/',
+    ],
+    scopeType: 'state-province',
+    jurisdictionIds: ['US-CA'],
+    jurisdictionScheme: 'ISO 3166-2',
+    scopeBasis: 'publisher-declared-reviewed',
+    scopeEvidenceUrls: ['https://calmatters.org/about/'],
+    reviewedAt: '2026-09-08',
+  }),
+  record({
     sourceId: 'abc-australia',
     name: 'ABC Australia',
     organizationName: 'Australian Broadcasting Corporation',
@@ -272,12 +328,14 @@ function record(definition) {
   return Object.freeze({
     ...definition,
     sourceLanguages: source ? [source.lang] : [],
-    reviewedAt: PROVENANCE_REVIEW_DATE,
+    reviewedAt: definition.reviewedAt || PROVENANCE_REVIEW_DATE,
+    jurisdictionIds: Object.freeze([...(definition.jurisdictionIds || [])]),
+    scopeEvidenceUrls: Object.freeze([...(definition.scopeEvidenceUrls || [])]),
   });
 }
 
 function isValidEntry(entry, source) {
-  return Boolean(
+  const baseValid = Boolean(
     entry &&
       source &&
       entry.sourceId === slugifySourceName(source.name) &&
@@ -294,5 +352,20 @@ function isValidEntry(entry, source) {
       entry.evidenceUrls.length > 0 &&
       entry.evidenceUrls.every(url => /^https:\/\//.test(url)) &&
       entry.reviewedAt
+  );
+  if (!baseValid) return false;
+  if (entry.geographicScope !== 'subnational') return true;
+  return Boolean(
+    SUBNATIONAL_SCOPE_TYPE_SET.has(entry.scopeType) &&
+      entry.locality === entry.scopeType &&
+      entry.jurisdictionScheme === 'ISO 3166-2' &&
+      Array.isArray(entry.jurisdictionIds) &&
+      entry.jurisdictionIds.length > 0 &&
+      entry.jurisdictionIds.every(id => /^[A-Z]{2}-[A-Z0-9]{1,3}$/.test(id)) &&
+      SCOPE_BASIS_SET.has(entry.scopeBasis) &&
+      entry.scopeBasis !== 'unknown' &&
+      Array.isArray(entry.scopeEvidenceUrls) &&
+      entry.scopeEvidenceUrls.length > 0 &&
+      entry.scopeEvidenceUrls.every(url => /^https:\/\//.test(url))
   );
 }

--- a/observatory/coverage/index.html
+++ b/observatory/coverage/index.html
@@ -20,6 +20,7 @@
         <span>No truth score</span>
         <span>No editorial verdict</span>
         <span>News coverage ≠ evidence coverage</span>
+        <span>Routing region ≠ local scope</span>
         <span>Collection eligibility stays explicit</span>
       </div>
     </header>
@@ -64,6 +65,15 @@
       </article>
     </section>
 
+    <section aria-labelledby="local-heading">
+      <div class="section-heading">
+        <p class="eyebrow">Subnational reporting</p>
+        <h2 id="local-heading">Reviewed source scope without locality inference</h2>
+        <p>These are reviewed publisher scopes, not automatic claims that every story is local. Item and event locality remain separate evidence questions.</p>
+      </div>
+      <div id="local-reporting-summary" class="record-list"></div>
+    </section>
+
     <section class="two-column" aria-label="Governance inventories">
       <article class="panel">
         <div class="panel-heading">
@@ -103,7 +113,7 @@
         <p class="eyebrow">Method</p>
         <h2 id="method-heading">What this observatory does not claim</h2>
       </div>
-      <p>It does not rank publishers, infer political bias, calculate factual accuracy, blend news-source counts with evidence counts, or treat a reviewed directory as permission to collect. Unknowns remain unknown until attributable evidence changes the underlying contract.</p>
+      <p>It does not rank publishers, infer political bias, calculate factual accuracy, infer story locality from publisher scope, blend news-source counts with evidence counts, or treat a reviewed directory as permission to collect. Unknowns remain unknown until attributable evidence changes the underlying contract.</p>
     </section>
 
     <div id="observatory-error" class="error-panel" hidden>

--- a/observatory/coverage/observatory.js
+++ b/observatory/coverage/observatory.js
@@ -23,6 +23,7 @@
     if (!data || typeof data !== 'object') throw new Error('Observatory payload missing');
     if (data.observatoryId !== 'coverage-evidence') throw new Error('Observatory identity mismatch');
     if (data.integrity?.valid !== true) throw new Error('Observatory integrity invalid');
+    if (data.integrity?.localReporting?.valid !== true) throw new Error('Local reporting integrity invalid');
     if (
       data.rules?.truthScore !== false ||
       data.rules?.editorialVerdict !== false ||
@@ -33,8 +34,25 @@
     ) {
       throw new Error('Observatory semantic contract changed');
     }
-    for (const field of ['newsCoverage', 'sourceRights', 'institutionalEvidence', 'evidenceCoverage']) {
+    for (const field of [
+      'newsCoverage',
+      'sourceRights',
+      'institutionalEvidence',
+      'evidenceCoverage',
+      'localReporting',
+    ]) {
       if (!data[field] || typeof data[field] !== 'object') throw new Error(`${field} missing`);
+    }
+    if (
+      data.localReporting.rules?.routingRegionIsGeographicScope !== false ||
+      data.localReporting.rules?.publisherOriginIsEventLocality !== false ||
+      data.localReporting.rules?.sourceScopeMakesEveryItemLocal !== false ||
+      data.localReporting.rules?.localReportingIsPrimaryEvidence !== false ||
+      data.localReporting.rules?.localPublisherImpliesIndependentCorroboration !== false ||
+      data.localReporting.rules?.observatoryIsAdmissionAuthority !== false ||
+      data.localReporting.rules?.automaticSourceWeighting !== false
+    ) {
+      throw new Error('Local reporting semantic contract changed');
     }
     if (!Array.isArray(data.gaps)) throw new Error('Gap inventory missing');
   }
@@ -54,6 +72,8 @@
     renderInto('baseline-grid', [
       metric(data.newsCoverage.totalSources, 'Live news sources'),
       metric(data.newsCoverage.gapCount, 'News coverage gaps'),
+      metric(data.localReporting.sourceCount, 'Subnational reporting sources'),
+      metric(data.localReporting.jurisdictionCount, 'Reviewed subnational jurisdictions'),
       metric(data.sourceRights.legacyUnreviewedSources, 'Legacy rights reviews open'),
       metric(data.institutionalEvidence.reviewedSources, 'Institutional candidates reviewed'),
       metric(data.institutionalEvidence.collectionEligibleSources, 'Institutional sources collection-eligible'),
@@ -80,6 +100,28 @@
         record(titleCase(item.documentType), item.count, 'Canonical evidence document type')
       )
     );
+
+    const local = data.localReporting;
+    const localRecords = array(local.sources).map(source =>
+      record(
+        source.sourceId,
+        array(source.jurisdictionIds).join(', '),
+        `${titleCase(source.scopeType)} scope · routing: ${source.routingRegion} · ${titleCase(source.scopeBasis)}`
+      )
+    );
+    const blockedLocal = array(local.researchCandidates).map(candidate =>
+      record(
+        `${candidate.name} — research only`,
+        'Blocked',
+        candidate.blocker || 'Requires additional review before admission.'
+      )
+    );
+    renderInto('local-reporting-summary', [
+      record('Reviewed jurisdictions', local.jurisdictionCount, joinIds(local.jurisdictionIds)),
+      record('Distinct operators', local.operatorCount, joinIds(local.operators)),
+      ...localRecords,
+      ...blockedLocal,
+    ]);
 
     const rights = data.sourceRights;
     renderInto('rights-summary', [
@@ -205,6 +247,7 @@
       'baseline-grid',
       'region-list',
       'evidence-class-list',
+      'local-reporting-summary',
       'rights-summary',
       'institutional-summary',
       'dossier-list',

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/institutional-evidence-acquisition.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs tests/brand-mark.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/institutional-evidence-acquisition.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs tests/local-reporting-observatory.test.mjs tests/brand-mark.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/tests/coverage-evidence-observatory.test.mjs
+++ b/tests/coverage-evidence-observatory.test.mjs
@@ -24,9 +24,9 @@ test('canonical coverage and evidence observatory validates and preserves semant
 
   assert.equal(observatory.observatoryId, COVERAGE_EVIDENCE_OBSERVATORY_ID);
   assert.equal(observatory.observatoryVersion, COVERAGE_EVIDENCE_OBSERVATORY_VERSION);
-  assert.equal(observatory.newsCoverage.totalSources, 19);
-  assert.equal(observatory.sourceRights.totalLiveSources, 19);
-  assert.equal(observatory.sourceRights.reviewedLiveSources, 2);
+  assert.equal(observatory.newsCoverage.totalSources, 21);
+  assert.equal(observatory.sourceRights.totalLiveSources, 21);
+  assert.equal(observatory.sourceRights.reviewedLiveSources, 4);
   assert.equal(observatory.sourceRights.legacyUnreviewedSources, 17);
   assert.equal(observatory.institutionalEvidence.reviewedSources, 10);
   assert.equal(observatory.institutionalEvidence.endpointReviewedSources, 1);
@@ -127,7 +127,7 @@ test('cached health is observational only and rejects stale source identities', 
   assert.ok(observatory.gaps.some(gap => gap.type === 'degraded-source-health'));
 });
 
-test('observatory API returns only integrity-valid payloads and supports CORS preflight', async () => {
+test('observatory API returns integrity-valid evidence and local-reporting payloads with no authority collapse', async () => {
   const request = new Request('https://globaldeets.com/api/intelligence/observatory/coverage', {
     headers: { Origin: 'https://globaldeets.com' },
   });
@@ -135,10 +135,17 @@ test('observatory API returns only integrity-valid payloads and supports CORS pr
   assert.equal(response.status, 200);
   const payload = await response.json();
   assert.equal(payload.integrity.valid, true);
+  assert.equal(payload.integrity.localReporting.valid, true);
   assert.equal(payload.observatoryId, COVERAGE_EVIDENCE_OBSERVATORY_ID);
   assert.equal(payload.rules.truthScore, false);
   assert.equal(payload.rules.newsCoverageIsEvidenceCoverage, false);
   assert.equal(payload.institutionalEvidence.collectionEligibleSources, 1);
+  assert.equal(payload.localReporting.sourceCount, 2);
+  assert.deepEqual(payload.localReporting.jurisdictionIds, ['US-CA', 'US-MN']);
+  assert.equal(payload.localReporting.rules.routingRegionIsGeographicScope, false);
+  assert.equal(payload.localReporting.rules.sourceScopeMakesEveryItemLocal, false);
+  assert.equal(payload.localReporting.rules.observatoryIsAdmissionAuthority, false);
+  assert.ok(payload.localReporting.researchCandidates.some(candidate => candidate.candidateId === 'laist-local'));
 
   const preflight = await onRequestOptions({ request });
   assert.equal(preflight.status, 204);

--- a/tests/local-reporting-observatory.test.mjs
+++ b/tests/local-reporting-observatory.test.mjs
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { SOURCES } from '../functions/api/news.js';
+import { buildCoverageInventory } from '../functions/lib/news-coverage.js';
+import {
+  SOURCE_ADMISSIONS,
+  SOURCE_RESEARCH_CANDIDATES,
+  isProductionAdmissible,
+  validateSourceAdmissions,
+} from '../functions/lib/news-source-admission.js';
+import {
+  SOURCE_PROVENANCE,
+  validateSourceProvenance,
+} from '../functions/lib/news-source-provenance.js';
+import {
+  buildLocalReportingObservatory,
+  validateLocalReportingObservatory,
+} from '../functions/lib/local-reporting-observatory.js';
+
+function mutable(value) {
+  return structuredClone(value);
+}
+
+test('GD-019 admits two operator-distinct subnational sources across two explicit jurisdictions', () => {
+  const coverage = buildCoverageInventory();
+  const sourceIds = new Set(coverage.subnationalReporting.sourceIds);
+
+  assert.equal(SOURCES.length, 21);
+  assert.equal(validateSourceAdmissions().valid, true);
+  assert.equal(validateSourceProvenance().valid, true);
+  assert.equal(coverage.subnationalReporting.sourceCount, 2);
+  assert.deepEqual(coverage.subnationalReporting.jurisdictionIds, ['US-CA', 'US-MN']);
+  assert.equal(coverage.subnationalReporting.jurisdictionCount, 2);
+  assert.equal(coverage.subnationalReporting.operatorCount, 2);
+  assert.ok(sourceIds.has('minnesota-reformer'));
+  assert.ok(sourceIds.has('calmatters'));
+  assert.equal(coverage.gaps.some(gap => gap.id === 'geographic-scope:subnational'), false);
+  assert.equal(
+    coverage.gaps.some(gap => gap.id === 'geographic-scope:subnational-jurisdictions'),
+    false
+  );
+});
+
+test('routing region, publisher origin, reviewed source scope, and item locality remain distinct', () => {
+  const coverage = buildCoverageInventory();
+  for (const source of coverage.subnationalReporting.sources) {
+    assert.equal(source.routingRegion, 'americas');
+    assert.equal(source.scopeType, 'state-province');
+    assert.notEqual(source.routingRegion, source.scopeType);
+    assert.equal(source.primaryCountry, 'US');
+    assert.equal(source.jurisdictionScheme, 'ISO 3166-2');
+    assert.equal(source.jurisdictionIds.length, 1);
+    assert.equal(source.scopeBasis, 'publisher-declared-reviewed');
+  }
+  assert.equal(coverage.localityRules.routingRegionIsGeographicScope, false);
+  assert.equal(coverage.localityRules.publisherOriginIsEventLocality, false);
+  assert.equal(coverage.localityRules.sourceScopeMakesEveryItemLocal, false);
+  assert.equal(coverage.localityRules.subnationalReportingIsPrimaryEvidence, false);
+  assert.equal(coverage.localityRules.localPublisherImpliesIndependentCorroboration, false);
+});
+
+test('subnational provenance cannot substitute country, routing, or label assertions for reviewed jurisdiction evidence', () => {
+  const missingJurisdiction = mutable(SOURCE_PROVENANCE);
+  const minnesota = missingJurisdiction.find(entry => entry.sourceId === 'minnesota-reformer');
+  minnesota.jurisdictionIds = [];
+  assert.ok(validateSourceProvenance(SOURCES, missingJurisdiction).invalidEntries.includes('minnesota-reformer'));
+
+  const missingScopeEvidence = mutable(SOURCE_PROVENANCE);
+  missingScopeEvidence.find(entry => entry.sourceId === 'calmatters').scopeEvidenceUrls = [];
+  assert.ok(validateSourceProvenance(SOURCES, missingScopeEvidence).invalidEntries.includes('calmatters'));
+
+  const unreviewedScope = mutable(SOURCE_PROVENANCE);
+  unreviewedScope.find(entry => entry.sourceId === 'calmatters').scopeBasis = 'unknown';
+  assert.ok(validateSourceProvenance(SOURCES, unreviewedScope).invalidEntries.includes('calmatters'));
+});
+
+test('new local value does not bypass the existing source-admission gate', () => {
+  const minnesota = SOURCE_ADMISSIONS.find(entry => entry.sourceId === 'minnesota-reformer');
+  const calmatters = SOURCE_ADMISSIONS.find(entry => entry.sourceId === 'calmatters');
+  assert.equal(isProductionAdmissible(minnesota), true);
+  assert.equal(isProductionAdmissible(calmatters), true);
+  assert.equal(minnesota.legacy, false);
+  assert.equal(calmatters.legacy, false);
+  assert.equal(minnesota.itemLevelReviewRequired, false);
+  assert.equal(calmatters.itemLevelReviewRequired, false);
+
+  const unsafe = mutable(SOURCE_ADMISSIONS);
+  const unsafeMinnesota = unsafe.find(entry => entry.sourceId === 'minnesota-reformer');
+  unsafeMinnesota.allowedUseStatus = 'permission-required';
+  const validation = validateSourceAdmissions(SOURCES, unsafe);
+  assert.equal(validation.valid, false);
+  assert.ok(validation.unadmittedNewSourceIds.includes('minnesota-reformer'));
+});
+
+test('LAist remains research-only because mixed-origin feed content requires item-level restriction handling', () => {
+  const laist = SOURCE_RESEARCH_CANDIDATES.find(candidate => candidate.candidateId === 'laist-local');
+  assert.ok(laist);
+  assert.equal(laist.disposition, 'research');
+  assert.equal(laist.endpointAuthority, 'first-party');
+  assert.equal(laist.allowedUseStatus, 'verified-public-use');
+  assert.equal(laist.itemLevelReviewRequired, true);
+  assert.equal(SOURCE_ADMISSIONS.some(entry => entry.sourceId === 'laist'), false);
+  assert.equal(SOURCES.some(source => source.name === 'LAist'), false);
+});
+
+test('local reporting observatory is read-only and rejects semantic collapse or research self-promotion', () => {
+  const locality = buildLocalReportingObservatory();
+  assert.equal(validateLocalReportingObservatory(locality).valid, true);
+  assert.equal(locality.sourceCount, 2);
+  assert.equal(locality.jurisdictionCount, 2);
+  assert.equal(locality.rules.observatoryIsAdmissionAuthority, false);
+  assert.equal(locality.rules.automaticSourceWeighting, false);
+
+  const scopeCollapse = mutable(locality);
+  scopeCollapse.sources[0].routingRegion = scopeCollapse.sources[0].scopeType;
+  assert.ok(
+    validateLocalReportingObservatory(scopeCollapse).errors.some(error =>
+      error.endsWith(':routing-scope-collapse')
+    )
+  );
+
+  const itemCollapse = mutable(locality);
+  itemCollapse.rules.sourceScopeMakesEveryItemLocal = true;
+  assert.ok(
+    validateLocalReportingObservatory(itemCollapse).errors.includes(
+      'locality.rules.sourceScopeMakesEveryItemLocal:must-be-false'
+    )
+  );
+
+  const selfPromotion = mutable(locality);
+  selfPromotion.sourceIds.push('laist-local');
+  selfPromotion.sourceCount += 1;
+  assert.ok(
+    validateLocalReportingObservatory(selfPromotion).errors.includes(
+      'locality:laist-local:research-self-promotion'
+    )
+  );
+});

--- a/tests/news-admission-api.test.mjs
+++ b/tests/news-admission-api.test.mjs
@@ -19,7 +19,7 @@ for (const [source, target] of files) copyFileSync(fileURLToPath(new URL(source,
 const news = await import(pathToFileURL(join(functions, 'api', 'news.js')).href);
 const api = await import(pathToFileURL(join(functions, 'api', 'news', 'admission.js')).href);
 
-test('/api/news/admission exposes live review debt, research candidates, and fail-closed rules', async () => {
+test('/api/news/admission exposes live review debt, governed new sources, research candidates, and fail-closed rules', async () => {
   const response = await api.onRequestGet({
     request: new Request('https://globaldeets.com/api/news/admission', {
       headers: { Origin: 'https://globaldeets.com' },
@@ -31,12 +31,15 @@ test('/api/news/admission exposes live review debt, research candidates, and fai
   assert.equal(json.sourceFingerprint, news.SOURCE_FINGERPRINT);
   assert.match(json.admissionFingerprint, /^[0-9a-f]{8}$/);
   assert.equal(json.validation.valid, true);
-  assert.equal(json.summary.totalLiveSources, 19);
-  assert.equal(json.summary.reviewedSources, 2);
+  assert.equal(json.summary.totalLiveSources, 21);
+  assert.equal(json.summary.reviewedSources, 4);
   assert.equal(json.summary.legacyUnreviewedSources, 17);
   assert.deepEqual(json.summary.remediationSourceIds, ['ap', 'guardian']);
-  assert.equal(json.liveAdmissions.length, 19);
-  assert.equal(json.researchCandidates.length, 2);
+  assert.equal(json.liveAdmissions.length, 21);
+  assert.equal(json.researchCandidates.length, 3);
+  assert.ok(json.liveAdmissions.some(entry => entry.sourceId === 'minnesota-reformer' && entry.legacy === false));
+  assert.ok(json.liveAdmissions.some(entry => entry.sourceId === 'calmatters' && entry.legacy === false));
+  assert.ok(json.researchCandidates.some(entry => entry.candidateId === 'laist-local' && entry.itemLevelReviewRequired === true));
   assert.equal(json.rules.newSourcesRequireReviewedAdmission, true);
   assert.equal(json.rules.itemRestrictionsOverrideSourcePermission, true);
   assert.equal(json.rules.endpointAuthorityIsUsagePermission, false);

--- a/tests/news-coverage.test.mjs
+++ b/tests/news-coverage.test.mjs
@@ -18,26 +18,11 @@ mkdirSync(dirname(fixtureCoverageApi), { recursive: true });
 mkdirSync(dirname(fixtureCoverageLib), { recursive: true });
 writeFileSync(join(fixtureFunctions, 'package.json'), '{"type":"module"}\n');
 copyFileSync(fileURLToPath(new URL('../functions/api/news.js', import.meta.url)), fixtureNews);
-copyFileSync(
-  fileURLToPath(new URL('../functions/api/news/coverage.js', import.meta.url)),
-  fixtureCoverageApi
-);
-copyFileSync(
-  fileURLToPath(new URL('../functions/api/news/sources.js', import.meta.url)),
-  fixtureSourcesApi
-);
-copyFileSync(
-  fileURLToPath(new URL('../functions/lib/news-coverage.js', import.meta.url)),
-  fixtureCoverageLib
-);
-copyFileSync(
-  fileURLToPath(new URL('../functions/lib/news-source-provenance.js', import.meta.url)),
-  fixtureProvenanceLib
-);
-copyFileSync(
-  fileURLToPath(new URL('../functions/lib/news-source-admission.js', import.meta.url)),
-  fixtureAdmissionLib
-);
+copyFileSync(fileURLToPath(new URL('../functions/api/news/coverage.js', import.meta.url)), fixtureCoverageApi);
+copyFileSync(fileURLToPath(new URL('../functions/api/news/sources.js', import.meta.url)), fixtureSourcesApi);
+copyFileSync(fileURLToPath(new URL('../functions/lib/news-coverage.js', import.meta.url)), fixtureCoverageLib);
+copyFileSync(fileURLToPath(new URL('../functions/lib/news-source-provenance.js', import.meta.url)), fixtureProvenanceLib);
+copyFileSync(fileURLToPath(new URL('../functions/lib/news-source-admission.js', import.meta.url)), fixtureAdmissionLib);
 
 const newsModule = await import(pathToFileURL(fixtureNews).href);
 const provenanceModule = await import(pathToFileURL(fixtureProvenanceLib).href);
@@ -93,7 +78,7 @@ test('provenance registry maps exactly once to every canonical live source', () 
 
   assert.equal(validation.valid, true);
   assert.equal(SOURCE_PROVENANCE.length, SOURCES.length);
-  assert.equal(SOURCE_PROVENANCE.length, 19);
+  assert.equal(SOURCE_PROVENANCE.length, 21);
   assert.deepEqual(validation.duplicateIds, []);
   assert.deepEqual(validation.missingSourceIds, []);
   assert.deepEqual(validation.orphanSourceIds, []);
@@ -109,9 +94,13 @@ test('provenance registry maps exactly once to every canonical live source', () 
   assert.equal(cna.organizationName, 'CNA');
   assert.equal(cna.ownershipOperator, 'Mediacorp');
 
-  const dawn = SOURCE_PROVENANCE.find(entry => entry.sourceId === 'dawn');
-  assert.equal(dawn.organizationName, 'Dawn');
-  assert.equal(dawn.ownershipOperator, 'Pakistan Herald Publications Private Limited');
+  const minnesota = SOURCE_PROVENANCE.find(entry => entry.sourceId === 'minnesota-reformer');
+  assert.equal(minnesota.geographicScope, 'subnational');
+  assert.deepEqual(minnesota.jurisdictionIds, ['US-MN']);
+
+  const calmatters = SOURCE_PROVENANCE.find(entry => entry.sourceId === 'calmatters');
+  assert.equal(calmatters.geographicScope, 'subnational');
+  assert.deepEqual(calmatters.jurisdictionIds, ['US-CA']);
 });
 
 test('provenance validation rejects missing, orphaned, duplicate, drifted, and invalid records', () => {
@@ -164,30 +153,33 @@ test('coverage inventory is deterministic and enriched from reviewed provenance 
   );
 
   assert.deepEqual(first, second);
-  assert.equal(first.totalSources, 19);
+  assert.equal(first.totalSources, 21);
   assert.equal(first.totalRegions, 7);
   assert.equal(first.totalLanguages, 2);
   assert.equal(first.provenance.valid, true);
-  assert.equal(first.provenance.reviewedSources, 19);
+  assert.equal(first.provenance.reviewedSources, 21);
   assert.deepEqual(first.provenance.unknownOwnershipOperatorSourceIds, []);
   assert.equal(first.admission.valid, true);
-  assert.equal(first.admission.reviewedSources, 2);
+  assert.equal(first.admission.reviewedSources, 4);
   assert.equal(first.admission.legacyUnreviewedSources, 17);
   assert.deepEqual(first.admission.remediationSourceIds, ['ap', 'guardian']);
+  assert.equal(first.subnationalReporting.sourceCount, 2);
+  assert.deepEqual(first.subnationalReporting.jurisdictionIds, ['US-CA', 'US-MN']);
   assert.equal(first.nonEnglishSources.length, 1);
   assert.ok(first.nonEnglishSources.includes('nhk'));
   assert.ok(first.sourceClasses.some(group => group.sourceClass === 'news-agency'));
-  assert.ok(first.geographicScopes.some(group => group.geographicScope === 'national'));
+  assert.ok(first.geographicScopes.some(group => group.geographicScope === 'subnational'));
   assert.ok(first.sourceOriginCountries.some(group => group.country === 'UA'));
 });
 
-test('coverage inventory surfaces evidence, locality, language, and admission blind spots', () => {
+test('coverage inventory surfaces remaining evidence, language, regional, and admission blind spots without claiming no subnational inputs', () => {
   const inventory = buildCoverageInventory(SOURCES, SOURCE_PROVENANCE, SOURCE_ADMISSIONS);
   const gapIds = new Set(inventory.gaps.map(gap => gap.id));
 
   assert.equal(inventory.primarySourceInputs, 0);
   assert.ok(gapIds.has('evidence-role:primary-source-inputs'));
-  assert.ok(gapIds.has('geographic-scope:subnational'));
+  assert.equal(gapIds.has('geographic-scope:subnational'), false);
+  assert.equal(gapIds.has('geographic-scope:subnational-jurisdictions'), false);
   assert.ok(gapIds.has('regional-redundancy:pacific'));
   assert.ok(gapIds.has('portfolio-language-concentration:en'));
   assert.ok(gapIds.has('source-language-diversity:africa'));
@@ -199,7 +191,7 @@ test('coverage inventory surfaces evidence, locality, language, and admission bl
   assert.ok(gapIds.has('source-admission:remediation-required'));
 });
 
-test('coverage gap logic responds to stronger regional, language, primary-source, local, and admission diversity', () => {
+test('coverage gap logic responds to stronger regional, language, primary-source, subnational, and admission diversity', () => {
   const sample = [
     { name: 'A', url: 'https://a.example/rss', region: 'alpha', lang: 'en' },
     { name: 'B', url: 'https://b.example/rss', region: 'alpha', lang: 'fr' },
@@ -212,13 +204,22 @@ test('coverage gap logic responds to stronger regional, language, primary-source
     organizationName: `${source.name} Organization`,
     sourceClass: index === 0 ? 'institution' : 'newsroom',
     evidenceRole: index === 0 ? 'primary-source' : 'reporting',
-    geographicScope: index === 0 ? 'subnational' : 'national',
+    geographicScope: index < 2 ? 'subnational' : 'national',
     primaryCountry: ['AA', 'BB', 'CC', 'DD'][index],
-    locality: 'local',
+    locality: index < 2 ? 'state-province' : 'local',
     sourceLanguages: [source.lang],
     ownershipOperator: `${source.name} Organization`,
     evidenceUrls: [`https://${source.name.toLowerCase()}.example/about`],
     reviewedAt: '2026-09-03',
+    ...(index < 2
+      ? {
+          scopeType: 'state-province',
+          jurisdictionIds: [`AA-${index + 1}`],
+          jurisdictionScheme: 'ISO 3166-2',
+          scopeBasis: 'independently-reviewed',
+          scopeEvidenceUrls: [`https://${source.name.toLowerCase()}.example/scope`],
+        }
+      : {}),
   }));
   const sampleAdmissions = sample.map(reviewedAdmission);
   const inventory = buildCoverageInventory(sample, sampleProvenance, sampleAdmissions);
@@ -228,11 +229,12 @@ test('coverage gap logic responds to stronger regional, language, primary-source
   assert.equal(inventory.totalLanguages, 4);
   assert.equal(inventory.englishSourceShare, 0.25);
   assert.equal(inventory.primarySourceInputs, 1);
+  assert.equal(inventory.subnationalReporting.jurisdictionCount, 2);
   assert.equal(inventory.admission.valid, true);
   assert.equal(inventory.admission.legacyUnreviewedSources, 0);
 });
 
-test('/api/news/coverage exposes source fingerprint, provenance integrity, admission debt, and actionable inventory', async () => {
+test('/api/news/coverage exposes source fingerprint, provenance integrity, admission debt, and governed locality inventory', async () => {
   const response = await getCoverage({ request: request() });
   const json = await response.json();
 
@@ -241,10 +243,14 @@ test('/api/news/coverage exposes source fingerprint, provenance integrity, admis
   assert.equal(json.totalSources, SOURCES.length);
   assert.equal(json.totalRegions, 7);
   assert.equal(json.provenance.valid, true);
-  assert.equal(json.provenance.reviewedSources, 19);
+  assert.equal(json.provenance.reviewedSources, 21);
   assert.equal(json.admission.valid, true);
+  assert.equal(json.admission.reviewedSources, 4);
   assert.equal(json.admission.legacyUnreviewedSources, 17);
   assert.deepEqual(json.admission.remediationSourceIds, ['ap', 'guardian']);
+  assert.equal(json.subnationalReporting.sourceCount, 2);
+  assert.deepEqual(json.subnationalReporting.jurisdictionIds, ['US-CA', 'US-MN']);
+  assert.equal(json.localityRules.routingRegionIsGeographicScope, false);
   assert.ok(Array.isArray(json.sourceClasses));
   assert.ok(Array.isArray(json.evidenceRoles));
   assert.ok(Array.isArray(json.sourceOriginCountries));
@@ -253,7 +259,7 @@ test('/api/news/coverage exposes source fingerprint, provenance integrity, admis
   assert.match(json.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
 
-test('/api/news/sources exposes the reviewed provenance registry and its evidence links', async () => {
+test('/api/news/sources exposes the reviewed provenance registry and explicit subnational scope evidence', async () => {
   const response = await getSources({ request: request('/api/news/sources') });
   const json = await response.json();
 
@@ -261,7 +267,10 @@ test('/api/news/sources exposes the reviewed provenance registry and its evidenc
   assert.equal(json.sourceFingerprint, SOURCE_FINGERPRINT);
   assert.equal(json.validation.valid, true);
   assert.equal(json.totalSources, SOURCES.length);
-  assert.equal(json.sources.length, 19);
+  assert.equal(json.sources.length, 21);
   assert.ok(json.sources.every(source => source.organizationName));
   assert.ok(json.sources.every(source => source.evidenceUrls.every(url => url.startsWith('https://'))));
+  const subnational = json.sources.filter(source => source.geographicScope === 'subnational');
+  assert.equal(subnational.length, 2);
+  assert.deepEqual(subnational.flatMap(source => source.jurisdictionIds).sort(), ['US-CA', 'US-MN']);
 });

--- a/tests/news-source-admission-hardening.test.mjs
+++ b/tests/news-source-admission-hardening.test.mjs
@@ -94,6 +94,6 @@ test('malformed source and admission objects fail validation without throwing', 
     admission.SOURCE_ADMISSIONS
   );
   assert.equal(badSourceResult.valid, false);
-  assert.deepEqual(badSourceResult.invalidCanonicalSources, ['source-index:19', 'source-index:20']);
+  assert.deepEqual(badSourceResult.invalidCanonicalSources, ['source-index:21', 'source-index:22']);
   assert.equal(admission.isProductionAdmissible({ sourceId: 'broken' }), false);
 });

--- a/tests/news-source-admission.test.mjs
+++ b/tests/news-source-admission.test.mjs
@@ -51,18 +51,26 @@ const EXAMPLE_SOURCE = Object.freeze({
   lang: 'en',
 });
 
-test('all 19 live sources have exact admission records and explicit migration state', () => {
+test('21 live sources partition into 19 frozen legacy IDs and two reviewed GD-019 additions', () => {
   const validation = admission.validateSourceAdmissions();
   assert.equal(validation.valid, true);
-  assert.equal(news.SOURCES.length, 19);
-  assert.equal(admission.SOURCE_ADMISSIONS.length, 19);
+  assert.equal(news.SOURCES.length, 21);
+  assert.equal(admission.SOURCE_ADMISSIONS.length, 21);
   assert.equal(admission.LEGACY_SOURCE_IDS.length, 19);
-  assert.equal(new Set(admission.SOURCE_ADMISSIONS.map(entry => entry.sourceId)).size, 19);
-  assert.equal(admission.SOURCE_ADMISSIONS.every(entry => entry.legacy === true), true);
+  assert.equal(new Set(admission.SOURCE_ADMISSIONS.map(entry => entry.sourceId)).size, 21);
+
+  const newEntries = admission.SOURCE_ADMISSIONS.filter(entry => entry.legacy === false);
+  assert.deepEqual(newEntries.map(entry => entry.sourceId).sort(), ['calmatters', 'minnesota-reformer']);
+  assert.equal(newEntries.every(entry => admission.isProductionAdmissible(entry)), true);
   assert.equal(
     admission.SOURCE_ADMISSIONS.every(entry => ['legacy-unreviewed', 'reviewed'].includes(entry.reviewState)),
     true
   );
+  assert.equal(
+    admission.SOURCE_ADMISSIONS.filter(entry => entry.reviewState === 'legacy-unreviewed').length,
+    17
+  );
+
   const nhk = admission.SOURCE_ADMISSIONS.find(entry => entry.sourceId === 'nhk');
   assert.ok(nhk.currentUse.includes('translated-headline-summary'));
   assert.equal(nhk.excerptMaxChars, 280);
@@ -149,14 +157,17 @@ test('item-level restriction overrides broader source-level permission', () => {
 test('research candidates remain queryable but cannot become production by implication', () => {
   const rnz = admission.SOURCE_RESEARCH_CANDIDATES.find(entry => entry.candidateId === 'rnz-pacific');
   const brasil = admission.SOURCE_RESEARCH_CANDIDATES.find(entry => entry.candidateId === 'agencia-brasil');
+  const laist = admission.SOURCE_RESEARCH_CANDIDATES.find(entry => entry.candidateId === 'laist-local');
   assert.equal(rnz.disposition, 'research');
   assert.equal(rnz.allowedUseStatus, 'permission-required');
   assert.equal(brasil.disposition, 'research');
   assert.equal(brasil.allowedUseStatus, 'verified-public-use');
   assert.equal(brasil.itemLevelReviewRequired, true);
   assert.equal(brasil.syndicatedContentBehavior, 'mixed-rights-partner-content');
-  assert.equal(admission.SOURCE_RESEARCH_CANDIDATES.some(entry => entry.name === 'RNZ Pacific'), true);
-  assert.equal(admission.SOURCE_RESEARCH_CANDIDATES.some(entry => entry.name === 'Agencia Brasil'), true);
+  assert.equal(laist.disposition, 'research');
+  assert.equal(laist.allowedUseStatus, 'verified-public-use');
+  assert.equal(laist.itemLevelReviewRequired, true);
+  assert.equal(admission.SOURCE_ADMISSIONS.some(entry => entry.sourceId === 'laist'), false);
 });
 
 test('admission telemetry changes independently of the canonical news feed cache fingerprint', () => {

--- a/tests/observatory-smoke.spec.js
+++ b/tests/observatory-smoke.spec.js
@@ -17,12 +17,12 @@ const fixture = {
     automaticRemediation: false,
   },
   newsCoverage: {
-    totalSources: 19,
+    totalSources: 21,
     totalRegions: 7,
     totalLanguages: 2,
-    englishSourceShare: 18 / 19,
+    englishSourceShare: 20 / 21,
     primarySourceInputs: 0,
-    gapCount: 11,
+    gapCount: 9,
     regions: [
       {
         region: 'pacific',
@@ -32,24 +32,82 @@ const fixture = {
         publisherCount: 1,
       },
       {
-        region: 'global',
+        region: 'americas',
         sourceCount: 4,
-        languageCount: 2,
-        sourceOriginCountryCount: 4,
+        languageCount: 1,
+        sourceOriginCountryCount: 2,
         publisherCount: 4,
+      },
+      {
+        region: 'global',
+        sourceCount: 3,
+        languageCount: 1,
+        sourceOriginCountryCount: 3,
+        publisherCount: 3,
       },
     ],
     sourceOriginCountries: [],
     sourceClasses: [],
     evidenceRoles: [],
-    geographicScopes: [],
+    geographicScopes: [{ geographicScope: 'subnational', sourceCount: 2, sourceIds: ['calmatters', 'minnesota-reformer'] }],
     provenance: { valid: true },
     admission: { valid: true },
   },
+  localReporting: {
+    version: '2026-09-08.1',
+    rules: {
+      routingRegionIsGeographicScope: false,
+      publisherOriginIsEventLocality: false,
+      sourceScopeMakesEveryItemLocal: false,
+      localReportingIsPrimaryEvidence: false,
+      localPublisherImpliesIndependentCorroboration: false,
+      observatoryIsAdmissionAuthority: false,
+      automaticSourceWeighting: false,
+    },
+    sourceCount: 2,
+    sourceIds: ['calmatters', 'minnesota-reformer'],
+    jurisdictionCount: 2,
+    jurisdictionIds: ['US-CA', 'US-MN'],
+    operatorCount: 2,
+    operators: ['CalMatters', 'States Newsroom'],
+    sources: [
+      {
+        sourceId: 'calmatters',
+        routingRegion: 'americas',
+        primaryCountry: 'US',
+        scopeType: 'state-province',
+        jurisdictionScheme: 'ISO 3166-2',
+        jurisdictionIds: ['US-CA'],
+        scopeBasis: 'publisher-declared-reviewed',
+        scopeEvidenceUrls: ['https://calmatters.org/about/'],
+      },
+      {
+        sourceId: 'minnesota-reformer',
+        routingRegion: 'americas',
+        primaryCountry: 'US',
+        scopeType: 'state-province',
+        jurisdictionScheme: 'ISO 3166-2',
+        jurisdictionIds: ['US-MN'],
+        scopeBasis: 'publisher-declared-reviewed',
+        scopeEvidenceUrls: ['https://minnesotareformer.com/about/'],
+      },
+    ],
+    researchCandidates: [
+      {
+        candidateId: 'laist-local',
+        name: 'LAist',
+        disposition: 'research',
+        endpointAuthority: 'first-party',
+        allowedUseStatus: 'verified-public-use',
+        itemLevelReviewRequired: true,
+        blocker: 'mixed-origin feed requires deterministic item-origin restriction handling',
+      },
+    ],
+  },
   sourceRights: {
-    totalLiveSources: 19,
-    reviewedLiveSources: 2,
-    reviewedLiveSourceIds: ['ap', 'guardian'],
+    totalLiveSources: 21,
+    reviewedLiveSources: 4,
+    reviewedLiveSourceIds: ['ap', 'calmatters', 'guardian', 'minnesota-reformer'],
     legacyUnreviewedSources: 17,
     legacyUnreviewedSourceIds: ['bbc-world', 'cna', 'dawn'],
     remediationSourceIds: ['ap', 'guardian'],
@@ -58,6 +116,12 @@ const fixture = {
       {
         candidateId: 'rnz-pacific',
         name: 'RNZ Pacific',
+        disposition: 'research',
+        collectionEligible: false,
+      },
+      {
+        candidateId: 'laist-local',
+        name: 'LAist',
         disposition: 'research',
         collectionEligible: false,
       },
@@ -129,7 +193,7 @@ const fixture = {
   operationalHealth: {
     status: 'unavailable',
     generatedAt: null,
-    totalSources: 19,
+    totalSources: 21,
     healthySources: null,
     degradedSources: null,
     degradedSourceIds: [],
@@ -160,7 +224,7 @@ const fixture = {
       requires: ['manual-review', 'code'],
     },
   ],
-  integrity: { valid: true },
+  integrity: { valid: true, localReporting: { valid: true, errors: [] } },
 };
 
 test.beforeEach(async ({ page }) => {
@@ -181,7 +245,12 @@ test('coverage observatory renders an integrity-valid decomposed intelligence su
   await expect(page.getByText('Integrity validated')).toBeVisible();
   await expect(page.getByText('Legacy rights reviews open')).toBeVisible();
   await expect(page.getByText('Institutional sources collection-eligible')).toBeVisible();
+  await expect(page.getByText('Subnational reporting sources')).toBeVisible();
+  await expect(page.getByText('Reviewed subnational jurisdictions')).toBeVisible();
+  await expect(page.getByText('US-CA · US-MN')).toBeVisible();
+  await expect(page.getByText('LAist — research only')).toBeVisible();
   await expect(page.getByText('News coverage ≠ evidence coverage')).toBeVisible();
+  await expect(page.getByText('Routing region ≠ local scope')).toBeVisible();
   await expect(page.locator('#dossier-list .dossier-card')).toHaveCount(1);
   await expect(page.locator('#gap-list .gap-card')).toHaveCount(2);
   await expect(page.locator('#observatory-error')).toBeHidden();
@@ -194,6 +263,7 @@ test.describe('coverage observatory mobile surface', () => {
     await page.goto('/observatory/coverage/');
     await expect(page.locator('body[data-observatory-ready="true"]')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Explicit gaps' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Reviewed source scope without locality inference' })).toBeVisible();
     const dimensions = await page.evaluate(() => ({
       scrollWidth: document.documentElement.scrollWidth,
       clientWidth: document.documentElement.clientWidth,

--- a/tools/verify-intelligence-prod.js
+++ b/tools/verify-intelligence-prod.js
@@ -96,6 +96,56 @@ function requireCondition(condition, message) {
     'one or more live admissions lack explicit migration state'
   );
 
+  requireCondition(sources.totalSources === 21, 'GD-019 source count changed');
+  const minnesota = admission.liveAdmissions.find(entry => entry.sourceId === 'minnesota-reformer');
+  const calmatters = admission.liveAdmissions.find(entry => entry.sourceId === 'calmatters');
+  for (const [label, entry] of [
+    ['Minnesota Reformer', minnesota],
+    ['CalMatters', calmatters],
+  ]) {
+    requireCondition(Boolean(entry), `${label} admission missing`);
+    requireCondition(entry.legacy === false, `${label} was incorrectly marked legacy`);
+    requireCondition(entry.reviewState === 'reviewed', `${label} admission review state changed`);
+    requireCondition(entry.allowedUseStatus === 'verified-public-use', `${label} usage state changed`);
+    requireCondition(entry.endpointAuthority === 'first-party', `${label} endpoint authority changed`);
+    requireCondition(entry.healthVerificationStatus === 'verified', `${label} admission health review changed`);
+    requireCondition(entry.itemLevelReviewRequired === false, `${label} unexpectedly requires item-level gating`);
+  }
+  const laist = admission.researchCandidates.find(entry => entry.candidateId === 'laist-local');
+  requireCondition(laist?.disposition === 'research', 'LAist research-only disposition changed');
+  requireCondition(laist?.itemLevelReviewRequired === true, 'LAist mixed-origin item blocker disappeared');
+  requireCondition(!admission.liveAdmissions.some(entry => entry.sourceId === 'laist'), 'LAist silently entered live admission');
+
+  requireCondition(coverage.subnationalReporting?.sourceCount === 2, 'GD-019 subnational source count changed');
+  requireCondition(coverage.subnationalReporting?.jurisdictionCount === 2, 'GD-019 subnational jurisdiction count changed');
+  requireCondition(
+    JSON.stringify(coverage.subnationalReporting?.jurisdictionIds || []) === JSON.stringify(['US-CA', 'US-MN']),
+    'GD-019 jurisdiction identities changed'
+  );
+  requireCondition(coverage.subnationalReporting?.operatorCount === 2, 'GD-019 subnational operator diversity changed');
+  requireCondition(coverage.localityRules?.routingRegionIsGeographicScope === false, 'routing region became geographic scope');
+  requireCondition(coverage.localityRules?.publisherOriginIsEventLocality === false, 'publisher origin became event locality');
+  requireCondition(coverage.localityRules?.sourceScopeMakesEveryItemLocal === false, 'source scope became automatic item locality');
+  requireCondition(coverage.localityRules?.subnationalReportingIsPrimaryEvidence === false, 'subnational reporting became primary evidence');
+  requireCondition(coverage.localityRules?.localPublisherImpliesIndependentCorroboration === false, 'local publisher became automatic corroboration');
+  requireCondition(
+    !coverage.gaps.some(gap => gap.id === 'geographic-scope:subnational'),
+    'zero-subnational gap remained after admitted pilot'
+  );
+
+  // Force the canonical news path to initialize the current source-fingerprinted feed/health snapshot,
+  // then verify both newly admitted endpoints returned parsable stories rather than merely HTTP 200.
+  await fetchJson('/api/news?region=americas&limit=100');
+  const newsHealth = await fetchJson('/api/news/health');
+  requireCondition(newsHealth.sourceFingerprint === coverage.sourceFingerprint, 'news health fingerprint disagrees with coverage');
+  requireCondition(newsHealth.totalSources === 21, 'news health source count changed');
+  for (const sourceId of ['minnesota-reformer', 'calmatters']) {
+    const health = newsHealth.sourceHealth?.find(entry => entry.sourceId === sourceId);
+    requireCondition(Boolean(health), `${sourceId} production health record missing`);
+    requireCondition(health.lastError == null, `${sourceId} production feed is degraded: ${health.lastError}`);
+    requireCondition(Number.isInteger(health.storyCount) && health.storyCount > 0, `${sourceId} returned no parsable stories`);
+  }
+
   requireCondition(typeof schema.modelVersion === 'string', 'intelligence model version missing');
   requireCondition(Array.isArray(schema.entityTypes) && schema.entityTypes.includes('place'), 'place entity type missing');
   requireCondition(Array.isArray(schema.eventStatuses) && schema.eventStatuses.includes('disputed'), 'event status contract missing');
@@ -175,7 +225,7 @@ function requireCondition(condition, message) {
   );
 
   console.log(
-    `Intelligence APIs certified: ${sources.totalSources} news sources, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} institutional candidates / ${evidenceSchema.institutionalSources.collectionEligibleSources} governed collection source, acquisition ${acquisition.artifact.artifactId}, admission ${admission.admissionFingerprint}, models ${schema.modelVersion}/${evidenceSchema.modelVersion}, dossier ${dossier.dossierVersion}`
+    `Intelligence APIs certified: ${sources.totalSources} news sources, ${coverage.subnationalReporting.sourceCount} subnational sources / ${coverage.subnationalReporting.jurisdictionCount} jurisdictions, ${coverage.gaps.length} coverage gaps, ${schema.placeSeed.count} place identities, ${evidenceSchema.institutionalSources.reviewedSources} institutional candidates / ${evidenceSchema.institutionalSources.collectionEligibleSources} governed collection source, acquisition ${acquisition.artifact.artifactId}, admission ${admission.admissionFingerprint}, models ${schema.modelVersion}/${evidenceSchema.modelVersion}, dossier ${dossier.dossierVersion}`
   );
 })().catch(error => {
   console.error(`Intelligence API verification failed: ${error.message}`);

--- a/tools/verify-observatory-prod.js
+++ b/tools/verify-observatory-prod.js
@@ -56,6 +56,7 @@ function requireCondition(condition, message) {
   requireCondition(observatory.observatoryId === 'coverage-evidence', 'observatory identity changed');
   requireCondition(typeof observatory.observatoryVersion === 'string', 'observatory version missing');
   requireCondition(observatory.integrity?.valid === true, 'observatory integrity failed');
+  requireCondition(observatory.integrity?.localReporting?.valid === true, 'local reporting integrity failed');
   requireCondition(observatory.rules?.truthScore === false, 'observatory truth score must remain disabled');
   requireCondition(observatory.rules?.editorialVerdict === false, 'observatory editorial verdict must remain disabled');
   requireCondition(observatory.rules?.compositeCoverageScore === false, 'composite coverage score must remain disabled');
@@ -88,6 +89,44 @@ function requireCondition(condition, message) {
   requireCondition(observatory.sourceRights?.reviewedLiveSources === reviewedLive, 'reviewed live source count drifted');
   requireCondition(observatory.sourceRights?.legacyUnreviewedSources === legacyUnreviewed, 'legacy review debt count drifted');
   requireCondition(legacyUnreviewed === 17, 'source-rights review debt baseline changed unexpectedly');
+  requireCondition(sources.totalSources === 21, 'GD-019 live source count changed');
+  requireCondition(reviewedLive === 4, 'GD-019 reviewed live source count changed');
+
+  const subnationalSources = sources.sources.filter(source => source.geographicScope === 'subnational');
+  const subnationalIds = subnationalSources.map(source => source.sourceId).sort();
+  const subnationalJurisdictions = subnationalSources.flatMap(source => source.jurisdictionIds || []).sort();
+  requireCondition(
+    JSON.stringify(subnationalIds) === JSON.stringify(['calmatters', 'minnesota-reformer']),
+    'canonical subnational source identities changed'
+  );
+  requireCondition(
+    JSON.stringify(subnationalJurisdictions) === JSON.stringify(['US-CA', 'US-MN']),
+    'canonical subnational jurisdiction identities changed'
+  );
+  requireCondition(coverage.subnationalReporting?.sourceCount === subnationalSources.length, 'coverage subnational source count disagrees with provenance');
+  requireCondition(coverage.subnationalReporting?.jurisdictionCount === 2, 'coverage subnational jurisdiction count changed');
+  requireCondition(
+    JSON.stringify(coverage.subnationalReporting?.jurisdictionIds || []) === JSON.stringify(['US-CA', 'US-MN']),
+    'coverage subnational jurisdiction IDs changed'
+  );
+  requireCondition(coverage.subnationalReporting?.operatorCount === 2, 'subnational operator diversity changed');
+  requireCondition(coverage.localityRules?.routingRegionIsGeographicScope === false, 'routing region became geographic scope');
+  requireCondition(coverage.localityRules?.publisherOriginIsEventLocality === false, 'publisher origin became event locality');
+  requireCondition(coverage.localityRules?.sourceScopeMakesEveryItemLocal === false, 'source scope became automatic item locality');
+  requireCondition(coverage.localityRules?.subnationalReportingIsPrimaryEvidence === false, 'local reporting became primary evidence');
+  requireCondition(coverage.localityRules?.localPublisherImpliesIndependentCorroboration === false, 'local publisher became automatic corroboration');
+
+  requireCondition(observatory.localReporting?.sourceCount === coverage.subnationalReporting?.sourceCount, 'observatory local source count disagrees with coverage');
+  requireCondition(observatory.localReporting?.jurisdictionCount === coverage.subnationalReporting?.jurisdictionCount, 'observatory locality jurisdiction count disagrees with coverage');
+  requireCondition(observatory.localReporting?.operatorCount === coverage.subnationalReporting?.operatorCount, 'observatory locality operator count disagrees with coverage');
+  requireCondition(observatory.localReporting?.rules?.routingRegionIsGeographicScope === false, 'observatory collapsed routing and local scope');
+  requireCondition(observatory.localReporting?.rules?.sourceScopeMakesEveryItemLocal === false, 'observatory inferred item locality from source scope');
+  requireCondition(observatory.localReporting?.rules?.observatoryIsAdmissionAuthority === false, 'observatory became local source admission authority');
+  requireCondition(observatory.localReporting?.rules?.automaticSourceWeighting === false, 'observatory introduced local source weighting');
+  const laist = observatory.localReporting?.researchCandidates?.find(candidate => candidate.candidateId === 'laist-local');
+  requireCondition(laist?.disposition === 'research', 'LAist research-only disposition changed');
+  requireCondition(laist?.itemLevelReviewRequired === true, 'LAist mixed-origin item review blocker disappeared');
+  requireCondition(!admission.liveAdmissions.some(entry => entry.sourceId === 'laist'), 'LAist silently entered production admission');
 
   requireCondition(
     observatory.institutionalEvidence?.reviewedSources === evidenceSchema.institutionalSources?.reviewedSources,
@@ -133,13 +172,19 @@ function requireCondition(condition, message) {
     observatory.gaps.every(gap => typeof gap.nextAction === 'string' && Array.isArray(gap.requires)),
     'one or more observatory gaps lack operational actions'
   );
+  requireCondition(
+    !coverage.gaps.some(gap => gap.id === 'geographic-scope:subnational'),
+    'obsolete zero-subnational coverage gap remains after GD-019'
+  );
 
   requireCondition(page.includes('data-observatory-id="coverage-evidence"'), 'observatory page identity marker missing');
   requireCondition(page.includes('Coverage &amp; Evidence Observatory'), 'observatory page shell missing');
   requireCondition(page.includes('News coverage ≠ evidence coverage'), 'observatory semantic separation label missing');
+  requireCondition(page.includes('Routing region ≠ local scope'), 'locality semantic separation label missing');
+  requireCondition(page.includes('Reviewed source scope without locality inference'), 'local reporting UI section missing');
 
   console.log(
-    `Coverage & Evidence Observatory certified: ${observatory.newsCoverage.totalSources} live news sources, ${legacyUnreviewed} rights reviews open, ${observatory.institutionalEvidence.reviewedSources} institutional candidates / ${observatory.institutionalEvidence.collectionEligibleSources} governed collection source, ${dossierSummary.unresolvedClaimCount} unresolved claims, ${observatory.gaps.length} explicit gaps`
+    `Coverage & Evidence Observatory certified: ${observatory.newsCoverage.totalSources} live news sources, ${legacyUnreviewed} rights reviews open, ${observatory.localReporting.sourceCount} subnational sources / ${observatory.localReporting.jurisdictionCount} jurisdictions, ${observatory.institutionalEvidence.reviewedSources} institutional candidates / ${observatory.institutionalEvidence.collectionEligibleSources} governed collection source, ${dossierSummary.unresolvedClaimCount} unresolved claims, ${observatory.gaps.length} explicit gaps`
   );
 })().catch(error => {
   console.error(`Coverage & Evidence Observatory verification failed: ${error.message}`);


### PR DESCRIPTION
Closes #32.

## Production boundary

Exact starting baseline: production-certified brand/GD-018 main `1fb3c3160587c3f3c469d72dfabc5870f5cee497`.

This PR adds the first governed subnational reporting inputs without collapsing routing region, publisher origin, reviewed publisher scope, story/event locality, independent corroboration, or primary evidence.

## First pilot

### Minnesota Reformer — US-MN
- operator: States Newsroom
- reviewed scope: `state-province`
- canonical jurisdiction: `US-MN` (ISO 3166-2)
- first-party republisher endpoint: `https://minnesotareformer.com/feed/localFeed`
- States Newsroom documents `/feed/localFeed` as its republisher feed and says it excludes D.C./National team content
- reviewed GlobalDeets use remains headline/link + metadata + bounded excerpt

### CalMatters — US-CA
- operator: CalMatters
- reviewed scope: `state-province`
- canonical jurisdiction: `US-CA` (ISO 3166-2)
- first-party RSS endpoint: `https://calmatters.org/feed/`
- CalMatters explicitly documents free article republication subject to attribution/canonical/edit/commercial restrictions
- GlobalDeets uses headline/link + metadata + bounded excerpt and does not ingest article imagery

### Deliberately not admitted: LAist
LAist remains a visible research-only metro-local candidate. Its current first-party latest feed mixes LAist-originated stories with partner material while its blanket republication permission excludes partner content. It cannot self-promote until deterministic item-origin restriction handling or a narrower authorized feed is established.

## Mechanical boundaries

- routing region ≠ geographic reporting scope
- publisher origin ≠ event locality
- reviewed source scope ≠ automatic item locality
- local reporting ≠ primary institutional evidence
- local publisher ≠ independent corroboration
- observatory ≠ source-admission authority
- no source weighting, quality score, political-bias score, truth score, or locality score

## Canonical architecture

- both new sources enter the existing canonical `SOURCES` list and therefore source/cache/health fingerprinting
- both use the existing fail-closed production admission model as non-legacy reviewed sources
- subnational provenance carries scope type, ISO 3166-2 jurisdiction identity, review basis and scope evidence
- coverage inventory separately reports subnational source/jurisdiction/operator counts
- existing Coverage & Evidence Observatory exposes that contract rather than adding another dashboard
- LAist remains research-only in the existing admission candidate registry

## Hostile coverage

New contracts attack:
- country/routing labels substituting for reviewed jurisdiction evidence
- missing scope evidence
- unknown scope basis
- desired local value bypassing source admission
- source scope becoming automatic story locality
- local reporting becoming primary evidence or automatic corroboration
- observatory authority/automatic source weighting
- LAist research candidate self-promotion

Production verification additionally requires both admitted local feeds to return parsable stories under the exact deployed source fingerprint.

Do not merge until exact-head CI, merged-main CI, Cloudflare deploy, exact-commit health, production intelligence verification, and production observatory verification are green.