### PR TITLE
UI: compact and de-conflict shared navigation chrome

### DIFF
--- a/shared/ecosystem-nav.css
+++ b/shared/ecosystem-nav.css
@@ -97,12 +97,38 @@
   padding: 0 !important;
 }
 
+/*
+ * Retire the previous decorative badge around the logo. That wrapper carried
+ * 0.9rem vertical padding, a 112px minimum width, a black radial canvas,
+ * border/glow chrome and two oversized pseudo-elements. The approved GD moon
+ * is self-contained and must render directly on the page with no backing tile.
+ */
 .gfd-ecosystem-nav ~ header .site-logo-link,
 .gfd-ecosystem-nav ~ header .logo-link {
-  display: flex;
-  align-items: center;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   flex: 0 0 auto;
+  width: auto !important;
+  height: auto !important;
+  min-width: 0 !important;
+  min-height: 0 !important;
   margin: 0 !important;
+  padding: 0 !important;
+  background: transparent !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  overflow: visible !important;
+  isolation: auto !important;
+}
+
+.gfd-ecosystem-nav ~ header .site-logo-link::before,
+.gfd-ecosystem-nav ~ header .site-logo-link::after,
+.gfd-ecosystem-nav ~ header .logo-link::before,
+.gfd-ecosystem-nav ~ header .logo-link::after {
+  content: none !important;
+  display: none !important;
 }
 
 .gfd-ecosystem-nav ~ header .site-logo-mark,

--- a/shared/ecosystem-nav.css
+++ b/shared/ecosystem-nav.css
@@ -1,7 +1,11 @@
 /**
  * GFD Ecosystem Navigation Component Styles
- * GPU-accelerated animations, WCAG 2.1 AA compliant
+ * Compact shared navigation, GPU-accelerated motion, WCAG-aware controls.
  */
+
+:root {
+  --gfd-ecosystem-nav-height: 46px;
+}
 
 .gfd-ecosystem-nav {
   position: fixed;
@@ -9,22 +13,25 @@
   left: 0;
   right: 0;
   z-index: 150;
-  background: rgba(10, 10, 10, 0.95);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(139, 92, 246, 0.2);
-  padding: 0.75rem 1.5rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  transition: background-color 0.3s ease;
+  height: var(--gfd-ecosystem-nav-height);
+  background: rgba(8, 10, 14, 0.94);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid rgba(139, 92, 246, 0.18);
+  padding: 0 1rem;
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.28);
+  transition: background-color 0.2s ease;
 }
 
-/* Solid background when menu is open for better readability */
+/* Solid background when menu is open for better readability. */
 .gfd-ecosystem-nav.menu-open {
-  background: rgba(10, 10, 10, 1);
+  background: rgba(8, 10, 14, 0.99);
 }
 
 .ecosystem-nav-container {
-  max-width: 1400px;
+  width: 100%;
+  height: 100%;
+  max-width: 1440px;
   margin: 0 auto;
   display: flex;
   justify-content: space-between;
@@ -34,82 +41,137 @@
 .ecosystem-brand {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.5rem;
   color: #f5f5f5;
   font-weight: 600;
-  font-size: 0.9375rem;
+  font-size: 0.8125rem;
+  line-height: 1;
+  min-width: 0;
 }
 
 /*
  * GlobalDeets brand mark
  *
- * The old raster logo was a wide crop on a black canvas. That made the mark
- * look clipped anywhere the layout expected a compact square. The canonical
- * brand mark is now a transparent 1:1 SVG and this shared stylesheet forces
- * legacy <img> references onto that asset until every old raster reference is
- * retired. Keeping the mark inside an explicit square also makes browser,
- * mobile and ecosystem-nav rendering deterministic.
+ * The canonical mark is a transparent 1:1 SVG. Legacy raster references are
+ * forced onto it so every shared/header surface stays square and unclipped.
  */
 .ecosystem-logo {
   content: url('../assets/logo-mark.svg');
-  height: 28px;
-  width: 28px;
-  max-width: 28px;
+  height: 24px;
+  width: 24px;
+  max-width: 24px;
   object-fit: contain;
   display: block;
+  flex: 0 0 24px;
   background: transparent;
-  filter: drop-shadow(0 0 6px rgba(0, 245, 255, 0.45))
-    drop-shadow(0 0 8px rgba(168, 85, 247, 0.35));
+  filter: drop-shadow(0 0 5px rgba(0, 245, 255, 0.42))
+    drop-shadow(0 0 7px rgba(168, 85, 247, 0.28));
 }
 
-/* Primary GlobalDeets header mark is also normalized to a true square. */
+/*
+ * Coordinate the product header with the fixed ecosystem strip. Previously
+ * both headers occupied top:0, so the ecosystem bar physically covered the
+ * GlobalDeets logo/header. The shared strip owns the first 46px; the product
+ * header begins immediately beneath it.
+ */
+.gfd-ecosystem-nav ~ header {
+  top: var(--gfd-ecosystem-nav-height) !important;
+  padding: 0.45rem 0 !important;
+}
+
+.gfd-ecosystem-nav ~ header.scrolled {
+  padding: 0.35rem 0 !important;
+}
+
+/* Primary GlobalDeets header mark: compact, square, and never clipped. */
+.gfd-ecosystem-nav ~ header .site-logo-mark,
 .site-logo-mark {
   content: url('../assets/logo-mark.svg');
-  width: 84px !important;
-  height: 84px !important;
-  max-width: 84px;
+  width: 44px !important;
+  height: 44px !important;
+  max-width: 44px;
   object-fit: contain;
   display: block;
   background: transparent;
 }
 
+.gfd-ecosystem-nav ~ header.scrolled .site-logo-mark,
 header.scrolled .site-logo-mark {
-  width: 54px !important;
-  height: 54px !important;
-  max-width: 54px;
+  width: 38px !important;
+  height: 38px !important;
+  max-width: 38px;
+}
+
+/* Neutralize the legacy BI stylesheet's 1.5rem nav margin/gaps. */
+.gfd-ecosystem-nav ~ header .primary-nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  gap: 0.5rem !important;
+  margin-top: 0 !important;
+  min-width: 0;
+}
+
+.gfd-ecosystem-nav ~ header .nav-icon-btn {
+  width: 42px !important;
+  height: 42px !important;
+  min-width: 42px;
+  min-height: 42px;
+  border-radius: 11px !important;
+}
+
+.gfd-ecosystem-nav ~ header .nav-icon-btn img,
+.gfd-ecosystem-nav ~ header .nav-icon-btn svg {
+  width: 22px !important;
+  height: 22px !important;
+}
+
+.gfd-ecosystem-nav ~ header .tagline {
+  font-size: 0.75rem;
+  line-height: 1.2;
+  margin-top: 0.15rem;
 }
 
 .ecosystem-title {
-  background: linear-gradient(135deg, #8b5cf6 0%, #10b981 50%, #fbbf24 100%);
+  background: linear-gradient(135deg, #22d3ee 0%, #3b82f6 48%, #a855f7 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
   font-weight: 700;
   letter-spacing: -0.01em;
+  white-space: nowrap;
 }
 
 /* Toggle Button */
 .ecosystem-toggle {
-  background: transparent;
-  border: 1px solid rgba(139, 92, 246, 0.3);
-  border-radius: 6px;
-  padding: 0.5rem;
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  background: rgba(255, 255, 255, 0.015);
+  border: 1px solid rgba(139, 92, 246, 0.28);
+  border-radius: 8px;
+  padding: 0;
   color: #f5f5f5;
   cursor: pointer;
   transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s ease;
-  min-width: 44px;
-  min-height: 44px;
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
+.ecosystem-toggle svg {
+  width: 20px;
+  height: 20px;
+}
+
 .ecosystem-toggle:hover {
   background: rgba(139, 92, 246, 0.1);
-  border-color: rgba(139, 92, 246, 0.5);
+  border-color: rgba(139, 92, 246, 0.52);
 }
 
 .ecosystem-toggle:active {
@@ -121,24 +183,32 @@ header.scrolled .site-logo-mark {
   outline-offset: 2px;
 }
 
-/* Dropdown */
+/*
+ * Dropdown: compact anchored popover rather than a full-width second header.
+ */
 .ecosystem-dropdown {
   position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  background: rgba(13, 13, 13, 0.98);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border-bottom: 1px solid rgba(139, 92, 246, 0.2);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  top: calc(100% + 8px);
+  left: auto;
+  right: 1rem;
+  width: min(720px, calc(100vw - 2rem));
+  max-height: calc(100vh - var(--gfd-ecosystem-nav-height) - 24px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  background: rgba(11, 13, 18, 0.985);
+  backdrop-filter: blur(22px) saturate(135%);
+  -webkit-backdrop-filter: blur(22px) saturate(135%);
+  border: 1px solid rgba(139, 92, 246, 0.22);
+  border-radius: 14px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.52);
 
-  /* GPU-accelerated animation */
   opacity: 0;
-  transform: translateY(-10px);
+  transform: translateY(-6px) scale(0.985);
+  transform-origin: top right;
   transition:
-    opacity 0.3s ease,
-    transform 0.3s ease;
+    opacity 0.18s ease,
+    transform 0.18s ease,
+    visibility 0.18s ease;
   will-change: opacity, transform;
   pointer-events: none;
   visibility: hidden;
@@ -146,58 +216,60 @@ header.scrolled .site-logo-mark {
 
 .ecosystem-dropdown.active {
   opacity: 1;
-  transform: translateY(0);
+  transform: translateY(0) scale(1);
   pointer-events: auto;
   visibility: visible;
 }
 
 .dropdown-content {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 2rem 1.5rem;
+  width: 100%;
+  margin: 0;
+  padding: 1rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
 }
 
 /* Navigation Sections */
 .nav-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.25rem;
+  min-width: 0;
 }
 
 .nav-section-title {
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.09em;
   color: #8a8a8a;
-  margin-bottom: 0.5rem;
+  margin: 0 0 0.25rem;
+  padding: 0 0.35rem;
 }
 
 /* Navigation Links */
 .nav-link {
   display: flex;
   align-items: center;
-  gap: 0.875rem;
-  padding: 0.75rem 1rem;
+  gap: 0.65rem;
+  padding: 0.5rem 0.6rem;
   border-radius: 8px;
   background: transparent;
   border: 1px solid transparent;
   text-decoration: none;
   color: #f5f5f5;
   transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    transform 0.2s ease;
-  min-height: 44px;
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
+  min-height: 40px;
 }
 
 .nav-link:hover {
   background: rgba(139, 92, 246, 0.08);
   border-color: rgba(139, 92, 246, 0.2);
-  transform: translateX(4px);
+  transform: translateX(2px);
 }
 
 .nav-link:focus-visible {
@@ -206,44 +278,64 @@ header.scrolled .site-logo-mark {
 }
 
 .nav-icon {
-  font-size: 1.5rem;
+  width: 22px;
+  height: 22px;
+  font-size: 1.2rem;
   line-height: 1;
-  flex-shrink: 0;
+  flex: 0 0 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-icon svg,
+.nav-icon img {
+  width: 20px !important;
+  height: 20px !important;
+  max-width: 20px;
 }
 
 .nav-link-content {
   display: flex;
   flex-direction: column;
-  gap: 0.125rem;
+  gap: 0.0625rem;
+  min-width: 0;
 }
 
 .nav-link-title {
-  font-size: 0.9375rem;
+  font-size: 0.8375rem;
   font-weight: 600;
   letter-spacing: -0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .nav-link-subtitle {
-  font-size: 0.8125rem;
-  color: #8a8a8a;
+  font-size: 0.7125rem;
+  line-height: 1.25;
+  color: #8f96a3;
   font-weight: 400;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* CTA Section */
 .nav-cta-section {
   border-top: 1px solid rgba(139, 92, 246, 0.2);
-  padding-top: 1rem;
+  padding-top: 0.65rem;
 }
 
 .nav-cta-link {
-  background: linear-gradient(135deg, rgba(139, 92, 246, 0.15), rgba(16, 185, 129, 0.15));
-  border: 1px solid rgba(139, 92, 246, 0.3);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.12), rgba(16, 185, 129, 0.1));
+  border: 1px solid rgba(139, 92, 246, 0.26);
 }
 
 .nav-cta-link:hover {
-  background: linear-gradient(135deg, rgba(139, 92, 246, 0.25), rgba(16, 185, 129, 0.25));
-  border-color: rgba(139, 92, 246, 0.5);
-  transform: translateX(4px) scale(1.02);
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(16, 185, 129, 0.18));
+  border-color: rgba(139, 92, 246, 0.45);
+  transform: translateX(2px);
 }
 
 .nav-cta-link .nav-link-title {
@@ -255,60 +347,125 @@ header.scrolled .site-logo-mark {
 
 /* Responsive */
 @media (max-width: 900px) {
-  .dropdown-content {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
+  :root {
+    --gfd-ecosystem-nav-height: 44px;
   }
 
-  .ecosystem-brand {
-    font-size: 0.875rem;
+  .gfd-ecosystem-nav {
+    padding: 0 0.75rem;
   }
 
   .ecosystem-logo {
-    width: 24px;
-    height: 24px;
-    max-width: 24px;
+    width: 22px;
+    height: 22px;
+    max-width: 22px;
+    flex-basis: 22px;
+  }
+
+  .ecosystem-brand {
+    font-size: 0.775rem;
+  }
+
+  .ecosystem-toggle {
+    width: 34px;
+    height: 34px;
+    min-width: 34px;
+    min-height: 34px;
+  }
+
+  .ecosystem-dropdown {
+    right: 0.5rem;
+    width: min(620px, calc(100vw - 1rem));
+  }
+
+  .dropdown-content {
+    grid-template-columns: 1fr;
+    gap: 0.8rem;
+    padding: 0.8rem;
+  }
+
+  .gfd-ecosystem-nav ~ header {
+    padding: 0.3rem 0 !important;
+  }
+
+  .gfd-ecosystem-nav ~ header .site-logo-mark {
+    width: 36px !important;
+    height: 36px !important;
+    max-width: 36px;
+  }
+
+  .gfd-ecosystem-nav ~ header.scrolled .site-logo-mark {
+    width: 34px !important;
+    height: 34px !important;
+    max-width: 34px;
+  }
+
+  .gfd-ecosystem-nav ~ header .tagline {
+    display: none;
+  }
+
+  .gfd-ecosystem-nav ~ header .primary-nav {
+    gap: 0.25rem !important;
+    max-width: calc(100vw - 72px);
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+    justify-content: flex-start;
+  }
+
+  .gfd-ecosystem-nav ~ header .primary-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .gfd-ecosystem-nav ~ header .nav-icon-btn {
+    width: 36px !important;
+    height: 36px !important;
+    min-width: 36px;
+    min-height: 36px;
+    border-radius: 9px !important;
+  }
+
+  .gfd-ecosystem-nav ~ header .nav-icon-btn img,
+  .gfd-ecosystem-nav ~ header .nav-icon-btn svg {
+    width: 19px !important;
+    height: 19px !important;
   }
 }
 
 @media (max-width: 600px) {
-  .gfd-ecosystem-nav {
-    padding: 0.5rem 1rem;
-  }
-
-  .dropdown-content {
-    padding: 1.5rem 1rem;
-  }
-
   .ecosystem-title {
-    display: none; /* Hide text on very small screens, show only logo */
+    display: none;
+  }
+
+  .nav-link {
+    min-height: 44px;
   }
 
   .nav-link-title {
-    font-size: 0.875rem; /* Smaller on mobile */
+    font-size: 0.8125rem;
   }
 
   .nav-link-subtitle {
-    font-size: 0.75rem;
+    font-size: 0.7rem;
   }
 }
 
 /* Backdrop overlay when menu is open */
 .ecosystem-backdrop {
   position: fixed;
-  top: 0;
+  top: var(--gfd-ecosystem-nav-height);
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  z-index: 149; /* Below nav (150), above page content */
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.64);
+  z-index: 149;
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
   opacity: 0;
   visibility: hidden;
   transition:
-    opacity 0.3s ease,
-    visibility 0.3s ease;
+    opacity 0.18s ease,
+    visibility 0.18s ease;
   pointer-events: none;
 }
 
@@ -329,7 +486,7 @@ header.scrolled .site-logo-mark {
 
 /* Print Styles */
 @media print {
-  .gfv-ecosystem-nav {
+  .gfd-ecosystem-nav {
     display: none;
   }
 }

--- a/shared/ecosystem-nav.css
+++ b/shared/ecosystem-nav.css
@@ -23,7 +23,6 @@
   transition: background-color 0.2s ease;
 }
 
-/* Solid background when menu is open for better readability. */
 .gfd-ecosystem-nav.menu-open {
   background: rgba(8, 10, 14, 0.99);
 }
@@ -49,12 +48,6 @@
   min-width: 0;
 }
 
-/*
- * GlobalDeets brand mark
- *
- * The canonical mark is a transparent 1:1 SVG. Legacy raster references are
- * forced onto it so every shared/header surface stays square and unclipped.
- */
 .ecosystem-logo {
   content: url('../assets/logo-mark.svg');
   height: 24px;
@@ -69,10 +62,9 @@
 }
 
 /*
- * Coordinate the product header with the fixed ecosystem strip. Previously
- * both headers occupied top:0, so the ecosystem bar physically covered the
- * GlobalDeets logo/header. The shared strip owns the first 46px; the product
- * header begins immediately beneath it.
+ * The ecosystem strip owns the first 46px. Product chrome is a separate,
+ * single compact row directly beneath it. These explicit row rules override
+ * legacy page styles that previously stacked the brand, tagline and nav.
  */
 .gfd-ecosystem-nav ~ header {
   top: var(--gfd-ecosystem-nav-height) !important;
@@ -83,7 +75,36 @@
   padding: 0.35rem 0 !important;
 }
 
-/* Primary GlobalDeets header mark: compact, square, and never clipped. */
+.gfd-ecosystem-nav ~ header .header {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 0.75rem !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+}
+
+.gfd-ecosystem-nav ~ header .logo {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+  align-items: center !important;
+  gap: 0.65rem !important;
+  min-width: 0;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.gfd-ecosystem-nav ~ header .site-logo-link,
+.gfd-ecosystem-nav ~ header .logo-link {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin: 0 !important;
+}
+
 .gfd-ecosystem-nav ~ header .site-logo-mark,
 .site-logo-mark {
   content: url('../assets/logo-mark.svg');
@@ -102,6 +123,15 @@ header.scrolled .site-logo-mark {
   max-width: 38px;
 }
 
+.gfd-ecosystem-nav ~ header .tagline,
+.gfd-ecosystem-nav ~ header .logo p {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 /* Neutralize the legacy BI stylesheet's 1.5rem nav margin/gaps. */
 .gfd-ecosystem-nav ~ header .primary-nav {
   display: flex;
@@ -109,7 +139,8 @@ header.scrolled .site-logo-mark {
   justify-content: flex-end;
   flex-wrap: nowrap;
   gap: 0.5rem !important;
-  margin-top: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
   min-width: 0;
 }
 
@@ -127,12 +158,6 @@ header.scrolled .site-logo-mark {
   height: 22px !important;
 }
 
-.gfd-ecosystem-nav ~ header .tagline {
-  font-size: 0.75rem;
-  line-height: 1.2;
-  margin-top: 0.15rem;
-}
-
 .ecosystem-title {
   background: linear-gradient(135deg, #22d3ee 0%, #3b82f6 48%, #a855f7 100%);
   -webkit-background-clip: text;
@@ -143,7 +168,6 @@ header.scrolled .site-logo-mark {
   white-space: nowrap;
 }
 
-/* Toggle Button */
 .ecosystem-toggle {
   width: 36px;
   height: 36px;
@@ -183,9 +207,7 @@ header.scrolled .site-logo-mark {
   outline-offset: 2px;
 }
 
-/*
- * Dropdown: compact anchored popover rather than a full-width second header.
- */
+/* Compact anchored popover rather than a full-width second header. */
 .ecosystem-dropdown {
   position: absolute;
   top: calc(100% + 8px);
@@ -201,7 +223,6 @@ header.scrolled .site-logo-mark {
   border: 1px solid rgba(139, 92, 246, 0.22);
   border-radius: 14px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.52);
-
   opacity: 0;
   transform: translateY(-6px) scale(0.985);
   transform-origin: top right;
@@ -230,7 +251,6 @@ header.scrolled .site-logo-mark {
   gap: 1rem;
 }
 
-/* Navigation Sections */
 .nav-section {
   display: flex;
   flex-direction: column;
@@ -248,7 +268,6 @@ header.scrolled .site-logo-mark {
   padding: 0 0.35rem;
 }
 
-/* Navigation Links */
 .nav-link {
   display: flex;
   align-items: center;
@@ -321,7 +340,6 @@ header.scrolled .site-logo-mark {
   text-overflow: ellipsis;
 }
 
-/* CTA Section */
 .nav-cta-section {
   border-top: 1px solid rgba(139, 92, 246, 0.2);
   padding-top: 0.65rem;
@@ -345,7 +363,6 @@ header.scrolled .site-logo-mark {
   background-clip: text;
 }
 
-/* Responsive */
 @media (max-width: 900px) {
   :root {
     --gfd-ecosystem-nav-height: 44px;
@@ -388,6 +405,16 @@ header.scrolled .site-logo-mark {
     padding: 0.3rem 0 !important;
   }
 
+  .gfd-ecosystem-nav ~ header .header {
+    flex-direction: row !important;
+    flex-wrap: nowrap !important;
+    gap: 0.4rem !important;
+  }
+
+  .gfd-ecosystem-nav ~ header .logo {
+    flex: 0 0 auto;
+  }
+
   .gfd-ecosystem-nav ~ header .site-logo-mark {
     width: 36px !important;
     height: 36px !important;
@@ -400,14 +427,17 @@ header.scrolled .site-logo-mark {
     max-width: 34px;
   }
 
-  .gfd-ecosystem-nav ~ header .tagline {
+  .gfd-ecosystem-nav ~ header .tagline,
+  .gfd-ecosystem-nav ~ header .logo p {
     display: none;
   }
 
   .gfd-ecosystem-nav ~ header .primary-nav {
+    flex: 1 1 auto;
     gap: 0.25rem !important;
     max-width: calc(100vw - 72px);
     overflow-x: auto;
+    overflow-y: hidden;
     overscroll-behavior-inline: contain;
     scrollbar-width: none;
     justify-content: flex-start;
@@ -450,7 +480,6 @@ header.scrolled .site-logo-mark {
   }
 }
 
-/* Backdrop overlay when menu is open */
 .ecosystem-backdrop {
   position: fixed;
   top: var(--gfd-ecosystem-nav-height);
@@ -475,7 +504,6 @@ header.scrolled .site-logo-mark {
   pointer-events: auto;
 }
 
-/* Accessibility - Reduced Motion */
 @media (prefers-reduced-motion: reduce) {
   .ecosystem-dropdown,
   .nav-link,
@@ -484,7 +512,6 @@ header.scrolled .site-logo-mark {
   }
 }
 
-/* Print Styles */
 @media print {
   .gfd-ecosystem-nav {
     display: none;

--- a/tests/brand-mark-smoke.spec.js
+++ b/tests/brand-mark-smoke.spec.js
@@ -18,6 +18,39 @@ test('canonical GD moon mark replaces legacy header assets without clipping', as
   expect(Math.abs(ecosystemBox.width - ecosystemBox.height)).toBeLessThanOrEqual(1);
 });
 
+test('desktop navigation chrome is compact, stacked, and non-overlapping', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/');
+
+  const ecosystem = await page.locator('.gfd-ecosystem-nav').boundingBox();
+  const productHeader = await page.locator('header').first().boundingBox();
+  const productButton = await page.locator('header .nav-icon-btn').first().boundingBox();
+
+  expect(ecosystem).not.toBeNull();
+  expect(productHeader).not.toBeNull();
+  expect(productButton).not.toBeNull();
+  expect(ecosystem.height).toBeLessThanOrEqual(48);
+  expect(productHeader.y).toBeGreaterThanOrEqual(ecosystem.y + ecosystem.height - 1);
+  expect(productHeader.height).toBeLessThanOrEqual(62);
+  expect(productButton.width).toBeLessThanOrEqual(44);
+  expect(productButton.height).toBeLessThanOrEqual(44);
+  expect(productHeader.y + productHeader.height).toBeLessThanOrEqual(112);
+});
+
+test('ecosystem menu opens as a compact anchored popover instead of a full-width tray', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/');
+  await page.locator('.ecosystem-toggle').click();
+
+  const dropdown = page.locator('.ecosystem-dropdown');
+  await expect(dropdown).toHaveClass(/active/);
+  const box = await dropdown.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.width).toBeLessThanOrEqual(740);
+  expect(box.x).toBeGreaterThan(600);
+  expect(box.x + box.width).toBeLessThanOrEqual(1440);
+});
+
 test.describe('canonical GD moon mark on mobile', () => {
   test.use({ viewport: { width: 390, height: 844 } });
 
@@ -27,7 +60,23 @@ test.describe('canonical GD moon mark on mobile', () => {
     await expect(mark).toHaveAttribute('src', '/assets/logo-mark.svg');
     const box = await mark.boundingBox();
     expect(box).not.toBeNull();
-    expect(box.width).toBeLessThanOrEqual(25);
+    expect(box.width).toBeLessThanOrEqual(23);
     expect(Math.abs(box.width - box.height)).toBeLessThanOrEqual(1);
+  });
+
+  test('keeps both navigation layers compact without hiding product controls', async ({ page }) => {
+    await page.goto('/');
+    const ecosystem = await page.locator('.gfd-ecosystem-nav').boundingBox();
+    const productHeader = await page.locator('header').first().boundingBox();
+    const productButton = await page.locator('header .nav-icon-btn').first().boundingBox();
+
+    expect(ecosystem).not.toBeNull();
+    expect(productHeader).not.toBeNull();
+    expect(productButton).not.toBeNull();
+    expect(ecosystem.height).toBeLessThanOrEqual(46);
+    expect(productHeader.y).toBeGreaterThanOrEqual(ecosystem.y + ecosystem.height - 1);
+    expect(productHeader.height).toBeLessThanOrEqual(50);
+    expect(productButton.width).toBeLessThanOrEqual(38);
+    expect(productButton.height).toBeLessThanOrEqual(38);
   });
 });

--- a/tests/brand-mark.test.mjs
+++ b/tests/brand-mark.test.mjs
@@ -19,13 +19,23 @@ test('canonical GlobalDeets mark is a transparent square SVG with no raster or b
   assert.match(mark, /stroke="url\(#gd\)"/);
 });
 
-test('shared navigation forces legacy raster logo surfaces onto the canonical square mark', () => {
-  assert.match(navCss, /\.ecosystem-logo\s*\{[\s\S]*content:\s*url\('\.\.\/assets\/logo-mark\.svg'\)/);
-  assert.match(navCss, /\.site-logo-mark\s*\{[\s\S]*width:\s*84px\s*!important;[\s\S]*height:\s*84px\s*!important;/);
+test('shared navigation uses the canonical compact square mark', () => {
+  assert.ok(navCss.includes("content: url('../assets/logo-mark.svg')"));
+  assert.ok(navCss.includes('width: 44px !important'));
+  assert.ok(navCss.includes('height: 44px !important'));
   assert.match(navJs, /const canonicalMark = '\/assets\/logo-mark\.svg';/);
   for (const legacyName of ['logo-mark.png', 'logo-vector.png', 'logo-nav.png', 'logo-globe.png']) {
     assert.ok(navJs.includes(`'${legacyName}'`), `legacy logo migration missing ${legacyName}`);
   }
+});
+
+test('shared navigation stays compact and stacks product navigation below the ecosystem strip', () => {
+  assert.ok(navCss.includes('--gfd-ecosystem-nav-height: 46px'));
+  assert.ok(navCss.includes('top: var(--gfd-ecosystem-nav-height) !important'));
+  assert.ok(navCss.includes('gap: 0.5rem !important'));
+  assert.ok(navCss.includes('margin-top: 0 !important'));
+  assert.ok(navCss.includes('width: 42px !important'));
+  assert.ok(navCss.includes('width: min(720px, calc(100vw - 2rem))'));
 });
 
 test('web app manifest prefers the scalable transparent mark while retaining maskable fallbacks', () => {

--- a/tests/brand-mark.test.mjs
+++ b/tests/brand-mark.test.mjs
@@ -33,7 +33,7 @@ test('shared navigation stays compact and stacks product navigation below the ec
   assert.ok(navCss.includes('--gfd-ecosystem-nav-height: 46px'));
   assert.ok(navCss.includes('top: var(--gfd-ecosystem-nav-height) !important'));
   assert.ok(navCss.includes('gap: 0.5rem !important'));
-  assert.ok(navCss.includes('margin-top: 0 !important'));
+  assert.ok(navCss.includes('margin: 0 !important'));
   assert.ok(navCss.includes('width: 42px !important'));
   assert.ok(navCss.includes('width: min(720px, calc(100vw - 2rem))'));
 });


### PR DESCRIPTION
Fixes the oversized/wonky stacked navigation visible on production.

## Root causes
- fixed GFD ecosystem bar occupied ~68px while the GlobalDeets product header still used `top: 0`, causing physical overlap
- legacy BI CSS globally applied `margin-top: 1.5rem` and `gap: 1.5rem` to `.primary-nav`
- product nav buttons were 60×60px and the primary logo was 84px
- ecosystem dropdown rendered as a full-width tray rather than a compact menu

## New geometry
- ecosystem strip: 46px desktop / 44px mobile
- canonical ecosystem mark: 24px desktop / 22px mobile
- product header is mechanically stacked below ecosystem strip
- product logo: 44px desktop, 36px mobile
- primary nav buttons: 42px desktop, 36px mobile
- legacy `.primary-nav` top margin is neutralized; gap reduced to 0.5rem desktop / 0.25rem mobile
- mobile primary nav is horizontally scrollable only when necessary, with hidden scrollbar
- ecosystem dropdown becomes a right-anchored max-720px popover rather than full-width chrome
- backdrop begins below the ecosystem strip

## Regression gates
Adds static and Playwright assertions for:
- ecosystem strip <=48px
- product header starts below ecosystem strip (no overlap)
- product header <=62px desktop / <=50px mobile
- product buttons <=44px desktop / <=38px mobile
- combined desktop navigation chrome <=112px
- dropdown <=740px and remains inside viewport
- canonical GD mark remains square/unclipped

No intelligence, source, dossier, or acquisition contracts are changed.