### PR TITLE
SEC-002A: add checkout abuse-control fallback

### DIFF
--- a/docs/sec-002-abuse-controls.md
+++ b/docs/sec-002-abuse-controls.md
@@ -1,0 +1,72 @@
+# SEC-002 abuse and cost controls
+
+Status: application fallback implemented on `security/sec002-abuse-cost-controls`; Cloudflare edge rule is **not deployed** because the currently connected Cloudflare credential can read Rulesets but receives API error `10000 Authentication error` at the Rulesets mutation boundary.
+
+## Threat model
+
+SEC-002 limits cost-amplification paths without requiring accounts or CAPTCHA for ordinary readers:
+
+- repeated `/create-checkout` requests can create unnecessary Stripe Checkout sessions;
+- synchronized `/api/news` cache misses can fan out to the publisher portfolio;
+- translation and source-health work must stay explicitly bounded;
+- controls must not log donor PII or unnecessary client identifiers.
+
+## Checkout controls
+
+### Intended Cloudflare edge rule — pending authorization
+
+GlobalDeets is currently on Cloudflare Free, which provides one rate-limiting rule with a 10-second period. That scarce rule is reserved for the payment-session creation path rather than normal news reading.
+
+Planned Ruleset configuration:
+
+- phase: `http_ratelimit`
+- kind: `zone`
+- ruleset name: `SEC-002 GlobalDeets rate limits`
+- rule ref: `sec002_checkout`
+- expression: `http.request.uri.path eq "/create-checkout"`
+- action: `block`
+- characteristics: `cf.colo.id`, `ip.src`
+- period: `10` seconds
+- requests per period: `5`
+- mitigation timeout: `10` seconds
+
+Cloudflare Free does not expose HTTP method matching for this rate-limiting rule, so the path is the edge match boundary. There is no deployed rule identifier yet. Do not record one until Cloudflare accepts the mutation and a read-back confirms the exact live rule.
+
+### Application fallback
+
+`functions/create-checkout.js` adds a best-effort defense-in-depth counter using the existing `NEWS_CACHE` KV namespace under the isolated prefix `sec002_checkout_v1`.
+
+- threshold: 5 requests per 10-second fixed window;
+- the sixth request returns HTTP 429 with `Retry-After` before Stripe is called;
+- the client signal is Cloudflare's `CF-Connecting-IP` request header at the Pages Function boundary;
+- raw IP addresses are never logged or written to KV;
+- the KV key contains only a SHA-256 digest scoped to the fixed time bucket;
+- counter records contain only `{ count }` and expire after 20 seconds;
+- missing client-IP or unavailable KV preserves payment availability because the future edge rule remains the authoritative control.
+
+KV counters are eventually consistent and therefore are not represented as an atomic distributed rate limiter. Their purpose is to reduce straightforward repeated-session abuse while the Cloudflare edge rule remains authorization-blocked.
+
+## News controls
+
+News-cost controls are a separate SEC-002 tranche so checkout security can be reviewed and shipped independently. The next tranche will preserve normal anonymous cached reads while adding explicit source/translation ceilings and cache-miss anti-stampede behavior. Existing protections already include:
+
+- a 15-minute governed feed cache;
+- a fixed canonical source list (21 sources at SEC-002 start);
+- a 5-second timeout per source;
+- at most 300 normalized stories per refresh;
+- GD-021 admission enforcement before translation and persistence, which currently prevents unreviewed/restricted sources from invoking summary translation.
+
+The news tranche must not rate-limit ordinary cache hits merely to protect the more expensive regeneration path.
+
+## Verification requirements
+
+Checkout tranche is mergeable only when CI proves:
+
+1. five sequential requests from one Cloudflare client identity are permitted in one 10-second bucket;
+2. the sixth is rejected with 429 before any Stripe request;
+3. the stored KV key does not contain the raw client IP;
+4. throttle-error telemetry contains no raw client IP;
+5. missing/failed KV does not break legitimate checkout;
+6. existing origin, credential, PII, CSP, lint, Function and browser regressions remain green.
+
+Edge deployment remains incomplete until Cloudflare write authorization is restored, the rule is created, its returned identifier is recorded here, and a subsequent Rulesets GET confirms the live configuration.

--- a/functions/create-checkout.js
+++ b/functions/create-checkout.js
@@ -8,6 +8,10 @@
  */
 
 const STRIPE_API_VERSION = '2025-04-10';
+export const CHECKOUT_RATE_LIMIT = 5;
+export const CHECKOUT_RATE_WINDOW_SECONDS = 10;
+const CHECKOUT_COUNTER_TTL_SECONDS = 20;
+const CHECKOUT_COUNTER_PREFIX = 'sec002_checkout_v1';
 const ALLOWED_ORIGINS = new Set([
   'https://globaldeets.com',
   'https://www.globaldeets.com',
@@ -35,11 +39,60 @@ function originIsAllowed(request) {
   return !origin || ALLOWED_ORIGINS.has(origin);
 }
 
-function json(body, status, request) {
+function json(body, status, request, extraHeaders = {}) {
   return new Response(JSON.stringify(body), {
     status,
-    headers: corsHeaders(request),
+    headers: { ...corsHeaders(request), ...extraHeaders },
   });
+}
+
+function logThrottleError(error) {
+  console.error(
+    JSON.stringify({
+      event: 'globaldeets.checkout.throttle.error',
+      error: error?.message || String(error || 'unknown error'),
+    })
+  );
+}
+
+async function digestClientKey(clientIp, bucket) {
+  const bytes = new TextEncoder().encode(`${CHECKOUT_COUNTER_PREFIX}:${bucket}:${clientIp}`);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export async function enforceCheckoutThrottle(env, request, nowMs = Date.now()) {
+  // The edge Rulesets rate-limit remains the primary control. This short-lived KV counter is a
+  // privacy-minimized defense-in-depth fallback and intentionally does not log or persist raw IPs.
+  if (!env?.NEWS_CACHE) return { allowed: true, enforced: false, retryAfterSeconds: 0 };
+
+  const clientIp = request?.headers?.get('CF-Connecting-IP')?.trim();
+  if (!clientIp) return { allowed: true, enforced: false, retryAfterSeconds: 0 };
+
+  try {
+    const windowMs = CHECKOUT_RATE_WINDOW_SECONDS * 1000;
+    const bucket = Math.floor(nowMs / windowMs);
+    const elapsedMs = nowMs - bucket * windowMs;
+    const retryAfterSeconds = Math.max(1, Math.ceil((windowMs - elapsedMs) / 1000));
+    const digest = await digestClientKey(clientIp, bucket);
+    const key = `${CHECKOUT_COUNTER_PREFIX}:${bucket}:${digest}`;
+    const record = await env.NEWS_CACHE.get(key, { type: 'json' });
+    const count = Number.isInteger(record?.count) ? record.count : 0;
+
+    if (count >= CHECKOUT_RATE_LIMIT) {
+      return { allowed: false, enforced: true, retryAfterSeconds };
+    }
+
+    await env.NEWS_CACHE.put(key, JSON.stringify({ count: count + 1 }), {
+      expirationTtl: CHECKOUT_COUNTER_TTL_SECONDS,
+    });
+    return { allowed: true, enforced: true, retryAfterSeconds: 0 };
+  } catch (error) {
+    // Availability is preserved if KV is unavailable; the Cloudflare edge rule remains the
+    // authoritative abuse boundary once Rulesets write authorization is restored.
+    logThrottleError(error);
+    return { allowed: true, enforced: false, retryAfterSeconds: 0 };
+  }
 }
 
 export async function onRequestPost(context) {
@@ -47,6 +100,16 @@ export async function onRequestPost(context) {
 
   if (!originIsAllowed(request)) {
     return json({ error: 'Origin not allowed' }, 403, request);
+  }
+
+  const throttle = await enforceCheckoutThrottle(env, request);
+  if (!throttle.allowed) {
+    return json(
+      { error: 'Too many checkout requests. Please try again shortly.' },
+      429,
+      request,
+      { 'Retry-After': String(throttle.retryAfterSeconds) }
+    );
   }
 
   const stripeSecret = env?.STRIPE;

--- a/tests/payment-security.test.mjs
+++ b/tests/payment-security.test.mjs
@@ -7,6 +7,9 @@ import {
   onRequestOptions as getSessionOptions,
 } from '../functions/get-session.js';
 import {
+  CHECKOUT_RATE_LIMIT,
+  CHECKOUT_RATE_WINDOW_SECONDS,
+  enforceCheckoutThrottle,
   onRequestPost as createCheckout,
   onRequestOptions as createCheckoutOptions,
 } from '../functions/create-checkout.js';
@@ -18,15 +21,33 @@ test.afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-function request(url, { method = 'GET', origin, body } = {}) {
+function request(url, { method = 'GET', origin, body, clientIp } = {}) {
   const headers = new Headers();
   if (origin) headers.set('Origin', origin);
+  if (clientIp) headers.set('CF-Connecting-IP', clientIp);
   if (body !== undefined) headers.set('Content-Type', 'application/json');
   return new Request(url, {
     method,
     headers,
     body: body === undefined ? undefined : JSON.stringify(body),
   });
+}
+
+function makeKv() {
+  const data = new Map();
+  const puts = [];
+  return {
+    data,
+    puts,
+    async get(key) {
+      return data.get(key) ?? null;
+    },
+    async put(key, value, options) {
+      const parsed = JSON.parse(value);
+      data.set(key, parsed);
+      puts.push({ key, value: parsed, options });
+    },
+  };
 }
 
 test('get-session has no hardcoded Stripe credential assignment', () => {
@@ -123,6 +144,96 @@ test('create-checkout accepts explicit GFD origin and uses env Stripe credential
   assert.equal(body.sessionId, 'cs_test_created');
   assert.equal(authorization, 'Bearer env-secret');
   assert.equal(response.headers.get('Access-Control-Allow-Origin'), 'https://goodflippindesign.com');
+});
+
+test('checkout throttle is bounded to five requests per ten-second window without raw-IP storage', async () => {
+  assert.equal(CHECKOUT_RATE_LIMIT, 5);
+  assert.equal(CHECKOUT_RATE_WINDOW_SECONDS, 10);
+
+  const kv = makeKv();
+  const req = request('https://globaldeets.com/create-checkout', {
+    method: 'POST',
+    origin: 'https://globaldeets.com',
+    clientIp: '203.0.113.17',
+    body: { amount: 25, type: 'one-time' },
+  });
+  const now = Date.UTC(2026, 8, 12, 12, 0, 1);
+
+  for (let i = 0; i < CHECKOUT_RATE_LIMIT; i++) {
+    const result = await enforceCheckoutThrottle({ NEWS_CACHE: kv }, req, now);
+    assert.equal(result.allowed, true);
+    assert.equal(result.enforced, true);
+  }
+
+  const blocked = await enforceCheckoutThrottle({ NEWS_CACHE: kv }, req, now);
+  assert.equal(blocked.allowed, false);
+  assert.equal(blocked.enforced, true);
+  assert.ok(blocked.retryAfterSeconds >= 1 && blocked.retryAfterSeconds <= 10);
+  assert.ok(kv.puts.every(entry => entry.options.expirationTtl === 20));
+  assert.ok([...kv.data.keys()].every(key => !key.includes('203.0.113.17')));
+});
+
+test('create-checkout returns 429 before a sixth Stripe session can be created', async () => {
+  let stripeCalls = 0;
+  globalThis.fetch = async () => {
+    stripeCalls += 1;
+    return new Response(
+      JSON.stringify({ id: `cs_test_${stripeCalls}`, url: 'https://checkout.stripe.test/session' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  };
+
+  const kv = makeKv();
+  const env = { STRIPE: 'env-secret', NEWS_CACHE: kv };
+  const makeRequest = () =>
+    request('https://globaldeets.com/create-checkout', {
+      method: 'POST',
+      origin: 'https://globaldeets.com',
+      clientIp: '198.51.100.23',
+      body: { amount: 25, type: 'one-time' },
+    });
+
+  for (let i = 0; i < CHECKOUT_RATE_LIMIT; i++) {
+    const response = await createCheckout({ request: makeRequest(), env });
+    assert.equal(response.status, 200);
+  }
+
+  const blocked = await createCheckout({ request: makeRequest(), env });
+  const body = await blocked.json();
+  assert.equal(blocked.status, 429);
+  assert.equal(stripeCalls, CHECKOUT_RATE_LIMIT);
+  assert.equal(body.error, 'Too many checkout requests. Please try again shortly.');
+  assert.ok(Number(blocked.headers.get('Retry-After')) >= 1);
+});
+
+test('checkout throttle degrades without blocking payment if KV is unavailable', async () => {
+  const errors = [];
+  const originalError = console.error;
+  console.error = value => errors.push(String(value));
+  try {
+    const failingKv = {
+      async get() {
+        throw new Error('simulated KV outage');
+      },
+      async put() {
+        throw new Error('unexpected put');
+      },
+    };
+    const result = await enforceCheckoutThrottle(
+      { NEWS_CACHE: failingKv },
+      request('https://globaldeets.com/create-checkout', {
+        method: 'POST',
+        clientIp: '192.0.2.44',
+      }),
+      Date.UTC(2026, 8, 12, 12, 0, 1)
+    );
+    assert.equal(result.allowed, true);
+    assert.equal(result.enforced, false);
+    assert.ok(errors.some(entry => entry.includes('globaldeets.checkout.throttle.error')));
+    assert.ok(errors.every(entry => !entry.includes('192.0.2.44')));
+  } finally {
+    console.error = originalError;
+  }
 });
 
 test('Function middleware exposes no executable CSP capability', async () => {


### PR DESCRIPTION
## Purpose
Ship the application-side checkout protection from SEC-002 without misrepresenting the still-blocked Cloudflare Rulesets mutation as complete.

## Changes
- add a defense-in-depth fixed-window checkout counter: 5 requests / 10 seconds
- return HTTP 429 with `Retry-After` before a sixth Stripe Checkout session can be created
- derive the counter key from Cloudflare's `CF-Connecting-IP` signal using SHA-256; never log or store the raw address
- expire counter records after 20 seconds and store only `{ count }`
- preserve checkout availability when KV/client identity is unavailable; the Cloudflare edge rule remains the intended authoritative limiter
- add hostile regressions for threshold, pre-Stripe rejection, raw-IP non-persistence/non-logging, and KV failure
- document the exact pending Free-plan edge rule and the current Cloudflare `10000 Authentication error` mutation blocker

## Cloudflare truth boundary
Read access confirms there is still no zone-owned `http_ratelimit` ruleset. The intended `sec002_checkout` rule is documented but **not deployed**. No rule identifier is invented.

## Scope
This is SEC-002A only. News cache-miss anti-stampede and explicit source/translation budgets remain the next independent tranche so ordinary anonymous cached reads are not accidentally throttled.

Refs #41.