### PR TITLE
GD-021: enforce source-admission display policy in live news

### DIFF
--- a/functions/api/news.js
+++ b/functions/api/news.js
@@ -55,7 +55,7 @@ export const SOURCES = [
   },
 
   // ── Asia ──────────────────────────────────────────────────────────────────
-  // NHK Japanese-language feed — translated to English via MT on cache-miss
+  // NHK Japanese-language feed — translation occurs only when the admission ledger permits it.
   { name: 'NHK', url: 'https://www3.nhk.or.jp/rss/news/cat0.xml', region: 'asia', lang: 'ja' },
   { name: 'Yonhap', url: 'https://en.yna.co.kr/RSS/news.xml', region: 'asia', lang: 'en' },
   {
@@ -145,7 +145,8 @@ export function getSourceFingerprint(sources = SOURCES) {
 }
 
 export const SOURCE_FINGERPRINT = getSourceFingerprint();
-export const CACHE_KEY = `news_feed_v2_${SOURCE_FINGERPRINT}`;
+export const DISPLAY_POLICY_VERSION = 'gd021-admission-v1';
+export const CACHE_KEY_PREFIX = `news_feed_v3_${SOURCE_FINGERPRINT}_${DISPLAY_POLICY_VERSION}`;
 export const SOURCE_HEALTH_KEY = `news_source_health_v2_${SOURCE_FINGERPRINT}`;
 const CACHE_TTL_SECONDS = 900; // 15 minutes
 export const SOURCE_HEALTH_TTL_SECONDS = 86_400; // retain latest observation for 24 hours
@@ -201,9 +202,100 @@ export async function onRequestOptions({ request }) {
   return new Response(null, { status: 204, headers: getCorsHeaders(request) });
 }
 
+async function loadAdmissionContract() {
+  return import('../lib/news-source-admission.js');
+}
+
+export function getFeedCacheIdentity(admissionFingerprint) {
+  if (typeof admissionFingerprint !== 'string' || !admissionFingerprint) {
+    throw new TypeError('admission fingerprint is required');
+  }
+  return {
+    cacheKey: `${CACHE_KEY_PREFIX}_${admissionFingerprint}`,
+    admissionFingerprint,
+    displayPolicyVersion: DISPLAY_POLICY_VERSION,
+  };
+}
+
+function buildAdmissionIndex(admissions) {
+  return new Map(
+    (Array.isArray(admissions) ? admissions : [])
+      .filter(entry => typeof entry?.sourceId === 'string')
+      .map(entry => [entry.sourceId, entry])
+  );
+}
+
+export async function applyAdmissionPolicy(items, contract = null) {
+  const resolvedContract = contract || (await loadAdmissionContract());
+  const admissions = resolvedContract.SOURCE_ADMISSIONS || [];
+  const evaluateItemUse = resolvedContract.evaluateItemUse;
+  const allowedStatuses = new Set(resolvedContract.ALLOWED_USE_STATUSES || []);
+  const admissionById = buildAdmissionIndex(admissions);
+
+  if (typeof evaluateItemUse !== 'function') {
+    throw new TypeError('source admission evaluator is unavailable');
+  }
+
+  const governedItems = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    const sourceId = slugifySourceName(item?.source || '');
+    const admission = admissionById.get(sourceId);
+    const itemStatus = item?.itemAllowedUseStatus ?? null;
+
+    let decision;
+    if (itemStatus != null && !allowedStatuses.has(itemStatus)) {
+      decision = { allowedUseStatus: 'prohibited', displayMode: 'exclude' };
+    } else {
+      decision = evaluateItemUse(admission, itemStatus);
+    }
+
+    if (decision.displayMode === 'exclude') continue;
+
+    const governed = {
+      id: item.id,
+      headline: item.headline,
+      summary: item.summary,
+      source: item.source,
+      sourceId,
+      sourceUrl: item.sourceUrl,
+      published: item.published,
+      region: item.region,
+      lang: item.lang,
+      translated: Boolean(item.translated),
+      originalLang: item.originalLang || item.lang,
+      allowedUseStatus: decision.allowedUseStatus,
+      displayMode: decision.displayMode,
+    };
+
+    if (decision.displayMode === 'headline-link') {
+      governed.summary = null;
+      governed.translated = false;
+      governed.originalLang = item.lang;
+    } else {
+      const permitsExcerpt = Array.isArray(admission?.permittedUse)
+        ? admission.permittedUse.includes('excerpt')
+        : false;
+      if (!permitsExcerpt) {
+        governed.summary = null;
+      } else if (typeof governed.summary === 'string') {
+        const maxChars = Number.isInteger(admission?.excerptMaxChars)
+          ? admission.excerptMaxChars
+          : 0;
+        governed.summary = governed.summary.slice(0, Math.max(0, maxChars));
+      }
+    }
+
+    governedItems.push(governed);
+  }
+
+  return { items: governedItems, admissionById };
+}
+
 export async function onRequestGet({ env, request }) {
   const url = new URL(request.url);
   const headers = getCorsHeaders(request);
+  const admissionContract = await loadAdmissionContract();
+  const cacheIdentity = getFeedCacheIdentity(admissionContract.ADMISSION_FINGERPRINT);
 
   const rawRegion = url.searchParams.get('region') || 'global';
   const region = VALID_REGIONS.has(rawRegion) ? rawRegion : 'global';
@@ -213,9 +305,9 @@ export async function onRequestGet({ env, request }) {
   );
   const offset = Math.max(parseInt(url.searchParams.get('offset') || '0', 10) || 0, 0);
 
-  // Source definitions are part of the cache key, so changing any source deterministically
-  // invalidates the old feed instead of waiting for TTL expiry.
-  const cached = await readFeedCache(env);
+  // Source definitions, admission ledger state, and the display-policy contract all participate
+  // in cache identity. Restrictive governance changes therefore cannot reuse a richer old payload.
+  const cached = await readFeedCache(env, cacheIdentity.cacheKey);
   if (cached) {
     const filtered = filterByRegion(cached, region);
     const page = filtered.slice(offset, offset + limit);
@@ -225,14 +317,19 @@ export async function onRequestGet({ env, request }) {
         cached: true,
         total: filtered.length,
         sourceFingerprint: SOURCE_FINGERPRINT,
+        admissionFingerprint: cacheIdentity.admissionFingerprint,
+        displayPolicyVersion: cacheIdentity.displayPolicyVersion,
       }),
       { headers }
     );
   }
 
-  const { items, sourceHealth } = await fetchAllSources();
-  await translateNonEnglish(items, env);
-  await writeCaches(env, items, sourceHealth);
+  const { items: acquiredItems, sourceHealth } = await fetchAllSources();
+  // Governance is applied before translation and before KV persistence. Restricted summaries
+  // therefore never enter the translated or cached consumer payload.
+  const { items, admissionById } = await applyAdmissionPolicy(acquiredItems, admissionContract);
+  await translateNonEnglish(items, env, admissionById);
+  await writeCaches(env, items, sourceHealth, cacheIdentity.cacheKey);
 
   const filtered = filterByRegion(items, region);
   const page = filtered.slice(offset, offset + limit);
@@ -242,26 +339,28 @@ export async function onRequestGet({ env, request }) {
       cached: false,
       total: filtered.length,
       sourceFingerprint: SOURCE_FINGERPRINT,
+      admissionFingerprint: cacheIdentity.admissionFingerprint,
+      displayPolicyVersion: cacheIdentity.displayPolicyVersion,
     }),
     { headers }
   );
 }
 
-async function readFeedCache(env) {
+async function readFeedCache(env, cacheKey) {
   if (!env.NEWS_CACHE) return null;
   try {
-    return await env.NEWS_CACHE.get(CACHE_KEY, { type: 'json' });
+    return await env.NEWS_CACHE.get(cacheKey, { type: 'json' });
   } catch (error) {
-    logOperationalError('kv_read_feed', error, { cacheKey: CACHE_KEY });
+    logOperationalError('kv_read_feed', error, { cacheKey });
     return null;
   }
 }
 
-async function writeCaches(env, items, sourceHealth) {
+async function writeCaches(env, items, sourceHealth, cacheKey) {
   if (!env.NEWS_CACHE) return;
   try {
     await Promise.all([
-      env.NEWS_CACHE.put(CACHE_KEY, JSON.stringify(items), {
+      env.NEWS_CACHE.put(cacheKey, JSON.stringify(items), {
         expirationTtl: CACHE_TTL_SECONDS,
       }),
       env.NEWS_CACHE.put(
@@ -276,16 +375,22 @@ async function writeCaches(env, items, sourceHealth) {
     ]);
   } catch (error) {
     logOperationalError('kv_write_news', error, {
-      feedCacheKey: CACHE_KEY,
+      feedCacheKey: cacheKey,
       healthCacheKey: SOURCE_HEALTH_KEY,
     });
   }
 }
 
-async function translateNonEnglish(items, env) {
+export async function translateNonEnglish(items, env, admissionById = new Map()) {
   if (!env?.AI) return;
 
-  const toTranslate = items.filter(i => i.lang && i.lang !== 'en');
+  const toTranslate = items.filter(item => {
+    if (!item?.lang || item.lang === 'en' || item.displayMode !== 'current-use') return false;
+    const admission = admissionById.get(item.sourceId);
+    return Array.isArray(admission?.permittedUse)
+      ? admission.permittedUse.includes('translated-headline-summary')
+      : false;
+  });
   if (!toTranslate.length) return;
 
   await Promise.all(
@@ -422,7 +527,7 @@ function makeSourceHealth(source, observation) {
 }
 
 export function slugifySourceName(name) {
-  return name
+  return String(name || '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '');

--- a/news.js
+++ b/news.js
@@ -225,6 +225,8 @@
         currentOffset += items.length;
         window.__globalDeetsNewsTotal = data.total;
         window.__globalDeetsNewsCached = data.cached;
+        window.__globalDeetsNewsAdmissionFingerprint = data.admissionFingerprint;
+        window.__globalDeetsNewsDisplayPolicyVersion = data.displayPolicyVersion;
 
         renderVisibleCards();
         updateStatus();
@@ -271,16 +273,24 @@
 
       const pubTime = formatTime(item.published);
       const dateAttr = item.published ? ` datetime="${escapeAttr(item.published)}"` : '';
+      const headlineLinkOnly = item.displayMode === 'headline-link';
 
-      const mtBadge = item.translated
+      const mtBadge = !headlineLinkOnly && item.translated
         ? `<span class="news-mt-badge" title="Machine translated from ${escapeAttr(item.originalLang || 'original language')} · Cloudflare AI (m2m100)">MT</span>`
-        : item.originalLang && item.originalLang !== 'en' && !item.translated
+        : !headlineLinkOnly && item.originalLang && item.originalLang !== 'en' && !item.translated
           ? `<span class="news-mt-badge news-mt-badge--failed" title="Originally in ${escapeAttr(item.originalLang)}; translation unavailable">⚠ ${escapeAttr(item.originalLang?.toUpperCase())}</span>`
           : '';
+      const policyBadge = headlineLinkOnly
+        ? '<span class="news-source-badge" title="Source admission currently permits headline and publisher link display only">Headline/link only</span>'
+        : '';
+      const summaryHtml = typeof item.summary === 'string' && item.summary.trim()
+        ? `<p class="news-summary">${escapeHtml(item.summary)}</p>`
+        : '';
 
       card.innerHTML = `
         <div class="news-card-header">
           <span class="news-source-badge">${escapeHtml(item.source || '')}</span>
+          ${policyBadge}
           ${mtBadge}
           <time class="news-time"${dateAttr}>${pubTime}</time>
         </div>
@@ -291,7 +301,7 @@
             ${escapeHtml(item.headline || '')}
           </a>
         </h2>
-        <p class="news-summary">${escapeHtml(item.summary || '')}</p>
+        ${summaryHtml}
         <div class="news-card-footer">
           <span class="news-region-tag">${escapeHtml(REGION_LABELS[item.region] || item.region || '')}</span>
           <a class="news-read-link"

--- a/tests/gd021-news-policy.spec.js
+++ b/tests/gd021-news-policy.spec.js
@@ -1,0 +1,113 @@
+const { expect, test } = require('@playwright/test');
+
+const governedNews = {
+  cached: false,
+  total: 3,
+  sourceFingerprint: 'fixture-source',
+  admissionFingerprint: 'fixture-admission',
+  displayPolicyVersion: 'gd021-admission-v1',
+  items: [
+    {
+      id: 'minnesota-1',
+      source: 'Minnesota Reformer',
+      sourceId: 'minnesota-reformer',
+      headline: 'Minnesota verified-use story',
+      summary: 'This reviewed source is permitted to expose its bounded excerpt.',
+      sourceUrl: 'https://example.com/minnesota',
+      region: 'americas',
+      lang: 'en',
+      originalLang: 'en',
+      translated: false,
+      published: '2026-09-12T12:00:00Z',
+      allowedUseStatus: 'verified-public-use',
+      displayMode: 'current-use',
+    },
+    {
+      id: 'guardian-1',
+      source: 'Guardian',
+      sourceId: 'guardian',
+      headline: 'Guardian headline-link story',
+      summary: null,
+      sourceUrl: 'https://example.com/guardian',
+      region: 'global',
+      lang: 'en',
+      originalLang: 'en',
+      translated: false,
+      published: '2026-09-12T11:00:00Z',
+      allowedUseStatus: 'permission-required',
+      displayMode: 'headline-link',
+    },
+    {
+      id: 'nhk-1',
+      source: 'NHK',
+      sourceId: 'nhk',
+      headline: 'NHK source headline',
+      summary: null,
+      sourceUrl: 'https://example.com/nhk',
+      region: 'asia',
+      lang: 'ja',
+      originalLang: 'ja',
+      translated: false,
+      published: '2026-09-12T10:00:00Z',
+      allowedUseStatus: 'unknown',
+      displayMode: 'headline-link',
+    },
+  ],
+};
+
+const sources = {
+  totalSources: 21,
+  sources: [
+    { sourceId: 'minnesota-reformer', name: 'Minnesota Reformer' },
+    { sourceId: 'guardian', name: 'Guardian' },
+    { sourceId: 'nhk', name: 'NHK' },
+  ],
+};
+
+const health = {
+  generatedAt: new Date().toISOString(),
+  healthySources: 21,
+  totalSources: 21,
+  sourceHealth: [],
+};
+
+test('news cards honor admission display mode without blank or false translation UI', async ({ page }) => {
+  await page.route('**/api/news**', async route => {
+    const url = new URL(route.request().url());
+    const body = url.pathname === '/api/news/sources'
+      ? sources
+      : url.pathname === '/api/news/health'
+        ? health
+        : governedNews;
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(body),
+    });
+  });
+
+  await page.goto('/news.html');
+  await expect(page.locator('#news-grid .news-card')).toHaveCount(3);
+
+  const verified = page.locator('.news-card').filter({ hasText: 'Minnesota verified-use story' });
+  await expect(verified.locator('.news-summary')).toHaveCount(1);
+  await expect(verified.locator('.news-summary')).toContainText('permitted to expose');
+  await expect(verified.getByText('Headline/link only')).toHaveCount(0);
+
+  const guardian = page.locator('.news-card').filter({ hasText: 'Guardian headline-link story' });
+  await expect(guardian.getByText('Headline/link only')).toBeVisible();
+  await expect(guardian.locator('.news-summary')).toHaveCount(0);
+
+  const nhk = page.locator('.news-card').filter({ hasText: 'NHK source headline' });
+  await expect(nhk.getByText('Headline/link only')).toBeVisible();
+  await expect(nhk.locator('.news-summary')).toHaveCount(0);
+  await expect(nhk.locator('.news-mt-badge--failed')).toHaveCount(0);
+
+  await expect
+    .poll(() => page.evaluate(() => window.__globalDeetsNewsAdmissionFingerprint))
+    .toBe('fixture-admission');
+  await expect
+    .poll(() => page.evaluate(() => window.__globalDeetsNewsDisplayPolicyVersion))
+    .toBe('gd021-admission-v1');
+});

--- a/tests/news-functions.test.mjs
+++ b/tests/news-functions.test.mjs
@@ -12,22 +12,35 @@ const fixtureRoot = mkdtempSync(join(tmpdir(), 'globaldeets-functions-'));
 const fixtureFunctions = join(fixtureRoot, 'functions');
 const fixtureNews = join(fixtureFunctions, 'api', 'news.js');
 const fixtureHealth = join(fixtureFunctions, 'api', 'news', 'health.js');
+const fixtureAdmission = join(fixtureFunctions, 'lib', 'news-source-admission.js');
 mkdirSync(dirname(fixtureHealth), { recursive: true });
+mkdirSync(dirname(fixtureAdmission), { recursive: true });
 writeFileSync(join(fixtureFunctions, 'package.json'), '{"type":"module"}\n');
 copyFileSync(fileURLToPath(new URL('../functions/api/news.js', import.meta.url)), fixtureNews);
 copyFileSync(fileURLToPath(new URL('../functions/api/news/health.js', import.meta.url)), fixtureHealth);
+copyFileSync(
+  fileURLToPath(new URL('../functions/lib/news-source-admission.js', import.meta.url)),
+  fixtureAdmission
+);
 
 const newsModule = await import(pathToFileURL(fixtureNews).href);
 const healthModule = await import(pathToFileURL(fixtureHealth).href);
+const admissionModule = await import(pathToFileURL(fixtureAdmission).href);
 const {
-  CACHE_KEY,
+  CACHE_KEY_PREFIX,
+  DISPLAY_POLICY_VERSION,
   SOURCES,
   SOURCE_FINGERPRINT,
   SOURCE_HEALTH_KEY,
+  applyAdmissionPolicy,
+  getFeedCacheIdentity,
   getSourceFingerprint,
   onRequestGet: getNews,
+  translateNonEnglish,
 } = newsModule;
 const { onRequestGet: getNewsHealth } = healthModule;
+const { ADMISSION_FINGERPRINT, ALLOWED_USE_STATUSES, evaluateItemUse } = admissionModule;
+const CACHE_KEY = getFeedCacheIdentity(ADMISSION_FINGERPRINT).cacheKey;
 
 function makeKv(initial = new Map()) {
   const data = new Map(initial);
@@ -68,31 +81,48 @@ function captureErrors(t) {
   return entries;
 }
 
+function rawStory(source, overrides = {}) {
+  return {
+    id: `${source.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-1`,
+    headline: `${source} headline`,
+    summary: `${source} publisher summary`,
+    source,
+    sourceUrl: 'https://example.com/story',
+    published: '2026-09-02T00:00:00.000Z',
+    region: 'global',
+    lang: 'en',
+    translated: false,
+    originalLang: 'en',
+    ...overrides,
+  };
+}
+
 const story = {
-  id: 'cached-1',
-  headline: 'Cached headline',
-  summary: 'Cached summary',
-  source: 'BBC World',
-  sourceUrl: 'https://example.com/story',
-  published: '2026-09-02T00:00:00.000Z',
-  region: 'global',
-  lang: 'en',
-  translated: false,
-  originalLang: 'en',
+  ...rawStory('Minnesota Reformer', { region: 'americas' }),
+  sourceId: 'minnesota-reformer',
+  allowedUseStatus: 'verified-public-use',
+  displayMode: 'current-use',
 };
 
-test('source fingerprint is deterministic and changes when a source definition changes', () => {
+test('source and admission fingerprints deterministically version the feed cache', () => {
   assert.equal(getSourceFingerprint(SOURCES), SOURCE_FINGERPRINT);
   assert.equal(getSourceFingerprint(SOURCES), getSourceFingerprint(SOURCES.map(source => ({ ...source }))));
 
   const changed = SOURCES.map(source => ({ ...source }));
   changed[0].url = `${changed[0].url}?changed=1`;
   assert.notEqual(getSourceFingerprint(changed), SOURCE_FINGERPRINT);
-  assert.match(CACHE_KEY, new RegExp(`${SOURCE_FINGERPRINT}$`));
+
+  const identity = getFeedCacheIdentity(ADMISSION_FINGERPRINT);
+  const changedAdmission = getFeedCacheIdentity(`${ADMISSION_FINGERPRINT}-changed`);
+  assert.match(identity.cacheKey, new RegExp(`^${CACHE_KEY_PREFIX}_`));
+  assert.ok(identity.cacheKey.includes(SOURCE_FINGERPRINT));
+  assert.ok(identity.cacheKey.includes(DISPLAY_POLICY_VERSION));
+  assert.ok(identity.cacheKey.endsWith(ADMISSION_FINGERPRINT));
+  assert.notEqual(changedAdmission.cacheKey, identity.cacheKey);
   assert.match(SOURCE_HEALTH_KEY, new RegExp(`${SOURCE_FINGERPRINT}$`));
 });
 
-test('/api/news serves only the source-versioned cache and exposes its fingerprint', async () => {
+test('/api/news serves only the governed cache and exposes policy identity', async () => {
   const kv = makeKv(new Map([[CACHE_KEY, [story]]]));
   const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=5') });
   const json = await response.json();
@@ -102,9 +132,29 @@ test('/api/news serves only the source-versioned cache and exposes its fingerpri
   assert.equal(json.total, 1);
   assert.deepEqual(json.items, [story]);
   assert.equal(json.sourceFingerprint, SOURCE_FINGERPRINT);
+  assert.equal(json.admissionFingerprint, ADMISSION_FINGERPRINT);
+  assert.equal(json.displayPolicyVersion, DISPLAY_POLICY_VERSION);
 });
 
-test('/api/news cache miss writes feed and health under the current source fingerprint', async t => {
+test('/api/news ignores the predecessor source-only cache identity', async t => {
+  const previousFetch = globalThis.fetch;
+  t.after(() => {
+    globalThis.fetch = previousFetch;
+  });
+  globalThis.fetch = async url => rssResponse(url);
+
+  const staleKey = `news_feed_v2_${SOURCE_FINGERPRINT}`;
+  const staleStory = rawStory('Guardian', { summary: 'must not survive old cache identity' });
+  const kv = makeKv(new Map([[staleKey, [staleStory]]]));
+  const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=5') });
+  const json = await response.json();
+
+  assert.equal(json.cached, false);
+  assert.ok(kv.puts.some(put => put.key === CACHE_KEY));
+  assert.ok(!json.items.some(item => item.summary === staleStory.summary));
+});
+
+test('/api/news cache miss writes governed feed and source health under separate identities', async t => {
   const previousFetch = globalThis.fetch;
   t.after(() => {
     globalThis.fetch = previousFetch;
@@ -112,20 +162,137 @@ test('/api/news cache miss writes feed and health under the current source finge
   globalThis.fetch = async url => rssResponse(url);
 
   const kv = makeKv();
-  const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=5') });
+  const response = await getNews({ env: { NEWS_CACHE: kv }, request: request('/api/news?limit=100') });
   const json = await response.json();
 
   assert.equal(json.cached, false);
   assert.equal(json.sourceFingerprint, SOURCE_FINGERPRINT);
+  assert.equal(json.admissionFingerprint, ADMISSION_FINGERPRINT);
+  assert.equal(json.displayPolicyVersion, DISPLAY_POLICY_VERSION);
   assert.ok(json.items.length > 0);
   assert.deepEqual(
     kv.puts.map(put => put.key).sort(),
     [CACHE_KEY, SOURCE_HEALTH_KEY].sort()
   );
 
+  const feedWrite = kv.puts.find(put => put.key === CACHE_KEY);
+  assert.ok(feedWrite.value.every(item => ['current-use', 'headline-link'].includes(item.displayMode)));
+  assert.ok(
+    feedWrite.value
+      .filter(item => item.displayMode === 'headline-link')
+      .every(item => item.summary === null)
+  );
+
   const healthWrite = kv.puts.find(put => put.key === SOURCE_HEALTH_KEY);
   assert.equal(healthWrite.value.sourceFingerprint, SOURCE_FINGERPRINT);
   assert.equal(healthWrite.value.sourceHealth.length, SOURCES.length);
+});
+
+test('verified-public-use sources retain only their reviewed bounded excerpt', async () => {
+  const longSummary = 'x'.repeat(400);
+  const { items } = await applyAdmissionPolicy([
+    rawStory('Minnesota Reformer', { summary: longSummary, region: 'americas' }),
+  ]);
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].displayMode, 'current-use');
+  assert.equal(items[0].allowedUseStatus, 'verified-public-use');
+  assert.equal(items[0].summary.length, 280);
+  assert.equal(items[0].sourceId, 'minnesota-reformer');
+});
+
+test('unknown legacy sources fail closed to headline-link with no publisher summary', async () => {
+  const { items } = await applyAdmissionPolicy([rawStory('BBC World')]);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].allowedUseStatus, 'unknown');
+  assert.equal(items[0].displayMode, 'headline-link');
+  assert.equal(items[0].summary, null);
+});
+
+test('permission-required Guardian items cannot expose publisher summaries', async () => {
+  const { items } = await applyAdmissionPolicy([rawStory('Guardian')]);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].allowedUseStatus, 'permission-required');
+  assert.equal(items[0].displayMode, 'headline-link');
+  assert.equal(items[0].summary, null);
+});
+
+test('contract-required AP items cannot expose RSSHub-derived summaries', async () => {
+  const { items } = await applyAdmissionPolicy([rawStory('AP')]);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].allowedUseStatus, 'contract-required');
+  assert.equal(items[0].displayMode, 'headline-link');
+  assert.equal(items[0].summary, null);
+});
+
+test('prohibited items are excluded from the consumer payload', async () => {
+  const contract = {
+    SOURCE_ADMISSIONS: [
+      {
+        sourceId: 'blocked-source',
+        allowedUseStatus: 'prohibited',
+        permittedUse: [],
+        excerptMaxChars: 0,
+      },
+    ],
+    ALLOWED_USE_STATUSES,
+    evaluateItemUse,
+  };
+  const { items } = await applyAdmissionPolicy([rawStory('Blocked Source')], contract);
+  assert.deepEqual(items, []);
+});
+
+test('stricter item-level restrictions override a verified source', async () => {
+  const { items } = await applyAdmissionPolicy([
+    rawStory('Minnesota Reformer', {
+      region: 'americas',
+      itemAllowedUseStatus: 'permission-required',
+    }),
+  ]);
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].allowedUseStatus, 'permission-required');
+  assert.equal(items[0].displayMode, 'headline-link');
+  assert.equal(items[0].summary, null);
+});
+
+test('unsupported item-level restriction signals fail closed to exclusion', async () => {
+  const { items } = await applyAdmissionPolicy([
+    rawStory('Minnesota Reformer', {
+      region: 'americas',
+      itemAllowedUseStatus: 'not-a-supported-status',
+    }),
+  ]);
+  assert.deepEqual(items, []);
+});
+
+test('restricted translated-source content is stripped before any AI translation call', async () => {
+  const { items, admissionById } = await applyAdmissionPolicy([
+    rawStory('NHK', {
+      lang: 'ja',
+      originalLang: 'ja',
+      region: 'asia',
+      headline: '原文見出し',
+      summary: '原文要約',
+    }),
+  ]);
+  let aiCalls = 0;
+  const env = {
+    AI: {
+      async run() {
+        aiCalls += 1;
+        return { translated_text: 'translated' };
+      },
+    },
+  };
+
+  await translateNonEnglish(items, env, admissionById);
+
+  assert.equal(items.length, 1);
+  assert.equal(items[0].displayMode, 'headline-link');
+  assert.equal(items[0].summary, null);
+  assert.equal(items[0].translated, false);
+  assert.equal(aiCalls, 0);
 });
 
 test('/api/news degrades to live fetch when KV read fails and emits structured telemetry', async t => {


### PR DESCRIPTION
## Purpose
Make the live `/api/news` consumer path obey the existing source-admission ledger from issue #38 instead of treating governance as documentation-only.

## Enforcement boundary
- admission policy is applied immediately after acquisition and before translation
- restricted publisher summaries are removed before any AI call and before KV persistence
- `unknown`, `permission-required`, and `contract-required` items fail closed to deterministic `headline-link` payloads
- `prohibited` items are excluded
- stricter item-level restrictions override source-level permission
- unsupported item restriction signals fail closed to exclusion
- verified-public-use sources retain only their reviewed bounded excerpt

## Cache integrity
The consumer feed moves from source-only `news_feed_v2` identity to a v3 identity containing:
- canonical source fingerprint
- explicit GD-021 display-policy version
- admission-ledger fingerprint

The health snapshot remains source-fingerprint-only so health and usage-rights governance stay separate observability dimensions.

## Consumer UX
- headline/link-only cards are visibly labeled
- cards without permitted excerpts do not render empty summary paragraphs
- policy-restricted non-English items do not show a false “translation failed” badge
- admission/display fingerprints are exposed to the browser runtime for verification

## Regression coverage
The Function contract suite now covers verified-public-use, unknown, permission-required, contract-required, prohibited, item-level override, invalid item signals, translated-source fail-closed behavior, old-cache rejection, and governed KV writes. A dedicated Playwright regression verifies the actual card rendering boundary.

## Scope
No new source is admitted. No source-rights conclusion is changed. No health/provenance dimension is conflated with admission policy.

Closes #38 after merge and production certification.