### PR TITLE
GD-020: expose live consumer trust and coverage signals

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,9 @@ const filterStatus = document.getElementById('filterStatus');
 const addProjectBtn = document.getElementById('addProjectBtn');
 const exportBtn = document.getElementById('exportBtn');
 const loadingIndicator = document.getElementById('loadingIndicator');
+const API_BASE = ['localhost', '127.0.0.1'].includes(location.hostname)
+  ? 'https://globaldeets.com'
+  : '';
 
 // Debounce helper
 function debounce(func, wait) {
@@ -19,15 +22,15 @@ function debounce(func, wait) {
 
 // Show/hide loading
 function showLoading() {
-  loadingIndicator.classList.add('active');
+  loadingIndicator?.classList.add('active');
 }
 function hideLoading() {
-  loadingIndicator.classList.remove('active');
+  loadingIndicator?.classList.remove('active');
 }
 
 // Check performance
 function checkPerformance() {
-  if (projects.length > 50) {
+  if (typeof projects !== 'undefined' && projects.length > 50) {
     showLoading();
     setTimeout(hideLoading, 300);
   }
@@ -35,7 +38,7 @@ function checkPerformance() {
 
 // Export projects
 function exportProjectsList() {
-  const filtered = projects; // Could use window.filteredProjects if modules expose it
+  const filtered = typeof projects === 'undefined' ? [] : projects;
   const blob = new Blob([JSON.stringify(filtered, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
@@ -44,6 +47,94 @@ function exportProjectsList() {
   link.click();
   URL.revokeObjectURL(url);
   if (window.showToast) window.showToast('Projects exported successfully!', 'success');
+}
+
+function getHomepageMetric(label) {
+  return [...document.querySelectorAll('.dm-stat')].find(
+    stat => stat.querySelector('.dm-stat-label')?.textContent.trim() === label
+  );
+}
+
+function setHomepageMetric(metric, value, label) {
+  if (!metric) return;
+  const valueNode = metric.querySelector('.dm-stat-value');
+  const labelNode = metric.querySelector('.dm-stat-label');
+  if (valueNode) valueNode.textContent = String(value);
+  if (labelNode && label) labelNode.textContent = label;
+}
+
+function ensureHomepageTrustLinks() {
+  const actions = document.querySelector('.featured-platform .platform-actions');
+  if (!actions) return;
+
+  const links = [
+    {
+      href: '/observatory/coverage/',
+      label: 'Coverage & Evidence Observatory',
+      className: 'btn-sample',
+    },
+    {
+      href: '/dossiers/santa-ynez-pipeline/',
+      label: 'Open Evidence Dossier',
+      className: 'btn-sample',
+    },
+  ];
+
+  links.forEach(({ href, label, className }) => {
+    if (actions.querySelector(`a[href="${href}"]`)) return;
+    const link = document.createElement('a');
+    link.href = href;
+    link.className = className;
+    link.textContent = label;
+    actions.appendChild(link);
+  });
+}
+
+function replaceHomepageTrustCopy() {
+  // These two old metrics were not backed by the current intelligence contract.
+  // Replace them immediately, even if observability APIs are temporarily unavailable.
+  setHomepageMetric(getHomepageMetric('Webcams'), '—', 'Local/State Sources');
+  setHomepageMetric(getHomepageMetric('Paywalls'), '—', 'Open Coverage Gaps');
+
+  const staleHealthItem = [...document.querySelectorAll('.industry-feature')].find(feature =>
+    feature.textContent.includes('Archives and source health coming next')
+  );
+  if (staleHealthItem) {
+    const check = staleHealthItem.querySelector('.feature-check');
+    staleHealthItem.textContent = '';
+    if (check) staleHealthItem.appendChild(check);
+    staleHealthItem.appendChild(
+      document.createTextNode(' Source health, provenance, and coverage gaps are inspectable now')
+    );
+  }
+}
+
+async function hydrateHomepageTrustSurface() {
+  replaceHomepageTrustCopy();
+  ensureHomepageTrustLinks();
+
+  const liveSourcesMetric = getHomepageMetric('Live Sources');
+  const regionsMetric = getHomepageMetric('Regions');
+  const localSourcesMetric = getHomepageMetric('Local/State Sources');
+  const gapsMetric = getHomepageMetric('Open Coverage Gaps');
+
+  if (!liveSourcesMetric && !regionsMetric && !localSourcesMetric && !gapsMetric) return;
+
+  try {
+    const response = await fetch(`${API_BASE}/api/news/coverage`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const coverage = await response.json();
+
+    setHomepageMetric(liveSourcesMetric, coverage.totalSources ?? '—');
+    setHomepageMetric(regionsMetric, coverage.totalRegions ?? '—');
+    setHomepageMetric(localSourcesMetric, coverage.subnationalReporting?.sourceCount ?? '—');
+    setHomepageMetric(gapsMetric, Array.isArray(coverage.gaps) ? coverage.gaps.length : '—');
+  } catch (error) {
+    // Fail open: the homepage remains usable and links to the observatory stay available.
+    console.warn('GlobalDeets coverage snapshot unavailable:', error);
+  }
 }
 
 // Attach listeners
@@ -87,10 +178,11 @@ window.addEventListener('scroll', () => {
 
 // Initialize
 function init() {
-  if (window.renderProjects) window.renderProjects(projects);
-  if (window.updateStats) window.updateStats(projects);
+  if (window.renderProjects && typeof projects !== 'undefined') window.renderProjects(projects);
+  if (window.updateStats && typeof projects !== 'undefined') window.updateStats(projects);
   attachEventListeners();
   checkPerformance();
+  hydrateHomepageTrustSurface();
   // UI effects module will auto-init when available
 }
 

--- a/news.js
+++ b/news.js
@@ -1,6 +1,8 @@
 /**
  * GlobalDeets — News Feed Page Renderer
- * Fetches /api/news and renders region-filtered news cards
+ * Fetches /api/news and renders region-filtered news cards.
+ * Consumer trust signals are hydrated independently so observability failures
+ * never block the core source-linked news experience.
  */
 (function () {
   'use strict';
@@ -31,9 +33,11 @@
   // Init
   // -------------------------------------------------------------------------
   function init() {
+    prepareTrustSurface();
     renderTabs();
     bindSearch();
     loadNews(true);
+    hydrateTrustSurface();
 
     document.getElementById('load-more-btn')?.addEventListener('click', () => loadNews(false));
   }
@@ -47,6 +51,119 @@
       renderVisibleCards();
       updateStatus();
     });
+  }
+
+  // -------------------------------------------------------------------------
+  // Consumer trust / observability surface
+  // -------------------------------------------------------------------------
+  function prepareTrustSurface() {
+    const subtitle = document.querySelector('.news-page-subtitle');
+    if (subtitle) {
+      subtitle.textContent =
+        'Live source-linked headlines across seven routing regions. Original publisher links stay visible; freshness, provenance, and coverage gaps are inspectable.';
+    }
+
+    const tagline = document.querySelector('.logo .tagline');
+    if (tagline) tagline.textContent = 'World News · Source-Linked · Coverage Visible';
+
+    const sourceNote = document.querySelector('.news-sources-note');
+    if (sourceNote) sourceNote.textContent = 'Source inventory loading…';
+
+    if (!document.getElementById('news-trust-bar')) {
+      const tools = document.querySelector('.news-tools');
+      if (tools) {
+        const trustBar = document.createElement('div');
+        trustBar.id = 'news-trust-bar';
+        trustBar.className = 'news-status-bar';
+        trustBar.setAttribute('aria-label', 'Source coverage and freshness');
+
+        const sourceCount = document.createElement('span');
+        sourceCount.id = 'news-source-count';
+        sourceCount.textContent = 'Source contract loading…';
+
+        const health = document.createElement('span');
+        health.id = 'news-health-status';
+        health.setAttribute('aria-live', 'polite');
+        health.textContent = 'Health snapshot loading…';
+
+        const links = document.createElement('span');
+        links.className = 'news-sources-note';
+
+        const observatoryLink = document.createElement('a');
+        observatoryLink.href = '/observatory/coverage/';
+        observatoryLink.textContent = 'Coverage & Evidence Observatory →';
+
+        const separator = document.createTextNode(' · ');
+
+        const dossierLink = document.createElement('a');
+        dossierLink.href = '/dossiers/santa-ynez-pipeline/';
+        dossierLink.textContent = 'Evidence dossier';
+
+        links.append(observatoryLink, separator, dossierLink);
+        trustBar.append(sourceCount, health, links);
+        tools.insertAdjacentElement('afterend', trustBar);
+      }
+    }
+  }
+
+  async function fetchJson(path) {
+    const response = await fetch(`${API_BASE}${path}`, { headers: { Accept: 'application/json' } });
+    if (!response.ok) throw new Error(`${path}: HTTP ${response.status}`);
+    return response.json();
+  }
+
+  async function hydrateTrustSurface() {
+    const [sourcesResult, healthResult] = await Promise.allSettled([
+      fetchJson('/api/news/sources'),
+      fetchJson('/api/news/health'),
+    ]);
+
+    const sourceCount = document.getElementById('news-source-count');
+    const sourceNote = document.querySelector('.news-sources-note:not(#news-trust-bar .news-sources-note)');
+
+    if (sourcesResult.status === 'fulfilled') {
+      const sourceData = sourcesResult.value;
+      const sources = Array.isArray(sourceData.sources) ? sourceData.sources : [];
+      if (sourceCount) {
+        sourceCount.textContent = `${sourceData.totalSources ?? sources.length} source endpoints in the live contract`;
+      }
+      if (sourceNote) {
+        const names = sources.map(source => source.name).filter(Boolean);
+        sourceNote.textContent = names.length
+          ? `Sources: ${names.join(' · ')}`
+          : 'Source inventory is available in the Coverage & Evidence Observatory.';
+      }
+    } else {
+      if (sourceCount) sourceCount.textContent = 'Source inventory temporarily unavailable';
+      if (sourceNote) {
+        sourceNote.textContent = 'Source inventory is available in the Coverage & Evidence Observatory.';
+      }
+      console.warn('GlobalDeets source inventory unavailable:', sourcesResult.reason);
+    }
+
+    const healthNode = document.getElementById('news-health-status');
+    if (healthResult.status === 'fulfilled') {
+      const health = healthResult.value;
+      if (healthNode) {
+        const healthy = Number.isFinite(health.healthySources) ? health.healthySources : '—';
+        const total = Number.isFinite(health.totalSources) ? health.totalSources : '—';
+        healthNode.textContent = `${healthy}/${total} endpoints healthy · checked ${formatSnapshotTime(health.generatedAt)}`;
+      }
+    } else {
+      if (healthNode) healthNode.textContent = 'Health snapshot temporarily unavailable';
+      console.warn('GlobalDeets health snapshot unavailable:', healthResult.reason);
+    }
+  }
+
+  function formatSnapshotTime(iso) {
+    if (!iso) return 'time unavailable';
+    const date = new Date(iso);
+    const ageMs = Date.now() - date.getTime();
+    if (Number.isNaN(ageMs)) return 'time unavailable';
+    if (ageMs < 60_000) return 'just now';
+    if (ageMs < 3_600_000) return `${Math.max(1, Math.round(ageMs / 60_000))}m ago`;
+    if (ageMs < 86_400_000) return `${Math.round(ageMs / 3_600_000)}h ago`;
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   }
 
   // -------------------------------------------------------------------------
@@ -89,7 +206,6 @@
 
     const grid = document.getElementById('news-grid');
     const loadBtn = document.getElementById('load-more-btn');
-    const status = document.getElementById('news-status');
 
     if (reset && grid) {
       grid.innerHTML = '<div class="news-skeleton"></div>'.repeat(6);

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -31,26 +31,67 @@ const newsFixture = {
       published: '2026-05-25T09:15:00Z',
     },
   ],
-  sourceHealth: [
-    {
-      id: 'reuters',
-      name: 'Reuters',
-      url: 'https://www.reuters.com/world/',
-      region: 'global',
-      fetched: 1,
-      lastError: null,
-      stale: false,
-    },
-    {
-      id: 'bbc-world',
-      name: 'BBC World',
-      url: 'https://www.bbc.com/news/world',
-      region: 'europe',
-      fetched: 1,
-      lastError: null,
-      stale: false,
-    },
+};
+
+const coverageFixture = {
+  generatedAt: '2026-09-12T15:30:00.000Z',
+  sourceFingerprint: 'fixture-gd020',
+  totalSources: 21,
+  totalRegions: 7,
+  totalLanguages: 2,
+  englishSourceShare: 0.9524,
+  nonEnglishSources: ['nhk'],
+  primarySourceInputs: 0,
+  subnationalReporting: {
+    sourceCount: 2,
+    sourceIds: ['calmatters', 'minnesota-reformer'],
+    jurisdictionCount: 2,
+    jurisdictionIds: ['US-CA', 'US-MN'],
+  },
+  gaps: [
+    { id: 'portfolio-language-concentration:en', severity: 'high' },
+    { id: 'source-admission:legacy-review-backlog', severity: 'high' },
+    { id: 'source-admission:remediation-required', severity: 'high' },
   ],
+};
+
+const sourcesFixture = {
+  sourceFingerprint: 'fixture-gd020',
+  reviewedAt: '2026-09-08',
+  validation: { valid: true },
+  totalSources: 21,
+  sources: [
+    { sourceId: 'bbc-world', name: 'BBC World' },
+    { sourceId: 'ap', name: 'AP' },
+    { sourceId: 'guardian', name: 'Guardian' },
+    { sourceId: 'al-jazeera', name: 'Al Jazeera' },
+    { sourceId: 'anadolu-agency', name: 'Anadolu Agency' },
+    { sourceId: 'dw', name: 'DW' },
+    { sourceId: 'france-24', name: 'France 24' },
+    { sourceId: 'kyiv-independent', name: 'Kyiv Independent' },
+    { sourceId: 'ukrinform', name: 'Ukrinform' },
+    { sourceId: 'nhk', name: 'NHK' },
+    { sourceId: 'yonhap', name: 'Yonhap' },
+    { sourceId: 'the-hindu', name: 'The Hindu' },
+    { sourceId: 'cna', name: 'CNA' },
+    { sourceId: 'dawn', name: 'Dawn' },
+    { sourceId: 'npr', name: 'NPR' },
+    { sourceId: 'mercopress', name: 'Mercopress' },
+    { sourceId: 'minnesota-reformer', name: 'Minnesota Reformer' },
+    { sourceId: 'calmatters', name: 'CalMatters' },
+    { sourceId: 'abc-australia', name: 'ABC Australia' },
+    { sourceId: 'premium-times', name: 'Premium Times' },
+    { sourceId: 'the-east-african', name: 'The East African' },
+  ],
+};
+
+const healthFixture = {
+  generatedAt: new Date().toISOString(),
+  sourceFingerprint: 'fixture-gd020',
+  cacheAgeSeconds: 15,
+  healthySources: 20,
+  totalSources: 21,
+  sourceHealth: [],
 };
 
 const dossierFixture = {
@@ -171,22 +212,23 @@ const dossierFixture = {
   unknowns: ['The final appellate outcome remains unresolved.'],
 };
 
-test.beforeEach(async ({ page }) => {
-  await page.route('**/api/news**', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(newsFixture),
-    });
-  });
+async function fulfillNewsApi(route) {
+  const url = new URL(route.request().url());
+  let fixture = newsFixture;
 
-  await page.route('https://globaldeets.com/api/news**', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(newsFixture),
-    });
+  if (url.pathname === '/api/news/coverage') fixture = coverageFixture;
+  if (url.pathname === '/api/news/sources') fixture = sourcesFixture;
+  if (url.pathname === '/api/news/health') fixture = healthFixture;
+
+  await route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(fixture),
   });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/news**', fulfillNewsApi);
 
   await page.route('**/api/intelligence/dossiers/santa-ynez-pipeline', async route => {
     await route.fulfill({
@@ -204,9 +246,22 @@ test('homepage loads the primary GlobalDeets surface', async ({ page }) => {
   await expect(page.getByRole('navigation', { name: 'Primary navigation' })).toBeVisible();
   await expect(page.locator('#globe-hero-container')).toBeVisible();
   await expect(page.getByRole('heading', { name: /The Earth,\s*Right Now\./i })).toBeVisible();
+  await expect(page.locator('.dm-stat').filter({ hasText: 'Live Sources' })).toContainText('21');
+  await expect(page.locator('.dm-stat').filter({ hasText: 'Regions' })).toContainText('7');
+  await expect(page.locator('.dm-stat').filter({ hasText: 'Local/State Sources' })).toContainText('2');
+  await expect(page.locator('.dm-stat').filter({ hasText: 'Open Coverage Gaps' })).toContainText('3');
+  await expect(page.getByRole('link', { name: 'Coverage & Evidence Observatory' })).toHaveAttribute(
+    'href',
+    '/observatory/coverage/'
+  );
+  await expect(page.getByRole('link', { name: 'Open Evidence Dossier' })).toHaveAttribute(
+    'href',
+    '/dossiers/santa-ynez-pipeline/'
+  );
+  await expect(page.getByText(/0 Paywalls/i)).toHaveCount(0);
 });
 
-test('news page renders feed and avoids the hard failure state', async ({ page }) => {
+test('news page renders feed and exposes live source transparency', async ({ page }) => {
   await page.goto('/news.html');
 
   await expect(page.getByRole('heading', { name: /World News Feed/i })).toBeVisible();
@@ -215,6 +270,41 @@ test('news page renders feed and avoids the hard failure state', async ({ page }
   await expect(page.locator('#news-grid .news-card')).toHaveCount(3);
   await expect(page.locator('.news-error')).toHaveCount(0);
   await expect(page.getByText(/Unable to load news feed/i)).toHaveCount(0);
+  await expect(page.locator('#news-source-count')).toHaveText('21 source endpoints in the live contract');
+  await expect(page.locator('#news-health-status')).toContainText('20/21 endpoints healthy');
+  await expect(page.locator('.news-status-bar').filter({ hasText: 'Sources:' })).toContainText(
+    'Minnesota Reformer'
+  );
+  await expect(page.locator('.news-status-bar').filter({ hasText: 'Sources:' })).toContainText(
+    'CalMatters'
+  );
+  await expect(page.getByRole('link', { name: 'Coverage & Evidence Observatory →' })).toHaveAttribute(
+    'href',
+    '/observatory/coverage/'
+  );
+});
+
+test('news trust endpoints fail open without taking down the feed', async ({ page }) => {
+  await page.unroute('**/api/news**');
+  await page.route('**/api/news**', async route => {
+    const url = new URL(route.request().url());
+    if (url.pathname === '/api/news/sources' || url.pathname === '/api/news/health') {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: '{}' });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(newsFixture),
+    });
+  });
+
+  await page.goto('/news.html');
+
+  await expect(page.locator('#news-grid .news-card')).toHaveCount(3);
+  await expect(page.locator('#news-source-count')).toHaveText('Source inventory temporarily unavailable');
+  await expect(page.locator('#news-health-status')).toHaveText('Health snapshot temporarily unavailable');
+  await expect(page.locator('.news-error')).toHaveCount(0);
 });
 
 test('globe page loads with the canvas hero surface present', async ({ page }) => {


### PR DESCRIPTION
Closes #36

## What changes
- hydrates homepage source, region, reviewed subnational-source, and open-gap metrics from the canonical `/api/news/coverage` contract
- replaces the unsupported `0 Paywalls` metric with measured coverage-gap state
- replaces stale “source health coming next” copy at runtime with the shipped observability capability
- adds direct homepage routes to the Coverage & Evidence Observatory and the first evidence dossier
- hydrates World News source inventory from `/api/news/sources`
- exposes a compact endpoint-health/freshness snapshot from `/api/news/health`
- links World News directly to the observatory and evidence dossier
- keeps trust/observability calls fail-open so the core feed remains usable if those endpoints are unavailable
- adds Playwright coverage for the live trust surface and the fail-open case

## Deliberate boundary
This PR does **not** add truth, bias, reliability, or editorial scores. It also does not rewrite the source/evidence governance model.

Static SEO/JSON-LD still contains older portfolio-era language; that cleanup remains explicit follow-on debt rather than being mixed into this consumer trust tranche.