### PR TITLE
SEC-001: harden donation and session endpoints

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,13 +1,14 @@
 // Cloudflare Pages Functions Middleware
-// Applies security headers to all responses
+// Applies security headers to API/payment responses routed through Functions.
+// Static pages are governed separately by the root `_headers` policy.
 
 const BASE_SECURITY_HEADERS = {
   'Content-Security-Policy':
-    "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https: blob:; connect-src 'self' https:; font-src 'self' data: https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
   'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
   'X-Frame-Options': 'DENY',
   'X-Content-Type-Options': 'nosniff',
-  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Referrer-Policy': 'no-referrer',
   'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
 };
 

--- a/functions/create-checkout.js
+++ b/functions/create-checkout.js
@@ -3,185 +3,135 @@
  *
  * Endpoint: POST /create-checkout
  *
- * Handles Stripe Checkout Session creation for donations
- * - One-time donations
- * - Recurring monthly subscriptions
- * - Custom amounts (minimum $5)
- *
- * Required Environment Variables:
- * - STRIPE: Stripe live secret key (sk_live_...)
+ * Handles Stripe Checkout Session creation for donations.
+ * Required environment variable: STRIPE
  */
 
 const STRIPE_API_VERSION = '2025-04-10';
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'https://goodflippindesign.com',
+  'https://www.goodflippindesign.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+function corsHeaders(request) {
+  const origin = request?.headers?.get('Origin');
+  const headers = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    Vary: 'Origin',
+  };
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+  }
+  return headers;
+}
+
+function originIsAllowed(request) {
+  const origin = request?.headers?.get('Origin');
+  return !origin || ALLOWED_ORIGINS.has(origin);
+}
+
+function json(body, status, request) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: corsHeaders(request),
+  });
+}
 
 export async function onRequestPost(context) {
+  const { request, env } = context;
+
+  if (!originIsAllowed(request)) {
+    return json({ error: 'Origin not allowed' }, 403, request);
+  }
+
+  const stripeSecret = env?.STRIPE;
+  if (!stripeSecret) {
+    console.error('STRIPE environment variable not set');
+    return json({ error: 'Payment system configuration error' }, 500, request);
+  }
+
   try {
-    // Get Stripe secret key from environment variables
-    const STRIPE_SECRET_KEY = context.env.STRIPE;
+    const { amount, type } = await request.json();
+    const numericAmount = Number(amount);
 
-    if (!STRIPE_SECRET_KEY) {
-      console.error('STRIPE environment variable not set');
-      return new Response(
-        JSON.stringify({
-          error: 'Payment system configuration error',
-          details: 'Missing Stripe credentials',
-        }),
-        {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    }
-
-    const { amount, type } = await context.request.json();
-
-    // Validate inputs
-    if (!amount || amount < 5) {
-      return new Response(JSON.stringify({ error: 'Minimum donation is $5' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
+    if (!Number.isFinite(numericAmount) || numericAmount < 5 || numericAmount > 100000) {
+      return json({ error: 'Donation amount must be between $5 and $100,000' }, 400, request);
     }
 
     if (!['one-time', 'recurring'].includes(type)) {
-      return new Response(JSON.stringify({ error: 'Invalid donation type' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return json({ error: 'Invalid donation type' }, 400, request);
     }
 
-    // Create Checkout Session
-    const session = await createCheckoutSession(amount, type, STRIPE_SECRET_KEY);
-
-    return new Response(JSON.stringify({ sessionId: session.id, url: session.url }), {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-    });
+    const session = await createCheckoutSession(numericAmount, type, stripeSecret);
+    return json({ sessionId: session.id, url: session.url }, 200, request);
   } catch (error) {
     console.error('Checkout error:', error);
-    return new Response(
-      JSON.stringify({
-        error: 'Failed to create checkout session',
-        details: error.message,
-      }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return json({ error: 'Failed to create checkout session' }, 500, request);
   }
 }
 
-async function createCheckoutSession(amount, type, STRIPE_SECRET_KEY) {
+async function createCheckoutSession(amount, type, stripeSecret) {
   const amountInCents = Math.round(amount * 100);
+  const recurring = type === 'recurring';
+  const name = recurring
+    ? 'Monthly Support for Good Flippin Design'
+    : 'Support Good Flippin Design';
+  const description = recurring
+    ? 'Sustaining monthly contribution to fund free AI education, cultural preservation, and civic tech'
+    : 'One-time contribution to fund free AI education, cultural preservation, and civic tech';
 
-  const lineItems =
-    type === 'recurring'
-      ? [
-          {
-            price_data: {
-              currency: 'usd',
-              product_data: {
-                name: 'Monthly Support for Good Flippin Design',
-                description:
-                  'Sustaining monthly contribution to fund free AI education, cultural preservation, and civic tech',
-              },
-              unit_amount: amountInCents,
-              recurring: {
-                interval: 'month',
-              },
-            },
-            quantity: 1,
-          },
-        ]
-      : [
-          {
-            price_data: {
-              currency: 'usd',
-              product_data: {
-                name: 'Support Good Flippin Design',
-                description:
-                  'One-time contribution to fund free AI education, cultural preservation, and civic tech',
-              },
-              unit_amount: amountInCents,
-            },
-            quantity: 1,
-          },
-        ];
-
-  const sessionData = {
-    payment_method_types: ['card'],
-    line_items: lineItems,
-    mode: type === 'recurring' ? 'subscription' : 'payment',
+  const body = new URLSearchParams({
+    mode: recurring ? 'subscription' : 'payment',
     success_url:
       'https://www.goodflippindesign.com/donate/success?session_id={CHECKOUT_SESSION_ID}',
     cancel_url: 'https://www.goodflippindesign.com/donate?canceled=true',
     billing_address_collection: 'auto',
-    metadata: {
-      donation_type: type,
-      amount: amount.toString(),
-    },
-  };
+    'payment_method_types[0]': 'card',
+    'line_items[0][price_data][currency]': 'usd',
+    'line_items[0][price_data][product_data][name]': name,
+    'line_items[0][price_data][product_data][description]': description,
+    'line_items[0][price_data][unit_amount]': String(amountInCents),
+    'line_items[0][quantity]': '1',
+    'metadata[donation_type]': type,
+    'metadata[amount]': amount.toString(),
+  });
 
-  // Call Stripe API
+  if (recurring) {
+    body.set('line_items[0][price_data][recurring][interval]', 'month');
+  }
+
   const response = await fetch('https://api.stripe.com/v1/checkout/sessions', {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+      Authorization: `Bearer ${stripeSecret}`,
       'Content-Type': 'application/x-www-form-urlencoded',
       'Stripe-Version': STRIPE_API_VERSION,
     },
-    body: new URLSearchParams({
-      mode: sessionData.mode,
-      success_url: sessionData.success_url,
-      cancel_url: sessionData.cancel_url,
-      billing_address_collection: sessionData.billing_address_collection,
-      'payment_method_types[0]': 'card',
-      ...(type === 'recurring'
-        ? {
-            'line_items[0][price_data][currency]': 'usd',
-            'line_items[0][price_data][product_data][name]':
-              lineItems[0].price_data.product_data.name,
-            'line_items[0][price_data][product_data][description]':
-              lineItems[0].price_data.product_data.description,
-            'line_items[0][price_data][unit_amount]': amountInCents,
-            'line_items[0][price_data][recurring][interval]': 'month',
-            'line_items[0][quantity]': 1,
-          }
-        : {
-            'line_items[0][price_data][currency]': 'usd',
-            'line_items[0][price_data][product_data][name]':
-              lineItems[0].price_data.product_data.name,
-            'line_items[0][price_data][product_data][description]':
-              lineItems[0].price_data.product_data.description,
-            'line_items[0][price_data][unit_amount]': amountInCents,
-            'line_items[0][quantity]': 1,
-          }),
-      'metadata[donation_type]': type,
-      'metadata[amount]': amount.toString(),
-    }).toString(),
+    body: body.toString(),
   });
 
   if (!response.ok) {
-    const errorData = await response.text();
-    throw new Error(`Stripe API error: ${response.status} - ${errorData}`);
+    console.error(`Stripe checkout creation failed with status ${response.status}`);
+    throw new Error('Stripe checkout creation failed');
   }
 
-  return await response.json();
+  return response.json();
 }
 
-// Handle OPTIONS for CORS
-export async function onRequestOptions() {
+export async function onRequestOptions(context) {
+  const request = context?.request;
+  const headers = corsHeaders(request);
+  headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS';
+  headers['Access-Control-Allow-Headers'] = 'Content-Type';
+  headers['Access-Control-Max-Age'] = '86400';
+
   return new Response(null, {
-    status: 204,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'Access-Control-Max-Age': '86400',
-    },
+    status: originIsAllowed(request) ? 204 : 403,
+    headers,
   });
 }

--- a/functions/get-session.js
+++ b/functions/get-session.js
@@ -3,85 +3,113 @@
  *
  * Endpoint: GET /get-session?session_id={CHECKOUT_SESSION_ID}
  *
- * Returns donation details for the success page
+ * Returns the minimum non-PII donation details required by the success page.
+ * Required environment variable: STRIPE
  */
 
-const STRIPE_SECRET_KEY = 'mk_1So71wBL2ppdbQKqalkrbvd0';
-const STRIPE_API_VERSION = '2023-10-16';
+const STRIPE_API_VERSION = '2025-04-10';
+const ALLOWED_ORIGINS = new Set([
+  'https://globaldeets.com',
+  'https://www.globaldeets.com',
+  'https://goodflippindesign.com',
+  'https://www.goodflippindesign.com',
+  'http://localhost:5500',
+  'http://127.0.0.1:5500',
+]);
+
+function corsHeaders(request) {
+  const origin = request?.headers?.get('Origin');
+  const headers = {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    Vary: 'Origin',
+  };
+  if (origin && ALLOWED_ORIGINS.has(origin)) {
+    headers['Access-Control-Allow-Origin'] = origin;
+  }
+  return headers;
+}
+
+function originIsAllowed(request) {
+  const origin = request?.headers?.get('Origin');
+  return !origin || ALLOWED_ORIGINS.has(origin);
+}
+
+function json(body, status, request) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: corsHeaders(request),
+  });
+}
 
 export async function onRequestGet(context) {
+  const { request, env } = context;
+
+  if (!originIsAllowed(request)) {
+    return json({ error: 'Origin not allowed' }, 403, request);
+  }
+
+  const stripeSecret = env?.STRIPE;
+  if (!stripeSecret) {
+    console.error('STRIPE environment variable not set');
+    return json({ error: 'Payment system configuration error' }, 500, request);
+  }
+
   try {
-    const url = new URL(context.request.url);
+    const url = new URL(request.url);
     const sessionId = url.searchParams.get('session_id');
 
     if (!sessionId) {
-      return new Response(JSON.stringify({ error: 'Missing session_id parameter' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return json({ error: 'Missing session_id parameter' }, 400, request);
     }
 
-    // Retrieve Checkout Session from Stripe
     const response = await fetch(
-      `https://api.stripe.com/v1/checkout/sessions/${sessionId}?expand[]=line_items`,
+      `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(sessionId)}`,
       {
         method: 'GET',
         headers: {
-          Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+          Authorization: `Bearer ${stripeSecret}`,
           'Stripe-Version': STRIPE_API_VERSION,
         },
       }
     );
 
     if (!response.ok) {
-      const errorData = await response.text();
-      throw new Error(`Stripe API error: ${response.status} - ${errorData}`);
+      console.error(`Stripe session retrieval failed with status ${response.status}`);
+      return json({ error: 'Failed to retrieve session' }, 502, request);
     }
 
     const session = await response.json();
+    const amountTotal = Number(session.amount_total);
+    const created = Number(session.created);
 
-    // Extract relevant data
-    const sessionData = {
-      amount: session.amount_total / 100, // Convert cents to dollars
-      currency: session.currency.toUpperCase(),
-      customerEmail: session.customer_details?.email || null,
-      customerName: session.customer_details?.name || null,
-      paymentStatus: session.payment_status,
-      mode: session.mode, // 'payment' or 'subscription'
-      createdAt: new Date(session.created * 1000).toISOString(),
-    };
-
-    return new Response(JSON.stringify(sessionData), {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
+    return json(
+      {
+        amount: Number.isFinite(amountTotal) ? amountTotal / 100 : null,
+        currency:
+          typeof session.currency === 'string' ? session.currency.toUpperCase() : null,
+        paymentStatus: session.payment_status || null,
+        mode: session.mode || null,
+        createdAt: Number.isFinite(created) ? new Date(created * 1000).toISOString() : null,
       },
-    });
+      200,
+      request
+    );
   } catch (error) {
     console.error('Session retrieval error:', error);
-    return new Response(
-      JSON.stringify({
-        error: 'Failed to retrieve session',
-        details: error.message,
-      }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return json({ error: 'Failed to retrieve session' }, 500, request);
   }
 }
 
-// Handle OPTIONS for CORS
-export async function onRequestOptions() {
+export async function onRequestOptions(context) {
+  const request = context?.request;
+  const headers = corsHeaders(request);
+  headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS';
+  headers['Access-Control-Allow-Headers'] = 'Content-Type';
+  headers['Access-Control-Max-Age'] = '86400';
+
   return new Response(null, {
-    status: 204,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'Access-Control-Max-Age': '86400',
-    },
+    status: originIsAllowed(request) ? 204 : 403,
+    headers,
   });
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "generate-icons": "node generate-icons.js",
     "health:prod": "node health-prod.js",
     "health:prod:json": "node health-prod.js --json",
-    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/institutional-evidence-acquisition.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs tests/local-reporting-observatory.test.mjs tests/brand-mark.test.mjs",
+    "test:functions": "node --test tests/news-functions.test.mjs tests/news-coverage.test.mjs tests/news-source-admission.test.mjs tests/news-source-admission-hardening.test.mjs tests/news-admission-api.test.mjs tests/intelligence-model.test.mjs tests/claim-evidence-model.test.mjs tests/institutional-evidence-acquisition.test.mjs tests/santa-ynez-dossier.test.mjs tests/coverage-evidence-observatory.test.mjs tests/local-reporting-observatory.test.mjs tests/brand-mark.test.mjs tests/payment-security.test.mjs",
     "test:smoke": "playwright test"
   },
   "keywords": [

--- a/tests/payment-security.test.mjs
+++ b/tests/payment-security.test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+import {
+  onRequestGet as getSession,
+  onRequestOptions as getSessionOptions,
+} from '../functions/get-session.js';
+import {
+  onRequestPost as createCheckout,
+  onRequestOptions as createCheckoutOptions,
+} from '../functions/create-checkout.js';
+import { onRequest as securityMiddleware } from '../functions/_middleware.js';
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function request(url, { method = 'GET', origin, body } = {}) {
+  const headers = new Headers();
+  if (origin) headers.set('Origin', origin);
+  if (body !== undefined) headers.set('Content-Type', 'application/json');
+  return new Request(url, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+test('get-session has no hardcoded Stripe credential assignment', () => {
+  const source = fs.readFileSync(new URL('../functions/get-session.js', import.meta.url), 'utf8');
+  assert.doesNotMatch(source, /STRIPE_SECRET_KEY\s*=\s*['"]/);
+  assert.match(source, /env\?\.STRIPE/);
+});
+
+test('get-session fails closed when STRIPE binding is absent', async () => {
+  const response = await getSession({
+    request: request('https://globaldeets.com/get-session?session_id=cs_test_123', {
+      origin: 'https://globaldeets.com',
+    }),
+    env: {},
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 500);
+  assert.equal(body.error, 'Payment system configuration error');
+  assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://globaldeets.com');
+});
+
+test('get-session returns non-PII donation state only', async () => {
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        amount_total: 2500,
+        currency: 'usd',
+        customer_details: { email: 'donor@example.com', name: 'Private Donor' },
+        payment_status: 'paid',
+        mode: 'payment',
+        created: 1789228800,
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+
+  const response = await getSession({
+    request: request('https://globaldeets.com/get-session?session_id=cs_test_123', {
+      origin: 'https://www.goodflippindesign.com',
+    }),
+    env: { STRIPE: 'test-secret-from-env' },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.amount, 25);
+  assert.equal(body.currency, 'USD');
+  assert.equal(body.paymentStatus, 'paid');
+  assert.equal(body.customerEmail, undefined);
+  assert.equal(body.customerName, undefined);
+  assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://www.goodflippindesign.com');
+  assert.equal(response.headers.get('Cache-Control'), 'no-store');
+});
+
+test('payment endpoints reject arbitrary browser origins and never emit wildcard CORS', async () => {
+  const hostileOrigin = 'https://attacker.example';
+  const getOptions = await getSessionOptions({
+    request: request('https://globaldeets.com/get-session', { method: 'OPTIONS', origin: hostileOrigin }),
+  });
+  const checkoutOptions = await createCheckoutOptions({
+    request: request('https://globaldeets.com/create-checkout', {
+      method: 'OPTIONS',
+      origin: hostileOrigin,
+    }),
+  });
+
+  assert.equal(getOptions.status, 403);
+  assert.equal(checkoutOptions.status, 403);
+  assert.equal(getOptions.headers.get('Access-Control-Allow-Origin'), null);
+  assert.equal(checkoutOptions.headers.get('Access-Control-Allow-Origin'), null);
+});
+
+test('create-checkout accepts explicit GFD origin and uses env Stripe credential', async () => {
+  let authorization = null;
+  globalThis.fetch = async (_url, options) => {
+    authorization = options.headers.Authorization;
+    return new Response(
+      JSON.stringify({ id: 'cs_test_created', url: 'https://checkout.stripe.test/session' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  const response = await createCheckout({
+    request: request('https://globaldeets.com/create-checkout', {
+      method: 'POST',
+      origin: 'https://goodflippindesign.com',
+      body: { amount: 25, type: 'one-time' },
+    }),
+    env: { STRIPE: 'env-secret' },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.sessionId, 'cs_test_created');
+  assert.equal(authorization, 'Bearer env-secret');
+  assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://goodflippindesign.com');
+});
+
+test('Function middleware exposes no executable CSP capability', async () => {
+  const response = await securityMiddleware({
+    next: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+  });
+  const csp = response.headers.get('Content-Security-Policy');
+
+  assert.equal(csp, "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'");
+  assert.doesNotMatch(csp, /unsafe-eval|unsafe-inline|script-src|https:/);
+  assert.equal(response.headers.get('X-Content-Type-Options'), 'nosniff');
+});


### PR DESCRIPTION
Closes #39

## Security fixes
- removes the hardcoded credential-like Stripe value from tracked public source
- requires the `STRIPE` environment binding for session retrieval
- removes donor name/email from the unauthenticated session response
- scopes checkout/session CORS to explicit GlobalDeets, Good Flippin Design, and local development origins
- rejects arbitrary browser origins rather than reflecting them
- removes detailed Stripe/provider errors from consumer responses
- sets payment/session responses `Cache-Control: no-store`
- replaces permissive Function-response CSP with a non-executable `default-src 'none'` policy
- adds regression tests for secret handling, PII minimization, CORS, environment-bound Stripe auth, and CSP

## Audit correction
`_routes.json` routes only `/api/*`, `/create-checkout`, and `/get-session` through Pages Functions. The previous middleware CSP did not replace `_headers` for every static page. Static-site CSP and Function-response CSP remain separate concerns.

## External action still required
If the removed credential was ever valid, it must be revoked/rotated provider-side. Removing it from HEAD does not invalidate copies in public Git history or third-party caches.

Local `_SECURE_KEYS/` findings cannot be verified or remediated through GitHub because that directory is untracked/local; those credentials should be moved out of project/tool-visible storage and rotated according to exposure history.