### PR TITLE
Brand: implement approved GD moon monogram

### DIFF
--- a/assets/logo-mark.svg
+++ b/assets/logo-mark.svg
@@ -1,46 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
   <title id="title">GlobalDeets GD moon mark</title>
-  <desc id="desc">A transparent circular monogram where a G shapes the left lunar edge and a D shapes the right lunar edge.</desc>
+  <desc id="desc">A transparent circular GD monogram where the G forms the left lunar rim and the D forms the right lunar rim.</desc>
   <defs>
-    <linearGradient id="gd" x1="32" y1="32" x2="224" y2="224" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#00f5ff"/>
-      <stop offset="0.52" stop-color="#65d8ff"/>
-      <stop offset="1" stop-color="#a855f7"/>
+    <linearGradient id="gd" x1="24" y1="24" x2="232" y2="232" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#22e7f1"/>
+      <stop offset="0.42" stop-color="#149bff"/>
+      <stop offset="0.7" stop-color="#194bff"/>
+      <stop offset="1" stop-color="#7c23ff"/>
     </linearGradient>
   </defs>
 
-  <!-- G: the open left-hand lunar rim. -->
+  <!-- G: left lunar rim plus the inward bar and lower central stem. -->
   <path
-    d="M191.5 60.5A96 96 0 1 0 191.5 195.5"
+    d="M114 38C65 38 28 78 28 128s37 90 86 90"
     fill="none"
     stroke="url(#gd)"
-    stroke-width="17"
-    stroke-linecap="round"
+    stroke-width="30"
+    stroke-linecap="butt"
     stroke-linejoin="round"
   />
   <path
-    d="M212 128h-57m57 0v48"
+    d="M76 130h38v88"
     fill="none"
     stroke="url(#gd)"
-    stroke-width="17"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    stroke-width="30"
+    stroke-linecap="butt"
+    stroke-linejoin="miter"
   />
 
-  <!-- D: a clean inner chord and right-hand lunar rim. -->
+  <!-- D: central spine plus the right lunar rim. -->
   <path
-    d="M119 39v178"
+    d="M140 38v180"
     fill="none"
     stroke="url(#gd)"
-    stroke-width="15"
-    stroke-linecap="round"
+    stroke-width="30"
+    stroke-linecap="butt"
   />
   <path
-    d="M119 39c64 0 101 34 101 89s-37 89-101 89"
+    d="M140 38c49 0 88 40 88 90s-39 90-88 90"
     fill="none"
     stroke="url(#gd)"
-    stroke-width="15"
-    stroke-linecap="round"
+    stroke-width="30"
+    stroke-linecap="butt"
     stroke-linejoin="round"
   />
 </svg>


### PR DESCRIPTION
Implements the approved transparent circular GD moon mark as the canonical `assets/logo-mark.svg`.

Visual contract:
- no background canvas
- square 1:1 SVG
- G forms the left lunar rim and inner bar
- D forms the central spine and right lunar rim
- cyan → blue → violet gradient
- flat top/bottom center separation so the mark reads cleanly at small sizes

All existing shared navigation and manifest surfaces already resolve to this canonical SVG, so no parallel logo assets or duplicated markup are introduced.

Do not merge until exact-head CI and browser brand smoke pass.